### PR TITLE
Fix `stop_switch_entity_id` not being present causing the integration to crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.1.1 (2024-04-17)
+
+### Bug Fixes
+
+- Fix `stop_switch_entity_id` not being present causing the integration to crash
+
+
 ## 2.1.0 (2024-04-11)
 
 ### Features

--- a/custom_components/cover_time_based/cover.py
+++ b/custom_components/cover_time_based/cover.py
@@ -61,7 +61,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
                     vol.Required(CONF_NAME): cv.string,
                     vol.Required(CONF_OPEN_SWITCH_ENTITY_ID): cv.entity_id,
                     vol.Required(CONF_CLOSE_SWITCH_ENTITY_ID): cv.entity_id,
-                    vol.Optional(CONF_STOP_SWITCH_ENTITY_ID): cv.entity_id,
+                    vol.Optional(
+                        CONF_STOP_SWITCH_ENTITY_ID, default=None
+                    ): vol.Any(cv.entity_id, None),
                     vol.Optional(
                         CONF_TRAVELLING_TIME_DOWN, default=DEFAULT_TRAVEL_TIME
                     ): cv.positive_int,

--- a/custom_components/cover_time_based/manifest.json
+++ b/custom_components/cover_time_based/manifest.json
@@ -9,5 +9,5 @@
   "requirements": [
     "xknx==0.9.4"
   ],
-  "version": "2.1.0"
+  "version": "2.1.1"
 }


### PR DESCRIPTION
Fixes #8
Closes #9 