### PR TITLE
✨ Feature: Added support for button based cover controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ cover:
 | travelling_time_up     | int          | *Optional*   | Time it takes in seconds to open the cover                  | 30      |
 | tilting_time_down      | float        | *Optional*   | Time it takes in seconds to tilt the cover all the way down | None    |
 | tilting_time_up        | float        | *Optional*   | Time it takes in seconds to tilt the cover all the way up   | None    |
+| is_button				       | boolean      | *Optional*   | Treads the switches as buttons, only pressing them for 1s   | False   |
 
 
 [commits-shield]: https://img.shields.io/github/commit-activity/y/Sese-Schneider/ha-cover-time-based.svg?style=for-the-badge

--- a/custom_components/cover_time_based/cover.py
+++ b/custom_components/cover_time_based/cover.py
@@ -7,11 +7,11 @@ from datetime import timedelta
 import voluptuous as vol
 
 from asyncio import sleep
+from xknx.devices import TravelStatus, TravelCalculator
 
 from homeassistant.core import callback
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers.event import (
-    async_track_utc_time_change,
     async_track_time_interval,
 )
 from homeassistant.components.cover import (
@@ -20,15 +20,12 @@ from homeassistant.components.cover import (
     ATTR_POSITION,
     ATTR_TILT_POSITION,
     PLATFORM_SCHEMA,
-    DEVICE_CLASSES_SCHEMA,
     CoverEntity,
     CoverEntityFeature,
 )
 from homeassistant.const import (
     CONF_NAME,
-    CONF_DEVICE_CLASS,
     ATTR_ENTITY_ID,
-    ATTR_DEVICE_CLASS,
     SERVICE_CLOSE_COVER,
     SERVICE_OPEN_COVER,
     SERVICE_STOP_COVER,
@@ -163,8 +160,6 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
         is_button=False,
     ):
         """Initialize the cover."""
-        from xknx.devices import TravelCalculator
-
         self._travel_time_down = travel_time_down
         self._travel_time_up = travel_time_up
         self._tilting_time_down = tilt_time_down
@@ -268,8 +263,6 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
 
     @property
     def is_opening(self):
-        from xknx.devices import TravelStatus
-
         """Return if the cover is opening or not."""
         return (
             self.travel_calc.is_traveling()
@@ -283,8 +276,6 @@ class CoverTimeBased(CoverEntity, RestoreEntity):
     @property
     def is_closing(self):
         """Return if the cover is closing or not."""
-        from xknx.devices import TravelStatus
-
         return (
             self.travel_calc.is_traveling()
             and self.travel_calc.travel_direction == TravelStatus.DIRECTION_DOWN

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,4 @@
 {
-  "name": "Cover Time Based (dev)",
+  "name": "Cover Time Based",
   "render_readme": true
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,4 @@
 {
-  "name": "Cover Time Based",
+  "name": "Cover Time Based (dev)",
   "render_readme": true
 }


### PR DESCRIPTION
## Summary

This PR introduces the `is_button` variable to the cover configuration. When set to true, this simulates a momentary button press, where the associated switch is temporarily set to a high state, as opposed to flipping a persistent switch.

## Rationale

This feature is beneficial for remote-controlled window covers that have been adapted for HomeAssistant integration. These covers typically expect button presses for operation and only stop when a dedicated stop button is pressed. This PR enables the simulation of such button presses, making the integration compatible for these types of setups.

## Changes

- Added the `is_button` configuration option for all covers. It defaults to `false` to preserve compatibility with existing configurations.
- Utilized asyncio for its sleep functionality to manage timed deactivation.
- Implemented a delay in the `_async_handle_command` function to turn off the switch after 1 second of activation, simulating a button press. This is only enabled for covers where `is_button` is set to `true`.