### PR TITLE
fix: don't treat unknown/unavailable as external stop on wrapped covers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ### Bug Fixes
 
+- Fixed wrapped cover treating `unknown`/`unavailable` state as an external stop — stateless covers (e.g. Somfy RTS via Overkiz) now track position correctly (#59)
 - Fixed calibration direction override for tilt attributes — server now derives direction from attribute name instead of card sending position-based guess
 - Fixed calibration overhead calculation for tilt (3 steps vs 8 travel steps)
 - Fixed toggle mode tilt restore clearing `_last_command` prematurely, breaking stop pulse

--- a/custom_components/cover_time_based/cover_wrapped.py
+++ b/custom_components/cover_time_based/cover_wrapped.py
@@ -13,6 +13,9 @@ _OPENING = "opening"
 _CLOSING = "closing"
 _MOVING_STATES = {_OPENING, _CLOSING}
 
+# Cover states that indicate the cover has explicitly stopped
+_STOPPED_STATES = {"open", "closed"}
+
 
 class WrappedCoverTimeBased(CoverTimeBased):
     """A cover that delegates open/close/stop to an underlying cover entity."""
@@ -54,8 +57,8 @@ class WrappedCoverTimeBased(CoverTimeBased):
         elif new_val == _CLOSING:
             self._log("_handle_external_state_change :: wrapped cover closing")
             await self.async_close_cover()
-        elif old_val in _MOVING_STATES:
-            # Was moving, now stopped
+        elif old_val in _MOVING_STATES and new_val in _STOPPED_STATES:
+            # Was moving, now explicitly stopped (not unknown/unavailable)
             self._log("_handle_external_state_change :: wrapped cover stopped")
             await self.async_stop_cover()
 

--- a/tests/test_state_monitoring.py
+++ b/tests/test_state_monitoring.py
@@ -555,6 +555,43 @@ class TestWrappedCoverExternalStateChange:
 
         assert not cover.travel_calc.is_traveling()
 
+    @pytest.mark.asyncio
+    async def test_opening_to_unknown_does_not_stop(self, make_cover):
+        """Stateless covers transition to 'unknown' while still moving.
+
+        opening->unknown must NOT be treated as an external stop, because
+        'unknown' means 'no state feedback', not 'stopped'.
+        """
+        cover = make_cover(cover_entity_id="cover.inner")
+        cover.travel_calc.set_position(50)
+        cover.travel_calc.start_travel_up()
+        cover._last_command = SERVICE_OPEN_COVER
+
+        with patch.object(cover, "async_write_ha_state"):
+            await cover._handle_external_state_change(
+                "cover.inner", "opening", "unknown"
+            )
+
+        # Tracker should still be running — not stopped
+        assert cover.travel_calc.is_traveling()
+        assert cover._last_command == SERVICE_OPEN_COVER
+
+    @pytest.mark.asyncio
+    async def test_closing_to_unavailable_does_not_stop(self, make_cover):
+        """closing->unavailable must NOT be treated as an external stop."""
+        cover = make_cover(cover_entity_id="cover.inner")
+        cover.travel_calc.set_position(50)
+        cover.travel_calc.start_travel_down()
+        cover._last_command = SERVICE_CLOSE_COVER
+
+        with patch.object(cover, "async_write_ha_state"):
+            await cover._handle_external_state_change(
+                "cover.inner", "closing", "unavailable"
+            )
+
+        assert cover.travel_calc.is_traveling()
+        assert cover._last_command == SERVICE_CLOSE_COVER
+
 
 # ===================================================================
 # End-to-end tests through _async_switch_state_changed


### PR DESCRIPTION
## Summary

- Stateless covers (e.g. Somfy RTS via Overkiz) transition to `unknown` while still moving because they have no state feedback
- The wrapped cover handler was treating **any** transition away from a moving state (`opening`/`closing`) as an external stop, causing `set_position` to abort prematurely after ~5 seconds
- Now only explicit stopped states (`open`, `closed`) trigger an external stop — transitions to `unknown` or `unavailable` are ignored, allowing the auto-updater to track position to completion

Fixes #59

## Changes

- `cover_wrapped.py`: Added `_STOPPED_STATES` set and tightened the condition in `_handle_external_state_change` to require `new_val in _STOPPED_STATES`
- `test_state_monitoring.py`: Added `test_opening_to_unknown_does_not_stop` and `test_closing_to_unavailable_does_not_stop`
- `CHANGELOG.md`: Added bug fix entry

## Test plan

- [x] New tests fail before fix, pass after
- [x] All 698 existing tests pass
- [x] Ruff lint and format clean