### PR TITLE
fix: Bump xknx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.3.2 (2025-07-09)
+
+### Bug Fixes
+
+- Bump xknx (@bernardesarthur)
+
+
 ## 2.3.1 (2025-05-01)
 
 ### Bug Fixes

--- a/custom_components/cover_time_based/manifest.json
+++ b/custom_components/cover_time_based/manifest.json
@@ -7,7 +7,7 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/Sese-Schneider/ha-cover-time-based/issues",
   "requirements": [
-    "xknx==3.6.0"
+    "xknx==3.8.0"
   ],
   "version": "2.3.1"
 }

--- a/custom_components/cover_time_based/manifest.json
+++ b/custom_components/cover_time_based/manifest.json
@@ -9,5 +9,5 @@
   "requirements": [
     "xknx==3.8.0"
   ],
-  "version": "2.3.1"
+  "version": "2.3.2"
 }


### PR DESCRIPTION
Solve https://github.com/Sese-Schneider/ha-cover-time-based/issues/24

After Home Assistant Core 2025.06 the lib KNX requirement was updated to 3.8.0 and because this some users are experiencing some errors. 