### PR TITLE
Fix check for tilt support when stopping

### DIFF
--- a/custom_components/cover_time_based/cover.py
+++ b/custom_components/cover_time_based/cover.py
@@ -211,7 +211,7 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
             self.travel_calc.stop()
             self.stop_auto_updater()
 
-        if self.tilt_calc.is_traveling():
+        if self._has_tilt_support() and self.tilt_calc.is_traveling():
             _LOGGER.debug("_handle_stop :: button stops tilt movement")
             self.tilt_calc.stop()
             self.stop_auto_updater()


### PR DESCRIPTION
Avoids throwing an error when using a stop switch and not using tilt.