### PR TITLE
Add sequential_open tilt mode and close/open button behavior option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Features
 
+- **Sequential tilt split into two variants:** `sequential_close` (conventional — slats close when the motor drives further down past cover-closed) and `sequential_open` (for covers where slats *open* by driving further down past cover-closed, e.g. certain tilting shutters). Existing `sequential` configs auto-migrate to `sequential_close` (issue #61).
+- **Close/open button behavior option:** For sequential tilt modes, choose how the close/open buttons interact with slat articulation — `never` (default, travel only), `on_repeat` (two-press: first click travels, second articulates), or `one_press` (single motor motion for travel + articulation).
 - **UI-first configuration:** Config flow creates covers via UI; all settings managed through a Lovelace card and WebSocket API
 - **Control mode:** Single `control_mode` setting replaces separate `device_type`/`input_mode` — choose from wrapped, switch, pulse, or toggle
 - **External state monitoring:** Detects physical switch presses and keeps the position tracker in sync with actual motor state. Supports all control modes for both cover and tilt switches
@@ -37,6 +39,10 @@
 - Fixed switch mode tilt handler using pulse-mode behavior (now uses latching: ON=start, OFF=stop)
 - Fixed tilt switch echo filtering (pending=2 for direction switches to handle ON+OFF transitions)
 - Fixed wrapped cover handler not tracking direction changes (opening→closing)
+- Fixed external movements skipping tilt coupling for shared-motor strategies: physical button presses now track both tilt and travel phases on sequential and inline modes (only dual-motor external movements still skip, since the separate tilt relay cannot be sequenced)
+- Fixed toggle-mode external travel handler re-issuing the direction on a same-direction pulse while traveling; now stops the motor, matching real toggle-style motor controllers that latch OFF on the second same-direction pulse
+- Fixed toggle-mode external debounce window of `pulse_time + 0.5s` swallowing legitimate rapid clicks; shortened to 100 ms (enough for contact bounce, short enough for human click cadence)
+- Fixed calibration attribute availability for `sequential_open` at the two closed-cover known positions: the allowed set was inverted vs the strategy's actual physical constraints
 
 ## 3.0.0 (2025-12-10)
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,16 @@ The **Tilt Mode** setting controls how tilt and travel interact:
 - **Sequential (closes then tilts open):** Mirror image of the above — for covers where slats articulate *open* when the motor drives further down past cover-closed, not closed. First the cover closes then the slats tilt open (motor continues down). When opening, the slats first tilt closed (motor up) then the cover opens.
 - **Separate tilt motor (dual_motor):** A separate motor controls the tilt. Requires dedicated tilt open/close/stop switches. Tilt is only allowed when the cover is in a safe position (configurable).
 
+### Close/Open Button Behavior (sequential modes only)
+
+For the two sequential tilt modes, the **Close/open button behavior** setting controls how the main close and open buttons interact with slat articulation:
+
+- **Travel only** (default): Close and open only drive travel. Slats stay at the resting position; use the dedicated tilt buttons to articulate.
+- **Travel, then articulate on repeat press:** Two-press UX. Press close once to close the cover; press close again (from the resting closed state) to articulate the slats to the opposite extreme. Press open once from the articulated state to return slats to the resting position (stops at middle); press open again to travel to fully open.
+- **Travel and articulate in one press:** Close runs travel and articulation as a single continuous motor motion. Open is unchanged (the default plan already combines slat restoration with travel).
+
+This setting is ignored for non-sequential tilt modes.
+
 ### Tilt Motor
 
 For covers with a dedicated tilt motor, configure:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ It improves the original integration by adding tilt control, synchronized travel
 - **External state monitoring:** Detects physical switch presses and keeps the position tracker in sync.
 - **Multiple input modes:** Latching switches, momentary pulse buttons, or toggle-style relays.
 - **Wrap an existing cover:** Add time-based position tracking to any cover entity.
-- **Control the tilt of your cover based on time** with three tilt modes: inline, sequential (closes then tilts), or separate tilt motor.
+- **Control the tilt of your cover based on time** with four tilt modes: inline, sequential closes-then-tilts-closed, sequential closes-then-tilts-open, or separate tilt motor.
 - **Built-in configuration and calibration:** Calibrate travel times directly from the UI, including finer parameters to compensate for the time it takes the motor to startup.
 - **Resyncs position at endpoints:** The motor can be configured to run-on at the 0%/100% endpoints to resync the position tracker with the physical cover.
 
@@ -119,7 +119,8 @@ The **Tilt Mode** setting controls how tilt and travel interact:
 
 - **None:** Tilt is disabled. Only position tracking is used.
 - **Inline:** Tilt and travel use the same motor. Tilting can happen with the cover in any position. When closing the cover, the closing movement first causes the slats to tilt closed before the cover starts closing. When opening the cover, the opening movement first causes the slats to tilt open before the cover starts opening.
-- **Sequential (closes then tilts):** Tilting can only happen in the fully closed position. First the cover closes then the slats tilt closed. When opening, first the slats tilt open then the cover opens.
+- **Sequential (closes then tilts closed):** Tilting can only happen in the fully closed position. First the cover closes then the slats tilt closed (motor drives further down past cover-closed to close the slats). When opening, the slats first tilt open (motor up) then the cover opens.
+- **Sequential (closes then tilts open):** Mirror image of the above — for covers where slats articulate *open* when the motor drives further down past cover-closed, not closed. First the cover closes then the slats tilt open (motor continues down). When opening, the slats first tilt closed (motor up) then the cover opens.
 - **Separate tilt motor (dual_motor):** A separate motor controls the tilt. Requires dedicated tilt open/close/stop switches. Tilt is only allowed when the cover is in a safe position (configurable).
 
 ### Tilt Motor

--- a/custom_components/cover_time_based/__init__.py
+++ b/custom_components/cover_time_based/__init__.py
@@ -47,6 +47,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Migrate config entries between versions."""
+    _LOGGER.debug(
+        "Migrating config entry %s from version %s", entry.entry_id, entry.version
+    )
+
+    if entry.version < 3:
+        new_options = dict(entry.options)
+        if new_options.get("tilt_mode") == "sequential":
+            new_options["tilt_mode"] = "sequential_close"
+        hass.config_entries.async_update_entry(entry, options=new_options, version=3)
+
+    return True
+
+
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/custom_components/cover_time_based/config_flow.py
+++ b/custom_components/cover_time_based/config_flow.py
@@ -18,7 +18,7 @@ from .cover import DOMAIN
 class CoverTimeBasedConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Cover Time Based."""
 
-    VERSION = 2
+    VERSION = 3
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/cover_time_based/const.py
+++ b/custom_components/cover_time_based/const.py
@@ -12,3 +12,28 @@ CONF_TILT_STARTUP_DELAY = "tilt_startup_delay"
 CONF_ENDPOINT_RUNON_TIME = "endpoint_runon_time"
 CONF_MIN_MOVEMENT_TIME = "min_movement_time"
 DEFAULT_ENDPOINT_RUNON_TIME = 2.0
+
+# How the close/open buttons behave under sequential tilt modes.
+#
+# - "never" (default): the buttons only drive travel. Slats stay at their
+#   implicit-during-travel value; use the tilt buttons to articulate.
+# - "on_repeat": two-press UX. The first close/open click behaves like
+#   "never". A second click from the resting closed/articulated state
+#   articulates (close) or restores (open) the slats in a separate motor
+#   motion.
+# - "one_press": the close button runs travel+articulate in a single motor
+#   motion, ending at the fully-closed (travel=0, tilt=articulated) state.
+#   For open, "one_press" is equivalent to "never" — the default plan
+#   already combines tilt restoration with travel.
+#
+# Ignored for tilt modes other than sequential_close / sequential_open.
+CONF_SEQUENTIAL_BUTTON_BEHAVIOR = "sequential_button_behavior"
+SEQUENTIAL_BUTTON_BEHAVIOR_NEVER = "never"
+SEQUENTIAL_BUTTON_BEHAVIOR_ON_REPEAT = "on_repeat"
+SEQUENTIAL_BUTTON_BEHAVIOR_ONE_PRESS = "one_press"
+SEQUENTIAL_BUTTON_BEHAVIOR_VALUES = (
+    SEQUENTIAL_BUTTON_BEHAVIOR_NEVER,
+    SEQUENTIAL_BUTTON_BEHAVIOR_ON_REPEAT,
+    SEQUENTIAL_BUTTON_BEHAVIOR_ONE_PRESS,
+)
+DEFAULT_SEQUENTIAL_BUTTON_BEHAVIOR = SEQUENTIAL_BUTTON_BEHAVIOR_NEVER

--- a/custom_components/cover_time_based/cover.py
+++ b/custom_components/cover_time_based/cover.py
@@ -246,7 +246,12 @@ def _resolve_control_mode(config, defaults, has_cover_entity):
 
 def _resolve_tilt_strategy(tilt_mode_str, tilt_time_close, tilt_time_open, **kwargs):
     """Map tilt_mode config string to a TiltStrategy instance (or None)."""
-    from .tilt_strategies import DualMotorTilt, InlineTilt, SequentialTilt
+    from .tilt_strategies import (
+        DualMotorTilt,
+        InlineTilt,
+        SequentialCloseTilt,
+        SequentialOpenTilt,
+    )
 
     if tilt_mode_str == "none":
         return None
@@ -262,11 +267,13 @@ def _resolve_tilt_strategy(tilt_mode_str, tilt_time_close, tilt_time_open, **kwa
         )
     if tilt_mode_str == "inline":
         return InlineTilt()
+    if tilt_mode_str == "sequential_open":
+        return SequentialOpenTilt()
     if tilt_mode_str in ("sequential_close", "sequential"):
         # "sequential" is the legacy value; it resolves to sequential_close behavior.
-        return SequentialTilt()
+        return SequentialCloseTilt()
     # Unknown value → default to sequential_close for backward compatibility.
-    return SequentialTilt()
+    return SequentialCloseTilt()
 
 
 def _create_cover_from_options(options, device_id="", name=""):

--- a/custom_components/cover_time_based/cover.py
+++ b/custom_components/cover_time_based/cover.py
@@ -262,7 +262,10 @@ def _resolve_tilt_strategy(tilt_mode_str, tilt_time_close, tilt_time_open, **kwa
         )
     if tilt_mode_str == "inline":
         return InlineTilt()
-    # "sequential" or any other value with tilt times → sequential
+    if tilt_mode_str in ("sequential_close", "sequential"):
+        # "sequential" is the legacy value; it resolves to sequential_close behavior.
+        return SequentialTilt()
+    # Unknown value → default to sequential_close for backward compatibility.
     return SequentialTilt()
 
 

--- a/custom_components/cover_time_based/cover.py
+++ b/custom_components/cover_time_based/cover.py
@@ -27,6 +27,7 @@ from .calibration import (
 from .const import (
     CONF_ENDPOINT_RUNON_TIME,
     CONF_MIN_MOVEMENT_TIME,
+    CONF_SEQUENTIAL_BUTTON_BEHAVIOR,
     CONF_TILT_MODE,
     CONF_TILT_STARTUP_DELAY,
     CONF_TILT_TIME_CLOSE,
@@ -35,6 +36,7 @@ from .const import (
     CONF_TRAVEL_TIME_CLOSE,
     CONF_TRAVEL_TIME_OPEN,
     DEFAULT_ENDPOINT_RUNON_TIME,
+    DEFAULT_SEQUENTIAL_BUTTON_BEHAVIOR,
 )
 from .cover_base import CoverTimeBased  # noqa: F401
 from .helpers import resolve_entity
@@ -312,6 +314,9 @@ def _create_cover_from_options(options, device_id="", name=""):
         tilt_open_switch=options.get(CONF_TILT_OPEN_SWITCH),
         tilt_close_switch=options.get(CONF_TILT_CLOSE_SWITCH),
         tilt_stop_switch=options.get(CONF_TILT_STOP_SWITCH),
+        sequential_button_behavior=options.get(
+            CONF_SEQUENTIAL_BUTTON_BEHAVIOR, DEFAULT_SEQUENTIAL_BUTTON_BEHAVIOR
+        ),
     )
 
     if control_mode == CONTROL_MODE_WRAPPED:

--- a/custom_components/cover_time_based/cover_base.py
+++ b/custom_components/cover_time_based/cover_base.py
@@ -480,9 +480,18 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
 
         tilt_target = None
         pre_step_delay = 0.0
-        if not self._triggered_externally:
-            # Only plan tilt for self-initiated movements — external movements
-            # can't control relay sequencing (the relay is already on).
+        # Dual-motor externals skip tilt planning entirely — the separate tilt
+        # relay can't be sequenced, and the snap-to-endpoint fall-through in
+        # _plan_tilt_for_travel has no way to drive the tilt motor afterwards.
+        # Shared-motor strategies (inline, sequential_*) still need planning
+        # so the calculators stay in sync with the single motor's multi-phase
+        # motion (e.g. sequential_open: tilt close 100→0 then travel 0→100).
+        skip_tilt_planning = (
+            self._triggered_externally
+            and self._tilt_strategy is not None
+            and self._tilt_strategy.uses_tilt_motor
+        )
+        if not skip_tilt_planning:
             current_tilt = (
                 self.tilt_calc.current_position() if self._tilt_strategy else None
             )

--- a/custom_components/cover_time_based/cover_base.py
+++ b/custom_components/cover_time_based/cover_base.py
@@ -508,8 +508,12 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         await self._abandon_active_lifecycle()
 
         closing = target == 0
-        command = SERVICE_CLOSE_COVER if closing else SERVICE_OPEN_COVER
-        opposite_command = SERVICE_OPEN_COVER if closing else SERVICE_CLOSE_COVER
+        if self._tilt_strategy is not None:
+            command = self._tilt_strategy.tilt_command_for(closing)
+            opposite_command = self._tilt_strategy.tilt_command_for(not closing)
+        else:
+            command = SERVICE_CLOSE_COVER if closing else SERVICE_OPEN_COVER
+            opposite_command = SERVICE_OPEN_COVER if closing else SERVICE_CLOSE_COVER
 
         if self._startup_delay_task and not self._startup_delay_task.done():
             if self._last_command == opposite_command:

--- a/custom_components/cover_time_based/cover_base.py
+++ b/custom_components/cover_time_based/cover_base.py
@@ -41,7 +41,12 @@ from .const import (
     CONF_TRAVEL_STARTUP_DELAY,
     CONF_TRAVEL_TIME_CLOSE,
     CONF_TRAVEL_TIME_OPEN,
+    DEFAULT_SEQUENTIAL_BUTTON_BEHAVIOR,
+    SEQUENTIAL_BUTTON_BEHAVIOR_NEVER,
+    SEQUENTIAL_BUTTON_BEHAVIOR_ONE_PRESS,
+    SEQUENTIAL_BUTTON_BEHAVIOR_ON_REPEAT,
 )
+from .tilt_strategies import SequentialTilt
 from .tilt_strategies.planning import (
     calculate_pre_step_delay,
     extract_coupled_tilt,
@@ -71,6 +76,7 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         tilt_open_switch=None,
         tilt_close_switch=None,
         tilt_stop_switch=None,
+        sequential_button_behavior=DEFAULT_SEQUENTIAL_BUTTON_BEHAVIOR,
     ):
         """Initialize the cover."""
         self._unique_id = device_id
@@ -87,6 +93,7 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         self._tilt_open_switch_id = tilt_open_switch
         self._tilt_close_switch_id = tilt_close_switch
         self._tilt_stop_switch_id = tilt_stop_switch
+        self._sequential_button_behavior = sequential_button_behavior
 
         if name:
             self._name = name
@@ -323,6 +330,8 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
             self._log("async_close_cover :: currently opening, stopping first")
             await self.async_stop_cover()
             await self._direction_change_delay()
+        if await self._handle_sequential_close_behavior():
+            return
         await self._async_move_to_endpoint(target=0)
 
     async def async_open_cover(self, **kwargs):
@@ -333,7 +342,89 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
             self._log("async_open_cover :: currently closing, stopping first")
             await self.async_stop_cover()
             await self._direction_change_delay()
+        if await self._handle_sequential_open_behavior():
+            return
         await self._async_move_to_endpoint(target=100)
+
+    async def _handle_sequential_close_behavior(self) -> bool:
+        """Apply sequential_button_behavior for the close action.
+
+        Returns True if the behavior handled the close (caller should return
+        without falling through to _async_move_to_endpoint). Returns False
+        for "never" and for non-sequential tilt strategies — the caller
+        proceeds with the default close.
+        """
+        strategy = self._tilt_strategy
+        behavior = self._sequential_button_behavior
+        if behavior == SEQUENTIAL_BUTTON_BEHAVIOR_NEVER or not isinstance(
+            strategy, SequentialTilt
+        ):
+            return False
+
+        implicit = strategy.implicit_tilt_during_travel
+        articulated = 100 - implicit
+
+        if behavior == SEQUENTIAL_BUTTON_BEHAVIOR_ONE_PRESS:
+            # Single motor motion: travel to 0, then articulate slats.
+            # set_tilt_position plans [TravelTo(0), TiltTo(articulated)] when
+            # the cover is not already closed, or just [TiltTo(articulated)]
+            # when it is.
+            self._log(
+                "async_close_cover :: sequential one_press → set_tilt_position(%d)",
+                articulated,
+            )
+            await self.set_tilt_position(articulated)
+            return True
+
+        if behavior == SEQUENTIAL_BUTTON_BEHAVIOR_ON_REPEAT:
+            # Two-press: first press travels (handled by the caller's default
+            # _async_move_to_endpoint path). A second press from the resting
+            # closed state (travel=0, tilt=implicit) articulates the slats.
+            current_travel = self.travel_calc.current_position()
+            current_tilt = self.tilt_calc.current_position()
+            if current_travel == 0 and current_tilt == implicit:
+                self._log(
+                    "async_close_cover :: sequential on_repeat at rest → "
+                    "set_tilt_position(%d)",
+                    articulated,
+                )
+                await self.set_tilt_position(articulated)
+                return True
+            return False
+
+        return False
+
+    async def _handle_sequential_open_behavior(self) -> bool:
+        """Apply sequential_button_behavior for the open action.
+
+        Returns True if the behavior handled the open. Returns False for
+        "never", "one_press" (equivalent to "never" — the default plan
+        already combines tilt restoration with travel), and non-sequential
+        strategies.
+        """
+        strategy = self._tilt_strategy
+        behavior = self._sequential_button_behavior
+        if behavior != SEQUENTIAL_BUTTON_BEHAVIOR_ON_REPEAT or not isinstance(
+            strategy, SequentialTilt
+        ):
+            return False
+
+        # Two-press open: from (travel=0, tilt != implicit), the first press
+        # only restores tilt to the implicit resting value (stops at the
+        # middle position). The second press then travels to 100 via the
+        # default path, which sees tilt already at implicit and just travels.
+        implicit = strategy.implicit_tilt_during_travel
+        current_travel = self.travel_calc.current_position()
+        current_tilt = self.tilt_calc.current_position()
+        if current_travel == 0 and current_tilt is not None and current_tilt != implicit:
+            self._log(
+                "async_open_cover :: sequential on_repeat articulated → "
+                "set_tilt_position(%d)",
+                implicit,
+            )
+            await self.set_tilt_position(implicit)
+            return True
+        return False
 
     async def _direction_change_delay(self):
         """Pause between stop and direction change to let the motor settle.

--- a/custom_components/cover_time_based/cover_base.py
+++ b/custom_components/cover_time_based/cover_base.py
@@ -416,7 +416,11 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         implicit = strategy.implicit_tilt_during_travel
         current_travel = self.travel_calc.current_position()
         current_tilt = self.tilt_calc.current_position()
-        if current_travel == 0 and current_tilt is not None and current_tilt != implicit:
+        if (
+            current_travel == 0
+            and current_tilt is not None
+            and current_tilt != implicit
+        ):
             self._log(
                 "async_open_cover :: sequential on_repeat articulated → "
                 "set_tilt_position(%d)",

--- a/custom_components/cover_time_based/cover_base.py
+++ b/custom_components/cover_time_based/cover_base.py
@@ -1374,8 +1374,8 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
             else:
                 await self._send_tilt_open()
         else:
-            # Shared motor (inline): reverse main motor direction
-            command = SERVICE_CLOSE_COVER if closing else SERVICE_OPEN_COVER
+            # Shared motor (inline or sequential): consult the strategy for direction.
+            command = self._tilt_strategy.tilt_command_for(closing)
             await self._async_handle_command(command)
 
         self.tilt_calc.start_travel(restore_target)

--- a/custom_components/cover_time_based/cover_base.py
+++ b/custom_components/cover_time_based/cover_base.py
@@ -690,17 +690,19 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
 
         if current is None:
             closing = target <= 50
-            command = SERVICE_CLOSE_COVER if closing else SERVICE_OPEN_COVER
             current = 100 if closing else 0
             self.tilt_calc.update_position(current)
         elif target < current:
-            command = SERVICE_CLOSE_COVER
+            closing = True
         elif target > current:
-            command = SERVICE_OPEN_COVER
+            closing = False
         else:
             return
 
-        closing = command == SERVICE_CLOSE_COVER
+        if self._tilt_strategy is not None:
+            command = self._tilt_strategy.tilt_command_for(closing)
+        else:
+            command = SERVICE_CLOSE_COVER if closing else SERVICE_OPEN_COVER
 
         should_proceed, is_direction_change = await self._handle_pre_movement_checks(
             command

--- a/custom_components/cover_time_based/cover_calibration.py
+++ b/custom_components/cover_time_based/cover_calibration.py
@@ -117,12 +117,16 @@ class CalibrationMixin:
         """Start a simple travel/tilt time test by moving the cover."""
         assert self._calibration is not None
         if direction:
-            self._calibration.move_command = self._resolve_direction(direction, None)
+            move_command = self._resolve_direction(direction, None)
+        elif attribute.startswith("tilt_") and self._tilt_strategy is not None:
+            closing_tilt = "close" in attribute
+            move_command = self._tilt_strategy.tilt_command_for(closing_tilt)
         elif "close" in attribute:
-            self._calibration.move_command = SERVICE_CLOSE_COVER
+            move_command = SERVICE_CLOSE_COVER
         else:
-            self._calibration.move_command = SERVICE_OPEN_COVER
-        await self._async_handle_command(self._calibration.move_command)
+            move_command = SERVICE_OPEN_COVER
+        self._calibration.move_command = move_command
+        await self._async_handle_command(move_command)
 
     async def _start_overhead_test(self, attribute, direction):
         """Start automated step test for motor overhead."""

--- a/custom_components/cover_time_based/cover_toggle_mode.py
+++ b/custom_components/cover_time_based/cover_toggle_mode.py
@@ -99,11 +99,33 @@ class ToggleModeCover(SwitchCoverTimeBased):
         self._last_external_toggle_time[entity_id] = now
 
         if entity_id == self._open_switch_entity_id:
-            self._log("_handle_external_state_change :: external open toggle detected")
-            await self.async_open_cover()
+            if self.is_opening:
+                # Same direction while opening: toggle-style motor controllers
+                # latch OFF on a second same-direction pulse → stop.
+                self._log(
+                    "_handle_external_state_change ::"
+                    " open toggle while opening, stopping"
+                )
+                await self.async_stop_cover()
+            else:
+                # Idle or closing (opposite direction): async_open_cover
+                # handles the direction-change stop-and-reverse internally.
+                self._log(
+                    "_handle_external_state_change :: external open toggle detected"
+                )
+                await self.async_open_cover()
         elif entity_id == self._close_switch_entity_id:
-            self._log("_handle_external_state_change :: external close toggle detected")
-            await self.async_close_cover()
+            if self.is_closing:
+                self._log(
+                    "_handle_external_state_change ::"
+                    " close toggle while closing, stopping"
+                )
+                await self.async_stop_cover()
+            else:
+                self._log(
+                    "_handle_external_state_change :: external close toggle detected"
+                )
+                await self.async_close_cover()
 
     async def _handle_external_tilt_state_change(self, entity_id, old_val, new_val):
         """Handle external tilt state change in toggle mode.

--- a/custom_components/cover_time_based/cover_toggle_mode.py
+++ b/custom_components/cover_time_based/cover_toggle_mode.py
@@ -14,6 +14,13 @@ from .cover_switch import SwitchCoverTimeBased
 
 _LOGGER = logging.getLogger(__name__)
 
+# Short debounce window (seconds) to suppress contact bounce on external
+# momentary switches — a few tens of ms is enough in practice. Must be
+# shorter than any realistic human click cadence (≥ 200ms between
+# deliberate presses) so legitimate rapid toggles (e.g. "start then stop")
+# are not dropped.
+_EXTERNAL_TOGGLE_DEBOUNCE = 0.1
+
 
 class ToggleModeCover(SwitchCoverTimeBased):
     """Cover controlled by toggle-style relays (toggle mode).
@@ -89,8 +96,7 @@ class ToggleModeCover(SwitchCoverTimeBased):
 
         now = time.monotonic()
         last = self._last_external_toggle_time.get(entity_id, 0)
-        debounce_window = self._pulse_time + 0.5
-        if now - last < debounce_window:
+        if now - last < _EXTERNAL_TOGGLE_DEBOUNCE:
             self._log(
                 "_handle_external_state_change :: debounced toggle on %s",
                 entity_id,
@@ -138,8 +144,7 @@ class ToggleModeCover(SwitchCoverTimeBased):
 
         now = time.monotonic()
         last = self._last_external_toggle_time.get(entity_id, 0)
-        debounce_window = self._pulse_time + 0.5
-        if now - last < debounce_window:
+        if now - last < _EXTERNAL_TOGGLE_DEBOUNCE:
             self._log(
                 "_handle_external_tilt_state_change :: debounced toggle on %s",
                 entity_id,

--- a/custom_components/cover_time_based/frontend/cover-time-based-card.js
+++ b/custom_components/cover_time_based/frontend/cover-time-based-card.js
@@ -1097,7 +1097,7 @@ class CoverTimeBasedCard extends LitElement {
               ${this._t("sequential_button_behavior.one_press")}
             </option>
           </select>
-          <div class="helper-text">
+          <div class="helper-text" style="margin-top: 8px;">
             ${this._t(`sequential_button_behavior.hint.${buttonBehavior}`)}
           </div>
         </div>

--- a/custom_components/cover_time_based/frontend/cover-time-based-card.js
+++ b/custom_components/cover_time_based/frontend/cover-time-based-card.js
@@ -41,7 +41,8 @@ const EN = {
   "entities.stop_switch": "Stop switch",
   "tilt.label": "Tilt Mode",
   "tilt.none": "Not supported",
-  "tilt.sequential": "Closes then tilts",
+  "tilt.sequential_close": "Closes then tilts closed",
+  "tilt.sequential_open": "Closes then tilts open",
   "tilt.dual_motor": "Separate tilt motor",
   "tilt.inline": "Tilts inline with travel",
   "tilt_motor.label": "Tilt Motor",
@@ -89,10 +90,14 @@ const EN = {
   "controls.tilt_open": "Tilt open",
   "controls.tilt_stop": "Tilt stop",
   "controls.tilt_close": "Tilt close",
-  "hints.sequential.travel_time_close": "Start with cover fully open. Click Finish when the cover is fully closed, before the slats start tilting.",
-  "hints.sequential.travel_time_open": "Start with cover closed and slats open. Click Finish when the cover is fully open.",
-  "hints.sequential.tilt_time_close": "Start with cover closed but slats open. Click Finish when the slats are fully closed.",
-  "hints.sequential.tilt_time_open": "Start with cover and slats closed. Click Finish when the slats are open.",
+  "hints.sequential_close.travel_time_close": "Start with cover fully open. Click Finish when the cover is fully closed, before the slats start tilting.",
+  "hints.sequential_close.travel_time_open": "Start with cover closed and slats open. Click Finish when the cover is fully open.",
+  "hints.sequential_close.tilt_time_close": "Start with cover closed but slats open. Click Finish when the slats are fully closed.",
+  "hints.sequential_close.tilt_time_open": "Start with cover and slats closed. Click Finish when the slats are open.",
+  "hints.sequential_open.travel_time_close": "Start with cover fully open and slats closed. Click Finish when the cover is fully closed, before the slats start tilting open.",
+  "hints.sequential_open.travel_time_open": "Start with cover closed and slats closed. Click Finish when the cover is fully open.",
+  "hints.sequential_open.tilt_time_close": "Start with cover closed but slats open. Click Finish when the slats are fully closed.",
+  "hints.sequential_open.tilt_time_open": "Start with cover and slats closed. Click Finish when the slats are fully open.",
   "hints.dual_motor.travel_time_close": "Start with cover open and slats in safe position. Click Finish when the cover is fully closed.",
   "hints.dual_motor.travel_time_open": "Start with cover closed and slats in safe position. Click Finish when the cover is fully open.",
   "hints.dual_motor.tilt_time_close": "Start with cover closed and slats open. Click Finish when the slats are fully closed.",
@@ -131,7 +136,8 @@ const TRANSLATIONS = {
     "entities.stop_switch": "Interruptor de parar",
     "tilt.label": "Inclinação",
     "tilt.none": "Não suportado",
-    "tilt.sequential": "Fecha e depois inclina",
+    "tilt.sequential_close": "Fecha e depois inclina fechadas",
+    "tilt.sequential_open": "Fecha e depois inclina abertas",
     "tilt.dual_motor": "Motor de inclinação separado",
     "tilt.inline": "Inclina durante o deslocamento",
     "tilt_motor.label": "Motor de Inclinação",
@@ -179,10 +185,14 @@ const TRANSLATIONS = {
     "controls.tilt_open": "Inclinar abrir",
     "controls.tilt_stop": "Inclinar parar",
     "controls.tilt_close": "Inclinar fechar",
-    "hints.sequential.travel_time_close": "Comece com o estore totalmente aberto. Clique em Concluir quando o estore estiver totalmente fechado, antes de as lâminas começarem a inclinar.",
-    "hints.sequential.travel_time_open": "Comece com o estore fechado e as lâminas abertas. Clique em Concluir quando o estore estiver totalmente aberto.",
-    "hints.sequential.tilt_time_close": "Comece com o estore fechado mas as lâminas abertas. Clique em Concluir quando as lâminas estiverem totalmente fechadas.",
-    "hints.sequential.tilt_time_open": "Comece com o estore e as lâminas fechados. Clique em Concluir quando as lâminas estiverem abertas.",
+    "hints.sequential_close.travel_time_close": "Comece com o estore totalmente aberto. Clique em Concluir quando o estore estiver totalmente fechado, antes de as lâminas começarem a inclinar.",
+    "hints.sequential_close.travel_time_open": "Comece com o estore fechado e as lâminas abertas. Clique em Concluir quando o estore estiver totalmente aberto.",
+    "hints.sequential_close.tilt_time_close": "Comece com o estore fechado mas as lâminas abertas. Clique em Concluir quando as lâminas estiverem totalmente fechadas.",
+    "hints.sequential_close.tilt_time_open": "Comece com o estore e as lâminas fechados. Clique em Concluir quando as lâminas estiverem abertas.",
+    "hints.sequential_open.travel_time_close": "Comece com o estore totalmente aberto e as lâminas fechadas. Clique em Concluir quando o estore estiver totalmente fechado, antes de as lâminas começarem a inclinar-se abertas.",
+    "hints.sequential_open.travel_time_open": "Comece com o estore fechado e as lâminas fechadas. Clique em Concluir quando o estore estiver totalmente aberto.",
+    "hints.sequential_open.tilt_time_close": "Comece com o estore fechado mas as lâminas abertas. Clique em Concluir quando as lâminas estiverem totalmente fechadas.",
+    "hints.sequential_open.tilt_time_open": "Comece com o estore e as lâminas fechados. Clique em Concluir quando as lâminas estiverem totalmente abertas.",
     "hints.dual_motor.travel_time_close": "Comece com o estore aberto e as lâminas na posição segura. Clique em Concluir quando o estore estiver totalmente fechado.",
     "hints.dual_motor.travel_time_open": "Comece com o estore fechado e as lâminas na posição segura. Clique em Concluir quando o estore estiver totalmente aberto.",
     "hints.dual_motor.tilt_time_close": "Comece com o estore fechado e as lâminas abertas. Clique em Concluir quando as lâminas estiverem totalmente fechadas.",
@@ -218,7 +228,8 @@ const TRANSLATIONS = {
     "entities.stop_switch": "Przełącznik zatrzymania",
     "tilt.label": "Nachylenie",
     "tilt.none": "Nieobsługiwane",
-    "tilt.sequential": "Najpierw zamyka, potem nachyla",
+    "tilt.sequential_close": "Najpierw zamyka, potem nachyla zamknięte",
+    "tilt.sequential_open": "Najpierw zamyka, potem nachyla otwarte",
     "tilt.dual_motor": "Osobny silnik nachylenia",
     "tilt.inline": "Nachylenie w trakcie ruchu",
     "tilt_motor.label": "Silnik nachylenia",
@@ -266,10 +277,14 @@ const TRANSLATIONS = {
     "controls.tilt_open": "Otwórz nachylenie",
     "controls.tilt_stop": "Zatrzymaj nachylenie",
     "controls.tilt_close": "Zamknij nachylenie",
-    "hints.sequential.travel_time_close": "Zacznij z roletą w pełni otwartą. Kliknij Zakończ, gdy roleta jest w pełni zamknięta, zanim listwy zaczną się nachylać.",
-    "hints.sequential.travel_time_open": "Zacznij z zamkniętą roletą i otwartymi listwami. Kliknij Zakończ, gdy roleta jest w pełni otwarta.",
-    "hints.sequential.tilt_time_close": "Zacznij z zamkniętą roletą, ale otwartymi listwami. Kliknij Zakończ, gdy listwy są w pełni zamknięte.",
-    "hints.sequential.tilt_time_open": "Zacznij z zamkniętą roletą i zamkniętymi listwami. Kliknij Zakończ, gdy listwy są otwarte.",
+    "hints.sequential_close.travel_time_close": "Zacznij z roletą w pełni otwartą. Kliknij Zakończ, gdy roleta jest w pełni zamknięta, zanim listwy zaczną się nachylać.",
+    "hints.sequential_close.travel_time_open": "Zacznij z zamkniętą roletą i otwartymi listwami. Kliknij Zakończ, gdy roleta jest w pełni otwarta.",
+    "hints.sequential_close.tilt_time_close": "Zacznij z zamkniętą roletą, ale otwartymi listwami. Kliknij Zakończ, gdy listwy są w pełni zamknięte.",
+    "hints.sequential_close.tilt_time_open": "Zacznij z zamkniętą roletą i zamkniętymi listwami. Kliknij Zakończ, gdy listwy są otwarte.",
+    "hints.sequential_open.travel_time_close": "Zacznij z roletą w pełni otwartą i zamkniętymi listwami. Kliknij Zakończ, gdy roleta jest w pełni zamknięta, zanim listwy zaczną się nachylać otwarte.",
+    "hints.sequential_open.travel_time_open": "Zacznij z zamkniętą roletą i zamkniętymi listwami. Kliknij Zakończ, gdy roleta jest w pełni otwarta.",
+    "hints.sequential_open.tilt_time_close": "Zacznij z zamkniętą roletą, ale otwartymi listwami. Kliknij Zakończ, gdy listwy są w pełni zamknięte.",
+    "hints.sequential_open.tilt_time_open": "Zacznij z zamkniętą roletą i zamkniętymi listwami. Kliknij Zakończ, gdy listwy są w pełni otwarte.",
     "hints.dual_motor.travel_time_close": "Zacznij z otwartą roletą i listwami w bezpiecznej pozycji. Kliknij Zakończ, gdy roleta jest w pełni zamknięta.",
     "hints.dual_motor.travel_time_open": "Zacznij z zamkniętą roletą i listwami w bezpiecznej pozycji. Kliknij Zakończ, gdy roleta jest w pełni otwarta.",
     "hints.dual_motor.tilt_time_close": "Zacznij z zamkniętą roletą i otwartymi listwami. Kliknij Zakończ, gdy listwy są w pełni zamknięte.",
@@ -624,8 +639,8 @@ class CoverTimeBasedCard extends LitElement {
       });
     } else {
       const updates = { tilt_mode: mode };
-      if (mode === "sequential") {
-        // Clear dual-motor fields when switching to sequential
+      if (mode === "sequential_close" || mode === "sequential_open") {
+        // Clear dual-motor fields when switching to either sequential variant
         updates.safe_tilt_position = null;
         updates.max_tilt_allowed_position = null;
         updates.tilt_open_switch = null;
@@ -1025,8 +1040,11 @@ class CoverTimeBasedCard extends LitElement {
           <option value="none" ?selected=${tiltMode === "none"}>
             ${this._t("tilt.none")}
           </option>
-          <option value="sequential" ?selected=${tiltMode === "sequential"}>
-            ${this._t("tilt.sequential")}
+          <option value="sequential_close" ?selected=${tiltMode === "sequential_close"}>
+            ${this._t("tilt.sequential_close")}
+          </option>
+          <option value="sequential_open" ?selected=${tiltMode === "sequential_open"}>
+            ${this._t("tilt.sequential_open")}
           </option>
 <option value="dual_motor" ?selected=${tiltMode === "dual_motor"}>
             ${this._t("tilt.dual_motor")}
@@ -1135,7 +1153,7 @@ class CoverTimeBasedCard extends LitElement {
   }
 
   _renderTimingTable(c) {
-    const hasTiltTimes = c.tilt_mode === "sequential" || c.tilt_mode === "dual_motor" || c.tilt_mode === "inline";
+    const hasTiltTimes = c.tilt_mode === "sequential_close" || c.tilt_mode === "sequential_open" || c.tilt_mode === "dual_motor" || c.tilt_mode === "inline";
 
     const travelRows = [
       ["timing.travel_time_close", "travel_time_close", c.travel_time_close, 0.1],
@@ -1183,7 +1201,7 @@ class CoverTimeBasedCard extends LitElement {
 
   _renderPositionReset() {
     const tiltMode = this._config?.tilt_mode || "none";
-    const hasIndependentTilt = tiltMode === "sequential" || tiltMode === "dual_motor" || tiltMode === "inline";
+    const hasIndependentTilt = tiltMode === "sequential_close" || tiltMode === "sequential_open" || tiltMode === "dual_motor" || tiltMode === "inline";
 
     return html`
       <div class="section">
@@ -1259,7 +1277,7 @@ class CoverTimeBasedCard extends LitElement {
     const state = this._getEntityState();
     const attrs = state?.attributes || {};
     const tiltMode = this._config?.tilt_mode || "none";
-    const hasTiltCalibration = tiltMode === "sequential" || tiltMode === "dual_motor" || tiltMode === "inline";
+    const hasTiltCalibration = tiltMode === "sequential_close" || tiltMode === "sequential_open" || tiltMode === "dual_motor" || tiltMode === "inline";
 
     const availableAttributes = TIMING_ATTRIBUTES.filter(
       ([key]) => {

--- a/custom_components/cover_time_based/frontend/cover-time-based-card.js
+++ b/custom_components/cover_time_based/frontend/cover-time-based-card.js
@@ -43,6 +43,13 @@ const EN = {
   "tilt.none": "Not supported",
   "tilt.sequential_close": "Closes then tilts closed",
   "tilt.sequential_open": "Closes then tilts open",
+  "sequential_button_behavior.label": "Close/open button behavior",
+  "sequential_button_behavior.never": "Travel only",
+  "sequential_button_behavior.on_repeat": "Travel, then articulate on repeat press",
+  "sequential_button_behavior.one_press": "Travel and articulate in one press",
+  "sequential_button_behavior.hint.never": "Close and open only drive travel. Use the tilt buttons to articulate the slats.",
+  "sequential_button_behavior.hint.on_repeat": "Press close twice: first closes the cover, second articulates the slats. Press open twice: first returns slats to the resting position, second opens the cover.",
+  "sequential_button_behavior.hint.one_press": "A single close press runs travel and articulation as one continuous motor motion.",
   "tilt.dual_motor": "Separate tilt motor",
   "tilt.inline": "Tilts inline with travel",
   "tilt_motor.label": "Tilt Motor",
@@ -138,6 +145,13 @@ const TRANSLATIONS = {
     "tilt.none": "Não suportado",
     "tilt.sequential_close": "Fecha e depois inclina fechadas",
     "tilt.sequential_open": "Fecha e depois inclina abertas",
+    "sequential_button_behavior.label": "Comportamento dos botões fechar/abrir",
+    "sequential_button_behavior.never": "Apenas deslocar",
+    "sequential_button_behavior.on_repeat": "Deslocar, depois inclinar num segundo clique",
+    "sequential_button_behavior.one_press": "Deslocar e inclinar num só clique",
+    "sequential_button_behavior.hint.never": "Fechar e abrir apenas controlam o deslocamento. Use os botões de inclinação para inclinar as lâminas.",
+    "sequential_button_behavior.hint.on_repeat": "Clique em fechar duas vezes: primeiro fecha o estore, depois inclina as lâminas. Clique em abrir duas vezes: primeiro devolve as lâminas à posição de repouso, depois abre o estore.",
+    "sequential_button_behavior.hint.one_press": "Um único clique em fechar realiza o deslocamento e a inclinação numa só movimentação contínua do motor.",
     "tilt.dual_motor": "Motor de inclinação separado",
     "tilt.inline": "Inclina durante o deslocamento",
     "tilt_motor.label": "Motor de Inclinação",
@@ -230,6 +244,13 @@ const TRANSLATIONS = {
     "tilt.none": "Nieobsługiwane",
     "tilt.sequential_close": "Najpierw zamyka, potem nachyla zamknięte",
     "tilt.sequential_open": "Najpierw zamyka, potem nachyla otwarte",
+    "sequential_button_behavior.label": "Zachowanie przycisków zamykania/otwierania",
+    "sequential_button_behavior.never": "Tylko ruch",
+    "sequential_button_behavior.on_repeat": "Ruch, nachylenie przy powtórnym kliknięciu",
+    "sequential_button_behavior.one_press": "Ruch i nachylenie w jednym kliknięciu",
+    "sequential_button_behavior.hint.never": "Zamykanie i otwieranie wpływa tylko na ruch. Do nachylania listew użyj osobnych przycisków.",
+    "sequential_button_behavior.hint.on_repeat": "Kliknij zamknij dwa razy: najpierw zamyka roletę, potem nachyla listwy. Kliknij otwórz dwa razy: najpierw przywraca listwy do pozycji spoczynkowej, potem otwiera roletę.",
+    "sequential_button_behavior.hint.one_press": "Jedno kliknięcie zamknij wykonuje ruch i nachylenie w jednym ciągłym ruchu silnika.",
     "tilt.dual_motor": "Osobny silnik nachylenia",
     "tilt.inline": "Nachylenie w trakcie ruchu",
     "tilt_motor.label": "Silnik nachylenia",
@@ -636,6 +657,8 @@ class CoverTimeBasedCard extends LitElement {
         tilt_open_switch: null,
         tilt_close_switch: null,
         tilt_stop_switch: null,
+        // Only meaningful for sequential_* modes
+        sequential_button_behavior: null,
       });
     } else {
       const updates = { tilt_mode: mode };
@@ -655,6 +678,8 @@ class CoverTimeBasedCard extends LitElement {
         if (this._config.max_tilt_allowed_position == null) {
           updates.max_tilt_allowed_position = 0;
         }
+        // Only meaningful for sequential_* modes
+        updates.sequential_button_behavior = null;
       } else if (mode === "inline") {
         // Clear dual-motor fields when switching to inline
         updates.safe_tilt_position = null;
@@ -662,6 +687,8 @@ class CoverTimeBasedCard extends LitElement {
         updates.tilt_open_switch = null;
         updates.tilt_close_switch = null;
         updates.tilt_stop_switch = null;
+        // Only meaningful for sequential_* modes
+        updates.sequential_button_behavior = null;
       }
       this._updateLocal(updates);
     }
@@ -1032,6 +1059,8 @@ class CoverTimeBasedCard extends LitElement {
       if (!(features & (16 | 32))) return "";
     }
     const tiltMode = c.tilt_mode || "none";
+    const isSequential = tiltMode === "sequential_close" || tiltMode === "sequential_open";
+    const buttonBehavior = c.sequential_button_behavior || "never";
 
     return html`
       <div class="section">
@@ -1054,7 +1083,30 @@ class CoverTimeBasedCard extends LitElement {
           </option>
         </select>
       </div>
+      ${isSequential ? html`
+        <div class="section">
+          <div class="field-label">${this._t("sequential_button_behavior.label")}</div>
+          <select class="ha-select" @change=${this._onSequentialButtonBehaviorChange}>
+            <option value="never" ?selected=${buttonBehavior === "never"}>
+              ${this._t("sequential_button_behavior.never")}
+            </option>
+            <option value="on_repeat" ?selected=${buttonBehavior === "on_repeat"}>
+              ${this._t("sequential_button_behavior.on_repeat")}
+            </option>
+            <option value="one_press" ?selected=${buttonBehavior === "one_press"}>
+              ${this._t("sequential_button_behavior.one_press")}
+            </option>
+          </select>
+          <div class="helper-text">
+            ${this._t(`sequential_button_behavior.hint.${buttonBehavior}`)}
+          </div>
+        </div>
+      ` : ""}
     `;
+  }
+
+  _onSequentialButtonBehaviorChange(e) {
+    this._updateLocal({ sequential_button_behavior: e.target.value });
   }
 
   _renderTiltMotorSection(c) {

--- a/custom_components/cover_time_based/frontend/cover-time-based-card.js
+++ b/custom_components/cover_time_based/frontend/cover-time-based-card.js
@@ -1306,15 +1306,31 @@ class CoverTimeBasedCard extends LitElement {
       disabledKeys.add("travel_time_close");
       disabledKeys.add("tilt_time_close");
     } else if (this._knownPosition === "closed_tilt_open") {
+      // tilt=100, cover closed. For sequential_close this is the "rest" state
+      // (slats at implicit-during-travel value), so travel_time_open and
+      // tilt_time_close are measurable. For sequential_open this is the
+      // "articulated" extreme (slats pushed open past cover-closed), so only
+      // tilt_time_close (restore slats to rest via motor up) is measurable.
       disabledKeys.add("travel_time_close");
       disabledKeys.add("tilt_time_open");
+      if (tiltMode === "sequential_open") {
+        disabledKeys.add("travel_time_open");
+        disabledKeys.add("travel_startup_delay");
+        disabledKeys.add("min_movement_time");
+      }
     } else if (this._knownPosition === "closed_tilt_closed") {
+      // tilt=0, cover closed. For sequential_close this is the "articulated"
+      // extreme — only tilt_time_open (restore slats) is measurable. For
+      // sequential_open this is the "rest" state (slats at implicit), so
+      // travel_time_open and tilt_time_open (articulate further down) are
+      // measurable.
       disabledKeys.add("travel_time_close");
       disabledKeys.add("tilt_time_close");
-      // Tilt must open before travel can move
-      disabledKeys.add("travel_time_open");
-      disabledKeys.add("travel_startup_delay");
-      disabledKeys.add("min_movement_time");
+      if (tiltMode !== "sequential_open") {
+        disabledKeys.add("travel_time_open");
+        disabledKeys.add("travel_startup_delay");
+        disabledKeys.add("min_movement_time");
+      }
     }
 
     // Startup delay requires the corresponding time to be calibrated first

--- a/custom_components/cover_time_based/tilt_strategies/__init__.py
+++ b/custom_components/cover_time_based/tilt_strategies/__init__.py
@@ -11,12 +11,14 @@ from .planning import (
     extract_coupled_tilt,
     extract_coupled_travel,
 )
-from .sequential import SequentialTilt
+from .sequential import SequentialCloseTilt, SequentialOpenTilt, SequentialTilt
 
 __all__ = [
     "DualMotorTilt",
     "InlineTilt",
     "MovementStep",
+    "SequentialCloseTilt",
+    "SequentialOpenTilt",
     "SequentialTilt",
     "TiltStrategy",
     "TiltTo",

--- a/custom_components/cover_time_based/tilt_strategies/base.py
+++ b/custom_components/cover_time_based/tilt_strategies/base.py
@@ -7,6 +7,8 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from homeassistant.const import SERVICE_CLOSE_COVER, SERVICE_OPEN_COVER
+
 if TYPE_CHECKING:
     from ..travel_calculator import TravelCalculator
 
@@ -75,6 +77,16 @@ class TiltStrategy(ABC):
     def allows_tilt_at_position(self, _position: int) -> bool:
         """Whether tilt is allowed at the given cover position."""
         return True
+
+    def tilt_command_for(self, closing_tilt: bool) -> str:
+        """Return the HA cover service to send for this tilt direction.
+
+        The default maps closing_tilt=True to close and closing_tilt=False
+        to open. Strategies with inverted physical direction (e.g.
+        SequentialOpenTilt, where slats open by motor driving further down)
+        override this.
+        """
+        return SERVICE_CLOSE_COVER if closing_tilt else SERVICE_OPEN_COVER
 
     @abstractmethod
     def snap_trackers_to_physical(

--- a/custom_components/cover_time_based/tilt_strategies/sequential.py
+++ b/custom_components/cover_time_based/tilt_strategies/sequential.py
@@ -42,7 +42,7 @@ class SequentialTilt(TiltStrategy):
 
     @property
     def name(self) -> str:
-        return "sequential"
+        return "sequential_close"
 
     @property
     def uses_tilt_motor(self) -> bool:

--- a/custom_components/cover_time_based/tilt_strategies/sequential.py
+++ b/custom_components/cover_time_based/tilt_strategies/sequential.py
@@ -1,8 +1,20 @@
-"""Sequential tilt strategy.
+"""Sequential tilt strategies.
 
 Tilt couples proportionally when travel moves, but travel does NOT
 couple when tilt moves. No boundary constraints are enforced.
 Tilt calibration is allowed.
+
+Two concrete variants share this logic:
+
+- SequentialCloseTilt (the conventional behavior):  slats physically
+  sit at tilt=100 (open) while the cover is not at the closed
+  position. Tilt-close from the closed position sends CLOSE (motor
+  down); tilt-open sends OPEN (motor up).
+- SequentialOpenTilt (Sese-Schneider/ha-cover-time-based#61):  slats
+  physically sit at tilt=0 (closed) while the cover is not at the
+  closed position. Tilt-open articulates the slats by driving the
+  motor further DOWN past the cover-closed position; tilt-close
+  sends OPEN (motor up).
 """
 
 from __future__ import annotations
@@ -15,15 +27,17 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class SequentialTilt(TiltStrategy):
-    """Sequential tilt mode.
+    """Sequential tilt base.
 
-    Tilt couples proportionally when travel moves, but travel does NOT
-    couple when tilt moves. No boundary constraints are enforced.
-    Tilt calibration is allowed.
+    Shared planning and snap logic for sequential modes. Subclasses
+    set ``implicit_tilt_during_travel`` — the tilt value physically
+    enforced whenever the cover is not at the closed position — and
+    optionally override ``tilt_command_for``.
     """
 
+    implicit_tilt_during_travel: int = 100
+
     def can_calibrate_tilt(self) -> bool:
-        """Tilt calibration is allowed in sequential mode."""
         return True
 
     @property
@@ -42,8 +56,8 @@ class SequentialTilt(TiltStrategy):
         self, target_pos: int, current_pos: int, current_tilt: int
     ) -> list[TiltTo | TravelTo]:
         steps: list[TiltTo | TravelTo] = []
-        if current_tilt != 100:
-            steps.append(TiltTo(100))  # flatten slats (fully open) before travel
+        if current_tilt != self.implicit_tilt_during_travel:
+            steps.append(TiltTo(self.implicit_tilt_during_travel))
         steps.append(TravelTo(target_pos))
         return steps
 
@@ -52,7 +66,7 @@ class SequentialTilt(TiltStrategy):
     ) -> list[TiltTo | TravelTo]:
         steps: list[TiltTo | TravelTo] = []
         if current_pos != 0:
-            steps.append(TravelTo(0))  # must be at closed position
+            steps.append(TravelTo(0))
         steps.append(TiltTo(target_tilt))
         return steps
 
@@ -61,10 +75,13 @@ class SequentialTilt(TiltStrategy):
         current_tilt_pos = tilt_calc.current_position()
         if current_travel is None or current_tilt_pos is None:
             return
-        if current_travel != 0 and current_tilt_pos != 100:
+        implicit = self.implicit_tilt_during_travel
+        if current_travel != 0 and current_tilt_pos != implicit:
             _LOGGER.debug(
-                "SequentialTilt :: Travel at %d%% (not closed), forcing tilt to 100%% (was %d%%)",
+                "%s :: Travel at %d%% (not closed), forcing tilt to %d%% (was %d%%)",
+                type(self).__name__,
                 current_travel,
+                implicit,
                 current_tilt_pos,
             )
-            tilt_calc.set_position(100)
+            tilt_calc.set_position(implicit)

--- a/custom_components/cover_time_based/tilt_strategies/sequential.py
+++ b/custom_components/cover_time_based/tilt_strategies/sequential.py
@@ -21,6 +21,8 @@ from __future__ import annotations
 
 import logging
 
+from homeassistant.const import SERVICE_CLOSE_COVER, SERVICE_OPEN_COVER
+
 from .base import TiltStrategy, TiltTo, TravelTo
 
 _LOGGER = logging.getLogger(__name__)
@@ -85,3 +87,36 @@ class SequentialTilt(TiltStrategy):
                 current_tilt_pos,
             )
             tilt_calc.set_position(implicit)
+
+
+class SequentialCloseTilt(SequentialTilt):
+    """Conventional sequential tilt.
+
+    Slats are physically at tilt=100 (open) while the cover is not at
+    the closed position. Tilt-close sends CLOSE (motor down);
+    tilt-open sends OPEN (motor up).
+
+    Inherits all behavior from SequentialTilt; exists as a distinct
+    type so callers can distinguish conventional and inverted sequential
+    variants via isinstance checks (see SequentialOpenTilt).
+    """
+
+
+class SequentialOpenTilt(SequentialTilt):
+    """Inverted sequential tilt (Sese-Schneider/ha-cover-time-based#61).
+
+    Slats are physically at tilt=0 (closed) while the cover is not at
+    the closed position. Tilt-open articulates the slats by driving
+    the motor further DOWN past the cover-closed position; tilt-close
+    sends OPEN (motor up to return from the open-slats position to
+    the slats-closed position).
+    """
+
+    implicit_tilt_during_travel: int = 0
+
+    @property
+    def name(self) -> str:
+        return "sequential_open"
+
+    def tilt_command_for(self, closing_tilt: bool) -> str:
+        return SERVICE_OPEN_COVER if closing_tilt else SERVICE_CLOSE_COVER

--- a/custom_components/cover_time_based/websocket_api.py
+++ b/custom_components/cover_time_based/websocket_api.py
@@ -38,9 +38,9 @@ from .cover import (
     CONTROL_MODE_WRAPPED,
     DEFAULT_ENDPOINT_RUNON_TIME,
     DEFAULT_PULSE_TIME,
+    DEFAULT_SEQUENTIAL_BUTTON_BEHAVIOR,
 )
-
-from .const import DOMAIN
+from .const import CONF_SEQUENTIAL_BUTTON_BEHAVIOR, DOMAIN
 from .helpers import resolve_entity_or_none
 
 _LOGGER = logging.getLogger(__name__)
@@ -67,6 +67,7 @@ _FIELD_MAP = {
     "tilt_open_switch": CONF_TILT_OPEN_SWITCH,
     "tilt_close_switch": CONF_TILT_CLOSE_SWITCH,
     "tilt_stop_switch": CONF_TILT_STOP_SWITCH,
+    "sequential_button_behavior": CONF_SEQUENTIAL_BUTTON_BEHAVIOR,
 }
 
 
@@ -141,6 +142,9 @@ async def ws_get_config(
             "tilt_open_switch": options.get(CONF_TILT_OPEN_SWITCH),
             "tilt_close_switch": options.get(CONF_TILT_CLOSE_SWITCH),
             "tilt_stop_switch": options.get(CONF_TILT_STOP_SWITCH),
+            "sequential_button_behavior": options.get(
+                CONF_SEQUENTIAL_BUTTON_BEHAVIOR, DEFAULT_SEQUENTIAL_BUTTON_BEHAVIOR
+            ),
         },
     )
 

--- a/custom_components/cover_time_based/websocket_api.py
+++ b/custom_components/cover_time_based/websocket_api.py
@@ -165,7 +165,14 @@ async def ws_get_config(
         vol.Optional("stop_switch_entity_id"): vol.Any(str, None),
         vol.Optional("cover_entity_id"): vol.Any(str, None),
         vol.Optional("tilt_mode"): vol.In(
-            ["none", "sequential", "dual_motor", "inline"]
+            [
+                "none",
+                "sequential_close",
+                "sequential_open",
+                "sequential",
+                "dual_motor",
+                "inline",
+            ]
         ),
         vol.Optional("travel_time_close"): vol.Any(
             None, vol.All(vol.Coerce(float), vol.Range(min=0.1, max=600))

--- a/custom_components/cover_time_based/websocket_api.py
+++ b/custom_components/cover_time_based/websocket_api.py
@@ -174,6 +174,9 @@ async def ws_get_config(
                 "inline",
             ]
         ),
+        vol.Optional("sequential_button_behavior"): vol.In(
+            ["never", "on_repeat", "one_press"]
+        ),
         vol.Optional("travel_time_close"): vol.Any(
             None, vol.All(vol.Coerce(float), vol.Range(min=0.1, max=600))
         ),

--- a/docs/superpowers/plans/2026-04-14-inverted-sequential-tilt.md
+++ b/docs/superpowers/plans/2026-04-14-inverted-sequential-tilt.md
@@ -1,0 +1,1465 @@
+# Inverted Sequential Tilt Mode Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `sequential_open` tilt mode for covers whose slats articulate by the motor driving *further down* past the cover-closed position, and rename the existing `sequential` mode to `sequential_close` for symmetry.
+
+**Architecture:** Introduce a `tilt_command_for(closing_tilt: bool) -> str` method on `TiltStrategy` that call sites consult to decide motor direction. `SequentialTilt` becomes a shared base holding planning/snap logic parameterised on `implicit_tilt_during_travel`. `SequentialCloseTilt` (100) and `SequentialOpenTilt` (0) are the two concrete subclasses; the latter also overrides `tilt_command_for` to invert the relay.
+
+**Tech Stack:** Python 3.13, pytest (asyncio_mode=auto), Home Assistant custom component.
+
+**Spec:** [docs/superpowers/specs/2026-04-14-inverted-sequential-tilt-design.md](../specs/2026-04-14-inverted-sequential-tilt-design.md)
+
+---
+
+## File Structure
+
+### Files to modify
+
+- `custom_components/cover_time_based/tilt_strategies/base.py` — add `tilt_command_for` default on `TiltStrategy`.
+- `custom_components/cover_time_based/tilt_strategies/sequential.py` — refactor `SequentialTilt` into shared base class; add `SequentialCloseTilt` and `SequentialOpenTilt` concrete subclasses parameterised on `implicit_tilt_during_travel`.
+- `custom_components/cover_time_based/tilt_strategies/__init__.py` — export the two new concrete classes.
+- `custom_components/cover_time_based/cover.py` — update `_resolve_tilt_strategy` to map `sequential_close`/`sequential_open` (with `sequential` as legacy alias).
+- `custom_components/cover_time_based/cover_base.py` — route `_async_move_tilt_to_endpoint`, `set_tilt_position`, `_start_tilt_restore` through `tilt_command_for`.
+- `custom_components/cover_time_based/cover_calibration.py` — route `_start_simple_time_test` tilt dispatch through `tilt_command_for`.
+- `custom_components/cover_time_based/config_flow.py` — bump `VERSION` 2 → 3.
+- `custom_components/cover_time_based/__init__.py` — add `async_migrate_entry`.
+- `custom_components/cover_time_based/frontend/cover-time-based-card.js` — update dropdown, `_onTiltModeChange`, and translations (en/pl/pt).
+- `README.md` — document the new mode.
+
+### Tests
+
+All under `tests/`:
+
+- `tests/test_tilt_strategy.py` — rename class references, add `SequentialOpenTilt` test class + `tilt_command_for` tests.
+- `tests/test_cover_factory.py` — update `_resolve_tilt_strategy` tests for new names, add alias test, add `sequential_open` test.
+- `tests/test_base_movement.py` or `tests/test_cover_base_extra.py` — integration tests for `_async_move_tilt_to_endpoint` and `set_tilt_position` direction with `SequentialOpenTilt`.
+- `tests/test_calibration.py` — tilt calibration direction test with `SequentialOpenTilt`.
+- `tests/integration/test_lifecycle.py` — config migration test (co-located with existing lifecycle tests that use `MockConfigEntry`).
+
+---
+
+## Task 1: Add `tilt_command_for` method to `TiltStrategy` base
+
+**Files:**
+- Modify: `custom_components/cover_time_based/tilt_strategies/base.py`
+- Test: `tests/test_tilt_strategy.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_tilt_strategy.py`:
+
+```python
+# ===================================================================
+# TiltStrategy.tilt_command_for (default implementation)
+# ===================================================================
+
+
+class TestTiltCommandForDefault:
+    """Default tilt_command_for maps closing_tilt to the standard direction."""
+
+    def test_closing_tilt_sends_close(self):
+        from homeassistant.const import SERVICE_CLOSE_COVER
+
+        strategy = InlineTilt()
+        assert strategy.tilt_command_for(closing_tilt=True) == SERVICE_CLOSE_COVER
+
+    def test_opening_tilt_sends_open(self):
+        from homeassistant.const import SERVICE_OPEN_COVER
+
+        strategy = InlineTilt()
+        assert strategy.tilt_command_for(closing_tilt=False) == SERVICE_OPEN_COVER
+
+    def test_default_applies_to_sequential(self):
+        from homeassistant.const import SERVICE_CLOSE_COVER, SERVICE_OPEN_COVER
+
+        strategy = SequentialTilt()
+        assert strategy.tilt_command_for(True) == SERVICE_CLOSE_COVER
+        assert strategy.tilt_command_for(False) == SERVICE_OPEN_COVER
+
+    def test_default_applies_to_dual_motor(self):
+        from homeassistant.const import SERVICE_CLOSE_COVER, SERVICE_OPEN_COVER
+
+        strategy = DualMotorTilt()
+        assert strategy.tilt_command_for(True) == SERVICE_CLOSE_COVER
+        assert strategy.tilt_command_for(False) == SERVICE_OPEN_COVER
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_tilt_strategy.py::TestTiltCommandForDefault -v`
+Expected: FAIL with `AttributeError: ... object has no attribute 'tilt_command_for'`
+
+- [ ] **Step 3: Add the method to `TiltStrategy` base**
+
+Edit `custom_components/cover_time_based/tilt_strategies/base.py`. Add the import at the top (after the existing imports), then add the method to `TiltStrategy`:
+
+```python
+from homeassistant.const import SERVICE_CLOSE_COVER, SERVICE_OPEN_COVER
+```
+
+Then inside `class TiltStrategy(ABC):`, after `allows_tilt_at_position` (just before `snap_trackers_to_physical`), add:
+
+```python
+    def tilt_command_for(self, closing_tilt: bool) -> str:
+        """Return the HA cover service to send for this tilt direction.
+
+        The default maps closing_tilt=True to close and closing_tilt=False
+        to open. Strategies with inverted physical direction (e.g.
+        SequentialOpenTilt, where slats open by motor driving further down)
+        override this.
+        """
+        return SERVICE_CLOSE_COVER if closing_tilt else SERVICE_OPEN_COVER
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_tilt_strategy.py::TestTiltCommandForDefault -v`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Run the full test file to ensure no regressions**
+
+Run: `pytest tests/test_tilt_strategy.py -v`
+Expected: All tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add custom_components/cover_time_based/tilt_strategies/base.py tests/test_tilt_strategy.py
+git commit -m "feat: add tilt_command_for method to TiltStrategy base"
+```
+
+---
+
+## Task 2: Parameterise `SequentialTilt` on `implicit_tilt_during_travel`
+
+Refactor `SequentialTilt` to read the "what tilt value is physically valid during travel" constant from `self.implicit_tilt_during_travel` instead of hard-coded `100`. No behavior change — `implicit_tilt_during_travel` defaults to `100`. Sets up Task 4 (subclass that overrides).
+
+**Files:**
+- Modify: `custom_components/cover_time_based/tilt_strategies/sequential.py`
+- Test: `tests/test_tilt_strategy.py` (existing tests must keep passing)
+
+- [ ] **Step 1: Write the passing test for the new property**
+
+Append to `tests/test_tilt_strategy.py` inside `class TestSequentialTiltProperties:` (around line 67):
+
+```python
+    def test_implicit_tilt_during_travel(self):
+        assert SequentialTilt().implicit_tilt_during_travel == 100
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_tilt_strategy.py::TestSequentialTiltProperties::test_implicit_tilt_during_travel -v`
+Expected: FAIL with `AttributeError: ... has no attribute 'implicit_tilt_during_travel'`
+
+- [ ] **Step 3: Refactor `SequentialTilt` to use the property**
+
+Replace the body of `custom_components/cover_time_based/tilt_strategies/sequential.py` with:
+
+```python
+"""Sequential tilt strategies.
+
+Tilt couples proportionally when travel moves, but travel does NOT
+couple when tilt moves. No boundary constraints are enforced.
+Tilt calibration is allowed.
+
+Two concrete variants share this logic:
+
+- SequentialCloseTilt (the conventional behavior):  slats physically
+  sit at tilt=100 (open) while the cover is not at the closed
+  position. Tilt-close from the closed position sends CLOSE (motor
+  down); tilt-open sends OPEN (motor up).
+- SequentialOpenTilt (Sese-Schneider/ha-cover-time-based#61):  slats
+  physically sit at tilt=0 (closed) while the cover is not at the
+  closed position. Tilt-open articulates the slats by driving the
+  motor further DOWN past the cover-closed position; tilt-close
+  sends OPEN (motor up).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.const import SERVICE_CLOSE_COVER, SERVICE_OPEN_COVER
+
+from .base import TiltStrategy, TiltTo, TravelTo
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class SequentialTilt(TiltStrategy):
+    """Sequential tilt base.
+
+    Shared planning and snap logic for sequential modes. Subclasses
+    set ``implicit_tilt_during_travel`` — the tilt value physically
+    enforced whenever the cover is not at the closed position — and
+    optionally override ``tilt_command_for``.
+    """
+
+    implicit_tilt_during_travel: int = 100
+
+    def can_calibrate_tilt(self) -> bool:
+        return True
+
+    @property
+    def name(self) -> str:
+        return "sequential"
+
+    @property
+    def uses_tilt_motor(self) -> bool:
+        return False
+
+    @property
+    def restores_tilt(self) -> bool:
+        return False
+
+    def plan_move_position(
+        self, target_pos: int, current_pos: int, current_tilt: int
+    ) -> list[TiltTo | TravelTo]:
+        steps: list[TiltTo | TravelTo] = []
+        if current_tilt != self.implicit_tilt_during_travel:
+            steps.append(TiltTo(self.implicit_tilt_during_travel))
+        steps.append(TravelTo(target_pos))
+        return steps
+
+    def plan_move_tilt(
+        self, target_tilt: int, current_pos: int, current_tilt: int
+    ) -> list[TiltTo | TravelTo]:
+        steps: list[TiltTo | TravelTo] = []
+        if current_pos != 0:
+            steps.append(TravelTo(0))
+        steps.append(TiltTo(target_tilt))
+        return steps
+
+    def snap_trackers_to_physical(self, travel_calc, tilt_calc):
+        current_travel = travel_calc.current_position()
+        current_tilt_pos = tilt_calc.current_position()
+        if current_travel is None or current_tilt_pos is None:
+            return
+        implicit = self.implicit_tilt_during_travel
+        if current_travel != 0 and current_tilt_pos != implicit:
+            _LOGGER.debug(
+                "%s :: Travel at %d%% (not closed), forcing tilt to %d%% (was %d%%)",
+                type(self).__name__,
+                current_travel,
+                implicit,
+                current_tilt_pos,
+            )
+            tilt_calc.set_position(implicit)
+```
+
+Note: the new file does NOT yet define `SequentialCloseTilt` or `SequentialOpenTilt` — those come in Tasks 3 and 4. The `SERVICE_*` imports are unused for now; they will be consumed when `SequentialOpenTilt` lands in Task 4.
+
+- [ ] **Step 4: Run the full tilt_strategy test file**
+
+Run: `pytest tests/test_tilt_strategy.py -v`
+Expected: All existing tests pass (the refactor preserves behavior) AND the new `test_implicit_tilt_during_travel` passes.
+
+- [ ] **Step 5: Run the full test suite to catch regressions**
+
+Run: `pytest tests/ -x -q`
+Expected: All tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add custom_components/cover_time_based/tilt_strategies/sequential.py tests/test_tilt_strategy.py
+git commit -m "refactor: parameterise SequentialTilt on implicit_tilt_during_travel"
+```
+
+---
+
+## Task 3: Rename internal mode `sequential` → `sequential_close` with legacy alias
+
+Rename the `SequentialTilt.name` return value to `"sequential_close"` and update `_resolve_tilt_strategy` to accept both `"sequential_close"` and the legacy `"sequential"`. This does *not* introduce new class names yet — that's Task 4. The existing `SequentialTilt` class keeps its name (we'll split it into concrete variants in Task 4).
+
+**Files:**
+- Modify: `custom_components/cover_time_based/tilt_strategies/sequential.py`
+- Modify: `custom_components/cover_time_based/cover.py`
+- Test: `tests/test_tilt_strategy.py`
+- Test: `tests/test_cover_factory.py`
+
+- [ ] **Step 1: Update name assertion test**
+
+In `tests/test_tilt_strategy.py`, change the existing `test_name` assertion inside `TestSequentialTiltProperties`:
+
+```python
+    def test_name(self):
+        assert SequentialTilt().name == "sequential_close"
+```
+
+- [ ] **Step 2: Add resolver alias tests**
+
+In `tests/test_cover_factory.py`, replace the existing `test_sequential` and `test_unknown_mode_defaults_to_sequential` tests (around lines 436-469) with:
+
+```python
+    def test_sequential_close(self):
+        result = _resolve_tilt_strategy("sequential_close", 2.0, 2.0)
+        assert isinstance(result, SequentialTilt)
+        assert result.name == "sequential_close"
+
+    def test_sequential_legacy_alias(self):
+        """Legacy 'sequential' value still resolves (covers unmigrated configs)."""
+        result = _resolve_tilt_strategy("sequential", 2.0, 2.0)
+        assert isinstance(result, SequentialTilt)
+
+    def test_unknown_mode_defaults_to_sequential(self):
+        result = _resolve_tilt_strategy("unknown_value", 2.0, 2.0)
+        assert isinstance(result, SequentialTilt)
+```
+
+Also update the two `_resolve_tilt_strategy("sequential", None, ...)` tests above to use `"sequential_close"` to reflect the new canonical name:
+
+```python
+    def test_none_when_no_tilt_times(self):
+        assert _resolve_tilt_strategy("sequential_close", None, None) is None
+
+    def test_none_when_partial_tilt_times(self):
+        assert _resolve_tilt_strategy("sequential_close", 2.0, None) is None
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `pytest tests/test_tilt_strategy.py::TestSequentialTiltProperties::test_name tests/test_cover_factory.py::TestResolveTiltStrategy -v`
+Expected: FAIL — `test_name` asserts "sequential_close" but class returns "sequential"; `test_sequential_close` not yet supported by resolver.
+
+- [ ] **Step 4: Update `SequentialTilt.name`**
+
+In `custom_components/cover_time_based/tilt_strategies/sequential.py`, change:
+
+```python
+    @property
+    def name(self) -> str:
+        return "sequential"
+```
+
+to:
+
+```python
+    @property
+    def name(self) -> str:
+        return "sequential_close"
+```
+
+- [ ] **Step 5: Update `_resolve_tilt_strategy`**
+
+In `custom_components/cover_time_based/cover.py`, replace the block at lines 247-266 with:
+
+```python
+def _resolve_tilt_strategy(tilt_mode_str, tilt_time_close, tilt_time_open, **kwargs):
+    """Map tilt_mode config string to a TiltStrategy instance (or None)."""
+    from .tilt_strategies import DualMotorTilt, InlineTilt, SequentialTilt
+
+    if tilt_mode_str == "none":
+        return None
+
+    has_tilt_times = tilt_time_close is not None and tilt_time_open is not None
+    if not has_tilt_times:
+        return None
+
+    if tilt_mode_str == "dual_motor":
+        return DualMotorTilt(
+            safe_tilt_position=kwargs.get("safe_tilt_position", 100),
+            max_tilt_allowed_position=kwargs.get("max_tilt_allowed_position"),
+        )
+    if tilt_mode_str == "inline":
+        return InlineTilt()
+    # "sequential_close", legacy "sequential", or any other value with tilt times
+    return SequentialTilt()
+```
+
+No functional change yet — `SequentialTilt()` still constructs the same concrete class. Task 4 replaces this with the concrete subclasses.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `pytest tests/test_tilt_strategy.py tests/test_cover_factory.py -v`
+Expected: All tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add custom_components/cover_time_based/tilt_strategies/sequential.py custom_components/cover_time_based/cover.py tests/test_tilt_strategy.py tests/test_cover_factory.py
+git commit -m "refactor: rename sequential tilt mode to sequential_close"
+```
+
+---
+
+## Task 4: Split `SequentialTilt` into `SequentialCloseTilt` + `SequentialOpenTilt`
+
+Introduce two concrete subclasses of `SequentialTilt`. `SequentialCloseTilt` is the existing behavior; `SequentialOpenTilt` inverts both `implicit_tilt_during_travel` and `tilt_command_for`. Make `SequentialTilt` abstract enough that only subclasses are instantiated (we keep it importable as the shared base for `isinstance` checks and inheritance).
+
+**Files:**
+- Modify: `custom_components/cover_time_based/tilt_strategies/sequential.py`
+- Modify: `custom_components/cover_time_based/tilt_strategies/__init__.py`
+- Test: `tests/test_tilt_strategy.py`
+
+- [ ] **Step 1: Write failing tests for the new subclasses**
+
+Append to `tests/test_tilt_strategy.py`, replacing the import line and adding new test classes:
+
+First, update the existing import (around line 5):
+
+```python
+from custom_components.cover_time_based.tilt_strategies import (
+    DualMotorTilt,
+    InlineTilt,
+    SequentialCloseTilt,
+    SequentialOpenTilt,
+    SequentialTilt,
+    TiltTo,
+    TravelTo,
+)
+```
+
+Then append these new test classes at the end of the file:
+
+```python
+# ===================================================================
+# SequentialCloseTilt (concrete, conventional direction)
+# ===================================================================
+
+
+class TestSequentialCloseTilt:
+    def test_name(self):
+        assert SequentialCloseTilt().name == "sequential_close"
+
+    def test_is_sequential_tilt(self):
+        assert isinstance(SequentialCloseTilt(), SequentialTilt)
+
+    def test_implicit_tilt_during_travel(self):
+        assert SequentialCloseTilt().implicit_tilt_during_travel == 100
+
+    def test_tilt_command_for_closing(self):
+        from homeassistant.const import SERVICE_CLOSE_COVER
+
+        assert SequentialCloseTilt().tilt_command_for(True) == SERVICE_CLOSE_COVER
+
+    def test_tilt_command_for_opening(self):
+        from homeassistant.const import SERVICE_OPEN_COVER
+
+        assert SequentialCloseTilt().tilt_command_for(False) == SERVICE_OPEN_COVER
+
+
+# ===================================================================
+# SequentialOpenTilt (concrete, inverted direction)
+# ===================================================================
+
+
+class TestSequentialOpenTilt:
+    def test_name(self):
+        assert SequentialOpenTilt().name == "sequential_open"
+
+    def test_is_sequential_tilt(self):
+        assert isinstance(SequentialOpenTilt(), SequentialTilt)
+
+    def test_implicit_tilt_during_travel(self):
+        assert SequentialOpenTilt().implicit_tilt_during_travel == 0
+
+    def test_uses_tilt_motor(self):
+        assert SequentialOpenTilt().uses_tilt_motor is False
+
+    def test_restores_tilt(self):
+        assert SequentialOpenTilt().restores_tilt is False
+
+    def test_can_calibrate_tilt(self):
+        assert SequentialOpenTilt().can_calibrate_tilt() is True
+
+    def test_tilt_command_for_closing_returns_open(self):
+        """Inverted: closing_tilt=True sends OPEN (motor up)."""
+        from homeassistant.const import SERVICE_OPEN_COVER
+
+        assert SequentialOpenTilt().tilt_command_for(True) == SERVICE_OPEN_COVER
+
+    def test_tilt_command_for_opening_returns_close(self):
+        """Inverted: closing_tilt=False sends CLOSE (motor further down)."""
+        from homeassistant.const import SERVICE_CLOSE_COVER
+
+        assert SequentialOpenTilt().tilt_command_for(False) == SERVICE_CLOSE_COVER
+
+
+class TestSequentialOpenPlanMovePosition:
+    def test_flattens_tilt_to_zero_before_travel(self):
+        strategy = SequentialOpenTilt()
+        steps = strategy.plan_move_position(
+            target_pos=70, current_pos=0, current_tilt=80
+        )
+        assert steps == [TiltTo(0), TravelTo(70)]
+
+    def test_skips_tilt_when_already_zero(self):
+        strategy = SequentialOpenTilt()
+        steps = strategy.plan_move_position(
+            target_pos=70, current_pos=0, current_tilt=0
+        )
+        assert steps == [TravelTo(70)]
+
+
+class TestSequentialOpenPlanMoveTilt:
+    def test_travels_to_closed_before_tilting(self):
+        strategy = SequentialOpenTilt()
+        steps = strategy.plan_move_tilt(
+            target_tilt=50, current_pos=70, current_tilt=0
+        )
+        assert steps == [TravelTo(0), TiltTo(50)]
+
+    def test_tilts_directly_when_at_closed(self):
+        strategy = SequentialOpenTilt()
+        steps = strategy.plan_move_tilt(target_tilt=100, current_pos=0, current_tilt=0)
+        assert steps == [TiltTo(100)]
+
+
+class TestSequentialOpenSnapTrackers:
+    def test_forces_tilt_to_zero_when_not_at_closed(self):
+        strategy = SequentialOpenTilt()
+        travel = TravelCalculator(10.0, 10.0)
+        tilt = TravelCalculator(2.0, 2.0)
+        travel.set_position(50)
+        tilt.set_position(80)
+        strategy.snap_trackers_to_physical(travel, tilt)
+        assert tilt.current_position() == 0
+
+    def test_no_op_when_at_closed(self):
+        strategy = SequentialOpenTilt()
+        travel = TravelCalculator(10.0, 10.0)
+        tilt = TravelCalculator(2.0, 2.0)
+        travel.set_position(0)
+        tilt.set_position(50)
+        strategy.snap_trackers_to_physical(travel, tilt)
+        assert tilt.current_position() == 50
+
+    def test_no_op_when_already_zero(self):
+        strategy = SequentialOpenTilt()
+        travel = TravelCalculator(10.0, 10.0)
+        tilt = TravelCalculator(2.0, 2.0)
+        travel.set_position(30)
+        tilt.set_position(0)
+        strategy.snap_trackers_to_physical(travel, tilt)
+        assert tilt.current_position() == 0
+```
+
+Also, update the existing `TestSequentialTiltProperties` class — rename it to `TestSequentialCloseTiltViaBase` to clarify it exercises the conventional variant, and update all the existing test classes `TestSequentialTilt*` that call `SequentialTilt()` directly to call `SequentialCloseTilt()` instead. These are the classes at lines 56-194:
+
+- `TestSequentialTiltCanCalibrate` — `SequentialTilt()` → `SequentialCloseTilt()`
+- `TestSequentialTiltProperties` — `SequentialTilt()` → `SequentialCloseTilt()`
+- `TestSequentialPlanMovePosition` — `SequentialTilt()` → `SequentialCloseTilt()` (5 occurrences)
+- `TestSequentialPlanMoveTilt` — `SequentialTilt()` → `SequentialCloseTilt()` (4 occurrences)
+- `TestSequentialSnapTrackers` — `SequentialTilt()` → `SequentialCloseTilt()` (6 occurrences)
+
+Plus `TestTiltCommandForDefault.test_default_applies_to_sequential` — `SequentialTilt()` → `SequentialCloseTilt()`.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_tilt_strategy.py -v 2>&1 | tail -40`
+Expected: Import error — `SequentialCloseTilt` and `SequentialOpenTilt` are not exported yet.
+
+- [ ] **Step 3: Add the subclasses**
+
+Append to `custom_components/cover_time_based/tilt_strategies/sequential.py`:
+
+```python
+class SequentialCloseTilt(SequentialTilt):
+    """Conventional sequential tilt.
+
+    Slats are physically at tilt=100 (open) while the cover is not at
+    the closed position. Tilt-close sends CLOSE (motor down);
+    tilt-open sends OPEN (motor up).
+    """
+
+    implicit_tilt_during_travel: int = 100
+
+    @property
+    def name(self) -> str:
+        return "sequential_close"
+
+
+class SequentialOpenTilt(SequentialTilt):
+    """Inverted sequential tilt (Sese-Schneider/ha-cover-time-based#61).
+
+    Slats are physically at tilt=0 (closed) while the cover is not at
+    the closed position. Tilt-open articulates the slats by driving
+    the motor further DOWN past the cover-closed position; tilt-close
+    sends OPEN (motor up to return from the open-slats position to
+    the slats-closed position).
+    """
+
+    implicit_tilt_during_travel: int = 0
+
+    @property
+    def name(self) -> str:
+        return "sequential_open"
+
+    def tilt_command_for(self, closing_tilt: bool) -> str:
+        return SERVICE_OPEN_COVER if closing_tilt else SERVICE_CLOSE_COVER
+```
+
+- [ ] **Step 4: Export the new classes**
+
+Edit `custom_components/cover_time_based/tilt_strategies/__init__.py`:
+
+```python
+"""Tilt strategy classes for cover_time_based.
+
+Tilt strategies determine how travel and tilt movements are coupled.
+"""
+
+from .base import MovementStep, TiltStrategy, TiltTo, TravelTo
+from .dual_motor import DualMotorTilt
+from .inline import InlineTilt
+from .planning import (
+    calculate_pre_step_delay,
+    extract_coupled_tilt,
+    extract_coupled_travel,
+)
+from .sequential import SequentialCloseTilt, SequentialOpenTilt, SequentialTilt
+
+__all__ = [
+    "DualMotorTilt",
+    "InlineTilt",
+    "MovementStep",
+    "SequentialCloseTilt",
+    "SequentialOpenTilt",
+    "SequentialTilt",
+    "TiltStrategy",
+    "TiltTo",
+    "TravelTo",
+    "calculate_pre_step_delay",
+    "extract_coupled_tilt",
+    "extract_coupled_travel",
+]
+```
+
+- [ ] **Step 5: Run tilt_strategy tests**
+
+Run: `pytest tests/test_tilt_strategy.py -v`
+Expected: All tests pass (old ones renamed, new `TestSequentialCloseTilt`, `TestSequentialOpenTilt`, `TestSequentialOpenPlanMovePosition`, `TestSequentialOpenPlanMoveTilt`, `TestSequentialOpenSnapTrackers` pass).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add custom_components/cover_time_based/tilt_strategies/sequential.py custom_components/cover_time_based/tilt_strategies/__init__.py tests/test_tilt_strategy.py
+git commit -m "feat: add SequentialCloseTilt and SequentialOpenTilt variants"
+```
+
+---
+
+## Task 5: Wire `sequential_close` and `sequential_open` through `_resolve_tilt_strategy`
+
+Update the resolver to instantiate the correct concrete subclass per mode string, keeping `"sequential"` as a legacy alias.
+
+**Files:**
+- Modify: `custom_components/cover_time_based/cover.py`
+- Test: `tests/test_cover_factory.py`
+
+- [ ] **Step 1: Write failing tests**
+
+In `tests/test_cover_factory.py`, update the import (around line 41):
+
+```python
+from custom_components.cover_time_based.tilt_strategies import (
+    DualMotorTilt,
+    InlineTilt,
+    SequentialCloseTilt,
+    SequentialOpenTilt,
+    SequentialTilt,
+)
+```
+
+Then update the resolver tests (the ones you added in Task 3):
+
+```python
+    def test_sequential_close(self):
+        result = _resolve_tilt_strategy("sequential_close", 2.0, 2.0)
+        assert isinstance(result, SequentialCloseTilt)
+        assert result.name == "sequential_close"
+
+    def test_sequential_open(self):
+        result = _resolve_tilt_strategy("sequential_open", 2.0, 2.0)
+        assert isinstance(result, SequentialOpenTilt)
+        assert result.name == "sequential_open"
+
+    def test_sequential_legacy_alias(self):
+        """Legacy 'sequential' value resolves to SequentialCloseTilt."""
+        result = _resolve_tilt_strategy("sequential", 2.0, 2.0)
+        assert isinstance(result, SequentialCloseTilt)
+
+    def test_unknown_mode_defaults_to_sequential_close(self):
+        result = _resolve_tilt_strategy("unknown_value", 2.0, 2.0)
+        assert isinstance(result, SequentialCloseTilt)
+```
+
+(Delete the old `test_unknown_mode_defaults_to_sequential`, replaced by `test_unknown_mode_defaults_to_sequential_close`.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_cover_factory.py::TestResolveTiltStrategy -v`
+Expected: FAIL — `sequential_close` currently returns base `SequentialTilt`, not `SequentialCloseTilt`; `sequential_open` not handled.
+
+- [ ] **Step 3: Update `_resolve_tilt_strategy`**
+
+In `custom_components/cover_time_based/cover.py`, replace the `_resolve_tilt_strategy` function (lines 247-266) with:
+
+```python
+def _resolve_tilt_strategy(tilt_mode_str, tilt_time_close, tilt_time_open, **kwargs):
+    """Map tilt_mode config string to a TiltStrategy instance (or None)."""
+    from .tilt_strategies import (
+        DualMotorTilt,
+        InlineTilt,
+        SequentialCloseTilt,
+        SequentialOpenTilt,
+    )
+
+    if tilt_mode_str == "none":
+        return None
+
+    has_tilt_times = tilt_time_close is not None and tilt_time_open is not None
+    if not has_tilt_times:
+        return None
+
+    if tilt_mode_str == "dual_motor":
+        return DualMotorTilt(
+            safe_tilt_position=kwargs.get("safe_tilt_position", 100),
+            max_tilt_allowed_position=kwargs.get("max_tilt_allowed_position"),
+        )
+    if tilt_mode_str == "inline":
+        return InlineTilt()
+    if tilt_mode_str == "sequential_open":
+        return SequentialOpenTilt()
+    # "sequential_close", legacy "sequential", or any unknown value → close variant
+    return SequentialCloseTilt()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_cover_factory.py::TestResolveTiltStrategy -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full test suite**
+
+Run: `pytest tests/ -x -q`
+Expected: All tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add custom_components/cover_time_based/cover.py tests/test_cover_factory.py
+git commit -m "feat: resolve sequential_close and sequential_open tilt modes"
+```
+
+---
+
+## Task 6: Route `_async_move_tilt_to_endpoint` through `tilt_command_for`
+
+Update the single-motor command path in `_async_move_tilt_to_endpoint` to consult the strategy for motor direction. This makes `SequentialOpenTilt` actually send inverted commands when tilt endpoints are requested.
+
+**Files:**
+- Modify: `custom_components/cover_time_based/cover_base.py`
+- Test: `tests/test_base_movement.py` or `tests/test_cover_base_extra.py`
+
+- [ ] **Step 1: Find an existing integration test pattern**
+
+Run: `grep -n "async_move_tilt_to_endpoint\|async_open_cover_tilt\|async_close_cover_tilt" tests/test_base_movement.py | head -20`
+
+This shows which file has integration tests for tilt movement. Look at the most recent 2-3 tests to identify the fixture pattern (`switch_cover` or similar).
+
+- [ ] **Step 2: Write a failing integration test**
+
+Append to `tests/test_base_movement.py` (or the file surfaced in Step 1). Replace the fixture construction pattern with whatever that file uses — the test asserts that calling `async_close_cover_tilt()` on a cover with `SequentialOpenTilt` sends `SERVICE_OPEN_COVER` (inverted):
+
+```python
+async def test_sequential_open_tilt_close_sends_open_command(hass):
+    """SequentialOpenTilt: closing the tilt physically sends OPEN (motor up)."""
+    from homeassistant.const import SERVICE_OPEN_COVER
+    from custom_components.cover_time_based.tilt_strategies import SequentialOpenTilt
+
+    cover = make_switch_cover(
+        hass,
+        tilt_strategy=SequentialOpenTilt(),
+        travel_time_open=10.0,
+        travel_time_close=10.0,
+        tilt_time_open=2.0,
+        tilt_time_close=2.0,
+    )
+    # Position: cover at 0 (closed), slats at tilt=100 (fully open, bottom)
+    cover.travel_calc.set_position(0)
+    cover.tilt_calc.set_position(100)
+
+    hass.services.async_call = AsyncMock()
+    await cover.async_close_cover_tilt()
+
+    # Find the relay service call that was made. For switch-mode, closing the
+    # tilt from tilt=100 to tilt=0 should send OPEN (motor up) with the
+    # inverted strategy.
+    calls = [c for c in hass.services.async_call.mock_calls if c.args[:2] == ("homeassistant", "turn_on")]
+    activated_entities = [c.args[2]["entity_id"] for c in calls]
+    # The OPEN switch (travel-up relay) should have been turned on.
+    assert cover._open_switch_entity_id in activated_entities
+    assert cover._close_switch_entity_id not in activated_entities
+```
+
+If `make_switch_cover` does not exist, copy the inline construction used by neighboring tests in the same file (it typically builds a `SwitchModeCover` directly with MagicMock entities). The key assertion is that `hass.services.async_call` is invoked with `turn_on` on the OPEN relay, not the CLOSE relay.
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `pytest tests/test_base_movement.py::test_sequential_open_tilt_close_sends_open_command -v`
+Expected: FAIL — the cover sends CLOSE because direction is still hard-coded.
+
+- [ ] **Step 4: Update `_async_move_tilt_to_endpoint`**
+
+In `custom_components/cover_time_based/cover_base.py`, replace lines 510-512 (the `command`/`opposite_command` derivation):
+
+```python
+        closing = target == 0
+        command = SERVICE_CLOSE_COVER if closing else SERVICE_OPEN_COVER
+        opposite_command = SERVICE_OPEN_COVER if closing else SERVICE_CLOSE_COVER
+```
+
+with:
+
+```python
+        closing = target == 0
+        if self._tilt_strategy is not None:
+            command = self._tilt_strategy.tilt_command_for(closing)
+            opposite_command = self._tilt_strategy.tilt_command_for(not closing)
+        else:
+            command = SERVICE_CLOSE_COVER if closing else SERVICE_OPEN_COVER
+            opposite_command = SERVICE_OPEN_COVER if closing else SERVICE_CLOSE_COVER
+```
+
+Do NOT change lines 583-587 (the `uses_tilt_motor` / dual-motor branch calling `_send_tilt_close` / `_send_tilt_open`). Dual-motor drives dedicated tilt switches — inversion does not apply.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pytest tests/test_base_movement.py::test_sequential_open_tilt_close_sends_open_command -v`
+Expected: PASS.
+
+- [ ] **Step 6: Run the full test suite**
+
+Run: `pytest tests/ -x -q`
+Expected: All tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add custom_components/cover_time_based/cover_base.py tests/test_base_movement.py
+git commit -m "feat: route _async_move_tilt_to_endpoint through tilt_command_for"
+```
+
+---
+
+## Task 7: Route `set_tilt_position` through `tilt_command_for`
+
+`set_tilt_position` handles arbitrary tilt targets (not just endpoints). Its command choice sits at lines 687-695 of `cover_base.py`. Route the three branches through `tilt_command_for`.
+
+**Files:**
+- Modify: `custom_components/cover_time_based/cover_base.py`
+- Test: same test file as Task 6
+
+- [ ] **Step 1: Write a failing test**
+
+Append to the test file used in Task 6:
+
+```python
+async def test_sequential_open_set_tilt_position_sends_close(hass):
+    """SequentialOpenTilt: moving tilt from 0→50 sends CLOSE (motor further down)."""
+    from custom_components.cover_time_based.tilt_strategies import SequentialOpenTilt
+
+    cover = make_switch_cover(
+        hass,
+        tilt_strategy=SequentialOpenTilt(),
+        travel_time_open=10.0,
+        travel_time_close=10.0,
+        tilt_time_open=2.0,
+        tilt_time_close=2.0,
+    )
+    cover.travel_calc.set_position(0)
+    cover.tilt_calc.set_position(0)
+
+    hass.services.async_call = AsyncMock()
+    await cover.set_tilt_position(50)
+
+    calls = [c for c in hass.services.async_call.mock_calls if c.args[:2] == ("homeassistant", "turn_on")]
+    activated_entities = [c.args[2]["entity_id"] for c in calls]
+    # Opening the tilt (target 50 > current 0) should drive the close relay (motor down).
+    assert cover._close_switch_entity_id in activated_entities
+    assert cover._open_switch_entity_id not in activated_entities
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_base_movement.py::test_sequential_open_set_tilt_position_sends_close -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Update `set_tilt_position`**
+
+In `custom_components/cover_time_based/cover_base.py`, replace lines 687-695 with:
+
+```python
+        if current is None:
+            closing = target <= 50
+            current = 100 if closing else 0
+            self.tilt_calc.update_position(current)
+        elif target < current:
+            closing = True
+        elif target > current:
+            closing = False
+        else:
+            return
+
+        if self._tilt_strategy is not None:
+            command = self._tilt_strategy.tilt_command_for(closing)
+        else:
+            command = SERVICE_CLOSE_COVER if closing else SERVICE_OPEN_COVER
+```
+
+Then remove the now-redundant `closing = command == SERVICE_CLOSE_COVER` assignment on the line immediately below (currently line 699) — `closing` is already bound.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_base_movement.py::test_sequential_open_set_tilt_position_sends_close -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full test suite**
+
+Run: `pytest tests/ -x -q`
+Expected: All tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add custom_components/cover_time_based/cover_base.py tests/test_base_movement.py
+git commit -m "feat: route set_tilt_position through tilt_command_for"
+```
+
+---
+
+## Task 8: Route `_start_tilt_restore` through `tilt_command_for`
+
+Only `InlineTilt` currently has `restores_tilt=True`, so this path is dead for sequential modes today. We route it through `tilt_command_for` for symmetry and to future-proof. No behavior change for inline (its default `tilt_command_for` returns the conventional mapping).
+
+**Files:**
+- Modify: `custom_components/cover_time_based/cover_base.py`
+
+- [ ] **Step 1: Run the existing inline tilt tests as a regression baseline**
+
+Run: `pytest tests/ -k "tilt_restore or inline" -v`
+Note which tests pass. After the change, they must still pass.
+
+- [ ] **Step 2: Update `_start_tilt_restore`**
+
+In `custom_components/cover_time_based/cover_base.py`, the shared-motor branch currently reads (lines 1370-1373):
+
+```python
+        else:
+            # Shared motor (inline): reverse main motor direction
+            command = SERVICE_CLOSE_COVER if closing else SERVICE_OPEN_COVER
+            await self._async_handle_command(command)
+```
+
+Change to:
+
+```python
+        else:
+            # Shared motor (inline or sequential): consult the strategy for direction.
+            command = self._tilt_strategy.tilt_command_for(closing)
+            await self._async_handle_command(command)
+```
+
+- [ ] **Step 3: Run regression tests**
+
+Run: `pytest tests/ -k "tilt_restore or inline" -v`
+Expected: Same tests pass as in Step 1.
+
+- [ ] **Step 4: Run the full test suite**
+
+Run: `pytest tests/ -x -q`
+Expected: All tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add custom_components/cover_time_based/cover_base.py
+git commit -m "refactor: route _start_tilt_restore through tilt_command_for"
+```
+
+---
+
+## Task 9: Route `_start_simple_time_test` for tilt attributes through `tilt_command_for`
+
+The calibration dispatcher currently derives direction from the attribute name (`"close" in attribute → SERVICE_CLOSE_COVER`). For `SequentialOpenTilt`, `tilt_time_open` calibration must send CLOSE (motor down) and `tilt_time_close` must send OPEN.
+
+**Files:**
+- Modify: `custom_components/cover_time_based/cover_calibration.py`
+- Test: `tests/test_calibration.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Look at existing patterns in `tests/test_calibration.py` for how tilt calibration is invoked (search for `tilt_time_open` or `start_calibration`). Mirror that pattern to assert that, with `SequentialOpenTilt`:
+
+```python
+async def test_sequential_open_tilt_time_open_sends_close(hass):
+    """With SequentialOpenTilt, calibrating tilt_time_open moves motor DOWN."""
+    from homeassistant.const import SERVICE_CLOSE_COVER
+    from custom_components.cover_time_based.tilt_strategies import SequentialOpenTilt
+
+    cover = make_switch_cover(
+        hass,
+        tilt_strategy=SequentialOpenTilt(),
+        travel_time_open=10.0,
+        travel_time_close=10.0,
+        tilt_time_open=2.0,
+        tilt_time_close=2.0,
+    )
+    cover.travel_calc.set_position(0)
+    cover.tilt_calc.set_position(0)
+
+    hass.services.async_call = AsyncMock()
+    await cover.start_calibration(attribute="tilt_time_open", timeout=60)
+
+    # The close relay should fire (motor down to articulate slats open).
+    calls = [c for c in hass.services.async_call.mock_calls if c.args[:2] == ("homeassistant", "turn_on")]
+    activated = [c.args[2]["entity_id"] for c in calls]
+    assert cover._close_switch_entity_id in activated
+    assert cover._open_switch_entity_id not in activated
+
+    # Cleanup — cancel the running calibration.
+    await cover.stop_calibration(cancel=True)
+
+
+async def test_sequential_open_tilt_time_close_sends_open(hass):
+    """With SequentialOpenTilt, calibrating tilt_time_close moves motor UP."""
+    from custom_components.cover_time_based.tilt_strategies import SequentialOpenTilt
+
+    cover = make_switch_cover(
+        hass,
+        tilt_strategy=SequentialOpenTilt(),
+        travel_time_open=10.0,
+        travel_time_close=10.0,
+        tilt_time_open=2.0,
+        tilt_time_close=2.0,
+    )
+    cover.travel_calc.set_position(0)
+    cover.tilt_calc.set_position(100)
+
+    hass.services.async_call = AsyncMock()
+    await cover.start_calibration(attribute="tilt_time_close", timeout=60)
+
+    calls = [c for c in hass.services.async_call.mock_calls if c.args[:2] == ("homeassistant", "turn_on")]
+    activated = [c.args[2]["entity_id"] for c in calls]
+    assert cover._open_switch_entity_id in activated
+    assert cover._close_switch_entity_id not in activated
+
+    await cover.stop_calibration(cancel=True)
+```
+
+Reuse the cover-factory helper (`make_switch_cover` or inline construction) from the file's existing tests.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_calibration.py -k "sequential_open" -v`
+Expected: FAIL — current dispatcher sends the conventional direction.
+
+- [ ] **Step 3: Update `_start_simple_time_test`**
+
+In `custom_components/cover_time_based/cover_calibration.py`, replace `_start_simple_time_test` (lines 116-125) with:
+
+```python
+    async def _start_simple_time_test(self, attribute, direction):
+        """Start a simple travel/tilt time test by moving the cover."""
+        assert self._calibration is not None
+        if direction:
+            move_command = self._resolve_direction(direction, None)
+        elif attribute.startswith("tilt_") and self._tilt_strategy is not None:
+            closing_tilt = "close" in attribute
+            move_command = self._tilt_strategy.tilt_command_for(closing_tilt)
+        elif "close" in attribute:
+            move_command = SERVICE_CLOSE_COVER
+        else:
+            move_command = SERVICE_OPEN_COVER
+        self._calibration.move_command = move_command
+        await self._async_handle_command(move_command)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_calibration.py -k "sequential_open" -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full test suite**
+
+Run: `pytest tests/ -x -q`
+Expected: All tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add custom_components/cover_time_based/cover_calibration.py tests/test_calibration.py
+git commit -m "feat: route tilt calibration dispatch through tilt_command_for"
+```
+
+---
+
+## Task 10: Bump ConfigFlow VERSION and add migration
+
+Bump `VERSION` 2 → 3 and add `async_migrate_entry` that rewrites `tilt_mode == "sequential"` to `"sequential_close"`.
+
+**Files:**
+- Modify: `custom_components/cover_time_based/config_flow.py`
+- Modify: `custom_components/cover_time_based/__init__.py`
+- Test: `tests/integration/test_lifecycle.py`
+
+The integration test suite under `tests/integration/` already uses `pytest_homeassistant_custom_component.common.MockConfigEntry` and a real `hass` fixture (see `tests/integration/conftest.py`). Add the migration tests there so they get a working `hass.config_entries.async_update_entry`.
+
+- [ ] **Step 1: Write failing migration tests**
+
+Append to `tests/integration/test_lifecycle.py`:
+
+```python
+async def test_migrate_v2_sequential_to_v3_sequential_close(hass: HomeAssistant):
+    """v2 entries with tilt_mode='sequential' migrate to v3 'sequential_close'."""
+    from custom_components.cover_time_based import async_migrate_entry
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=2,
+        title="Test",
+        data={},
+        options={"tilt_mode": "sequential", "travel_time_open": 10},
+    )
+    entry.add_to_hass(hass)
+
+    result = await async_migrate_entry(hass, entry)
+
+    assert result is True
+    assert entry.version == 3
+    assert entry.options["tilt_mode"] == "sequential_close"
+    assert entry.options["travel_time_open"] == 10
+
+
+async def test_migrate_v2_non_sequential_bumps_version_only(hass: HomeAssistant):
+    """v2 entries whose tilt_mode is not 'sequential' only bump the version."""
+    from custom_components.cover_time_based import async_migrate_entry
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=2,
+        title="Test",
+        data={},
+        options={"tilt_mode": "inline"},
+    )
+    entry.add_to_hass(hass)
+
+    result = await async_migrate_entry(hass, entry)
+
+    assert result is True
+    assert entry.version == 3
+    assert entry.options["tilt_mode"] == "inline"
+
+
+async def test_migrate_v3_is_idempotent(hass: HomeAssistant):
+    """v3 entries are not modified."""
+    from custom_components.cover_time_based import async_migrate_entry
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=3,
+        title="Test",
+        data={},
+        options={"tilt_mode": "sequential_close"},
+    )
+    entry.add_to_hass(hass)
+
+    result = await async_migrate_entry(hass, entry)
+
+    assert result is True
+    assert entry.version == 3
+    assert entry.options["tilt_mode"] == "sequential_close"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/integration/test_lifecycle.py -k migrate -v`
+Expected: FAIL — `async_migrate_entry` does not exist yet.
+
+- [ ] **Step 3: Bump VERSION**
+
+In `custom_components/cover_time_based/config_flow.py`, change line 21:
+
+```python
+    VERSION = 3
+```
+
+- [ ] **Step 4: Add `async_migrate_entry`**
+
+Edit `custom_components/cover_time_based/__init__.py`. Add the function below `async_setup_entry`:
+
+```python
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Migrate config entries between versions."""
+    _LOGGER.debug(
+        "Migrating config entry %s from version %s", entry.entry_id, entry.version
+    )
+
+    if entry.version < 3:
+        new_options = dict(entry.options)
+        if new_options.get("tilt_mode") == "sequential":
+            new_options["tilt_mode"] = "sequential_close"
+        hass.config_entries.async_update_entry(entry, options=new_options, version=3)
+
+    return True
+```
+
+The string `"tilt_mode"` here matches `CONF_TILT_MODE`'s value (defined in `const.py:5`); hard-coding keeps the function free of circular imports on startup.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pytest tests/integration/test_lifecycle.py -k migrate -v`
+Expected: PASS.
+
+- [ ] **Step 6: Run the full test suite**
+
+Run: `pytest tests/ -x -q`
+Expected: All tests pass. Existing integration tests create entries with `version=2` and `tilt_mode="sequential"` — migration runs at setup time and rewrites to `sequential_close`, while the legacy alias in `_resolve_tilt_strategy` covers any code path that sees the un-migrated value.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add custom_components/cover_time_based/config_flow.py custom_components/cover_time_based/__init__.py tests/integration/test_lifecycle.py
+git commit -m "feat: migrate tilt_mode 'sequential' to 'sequential_close' (v2→v3)"
+```
+
+---
+
+## Task 11: Update frontend dropdown, handler, and translations
+
+Update the frontend card to offer `sequential_close` and `sequential_open` as distinct dropdown options, adjust the mode-change handler, and add translations in en/pl/pt.
+
+**Files:**
+- Modify: `custom_components/cover_time_based/frontend/cover-time-based-card.js`
+
+No automated tests (frontend JS is not covered by the pytest suite). Manual verification steps are listed at the end of the task.
+
+- [ ] **Step 1: Update English translations (around lines 40-110)**
+
+Find the English translation block (starts around line 32 with `"tilt.label":`). Replace:
+
+```javascript
+  "tilt.sequential": "Closes then tilts",
+```
+
+with:
+
+```javascript
+  "tilt.sequential_close": "Closes then tilts closed",
+  "tilt.sequential_open": "Closes then tilts open",
+```
+
+Also find the hint keys (around lines 92-95):
+
+```javascript
+  "hints.sequential.travel_time_close": "Start with cover fully open. Click Finish when the cover is fully closed, before the slats start tilting.",
+  "hints.sequential.travel_time_open": "Start with cover closed and slats open. Click Finish when the cover is fully open.",
+  "hints.sequential.tilt_time_close": "Start with cover closed but slats open. Click Finish when the slats are fully closed.",
+  "hints.sequential.tilt_time_open": "Start with cover and slats closed. Click Finish when the slats are open.",
+```
+
+Replace with:
+
+```javascript
+  "hints.sequential_close.travel_time_close": "Start with cover fully open. Click Finish when the cover is fully closed, before the slats start tilting.",
+  "hints.sequential_close.travel_time_open": "Start with cover closed and slats open. Click Finish when the cover is fully open.",
+  "hints.sequential_close.tilt_time_close": "Start with cover closed but slats open. Click Finish when the slats are fully closed.",
+  "hints.sequential_close.tilt_time_open": "Start with cover and slats closed. Click Finish when the slats are open.",
+  "hints.sequential_open.travel_time_close": "Start with cover fully open and slats closed. Click Finish when the cover is fully closed, before the slats start tilting open.",
+  "hints.sequential_open.travel_time_open": "Start with cover closed and slats closed. Click Finish when the cover is fully open.",
+  "hints.sequential_open.tilt_time_close": "Start with cover closed but slats open. Click Finish when the slats are fully closed.",
+  "hints.sequential_open.tilt_time_open": "Start with cover and slats closed. Click Finish when the slats are fully open.",
+```
+
+- [ ] **Step 2: Update Portuguese translations (around lines 134-193)**
+
+Find the Portuguese block (starts around line 120 with `"pt": {`). Replace:
+
+```javascript
+    "tilt.sequential": "Fecha e depois inclina",
+```
+
+with:
+
+```javascript
+    "tilt.sequential_close": "Fecha e depois inclina fechadas",
+    "tilt.sequential_open": "Fecha e depois inclina abertas",
+```
+
+Replace the four `hints.sequential.*` keys (around lines 182-185) with:
+
+```javascript
+    "hints.sequential_close.travel_time_close": "Comece com o estore totalmente aberto. Clique em Concluir quando o estore estiver totalmente fechado, antes de as lâminas começarem a inclinar.",
+    "hints.sequential_close.travel_time_open": "Comece com o estore fechado e as lâminas abertas. Clique em Concluir quando o estore estiver totalmente aberto.",
+    "hints.sequential_close.tilt_time_close": "Comece com o estore fechado mas as lâminas abertas. Clique em Concluir quando as lâminas estiverem totalmente fechadas.",
+    "hints.sequential_close.tilt_time_open": "Comece com o estore e as lâminas fechados. Clique em Concluir quando as lâminas estiverem abertas.",
+    "hints.sequential_open.travel_time_close": "Comece com o estore totalmente aberto e as lâminas fechadas. Clique em Concluir quando o estore estiver totalmente fechado, antes de as lâminas começarem a inclinar-se abertas.",
+    "hints.sequential_open.travel_time_open": "Comece com o estore fechado e as lâminas fechadas. Clique em Concluir quando o estore estiver totalmente aberto.",
+    "hints.sequential_open.tilt_time_close": "Comece com o estore fechado mas as lâminas abertas. Clique em Concluir quando as lâminas estiverem totalmente fechadas.",
+    "hints.sequential_open.tilt_time_open": "Comece com o estore e as lâminas fechados. Clique em Concluir quando as lâminas estiverem totalmente abertas.",
+```
+
+- [ ] **Step 3: Update Polish translations (around lines 221-280)**
+
+Find the Polish block (starts around line 207 with `"pl": {`). Replace:
+
+```javascript
+    "tilt.sequential": "Najpierw zamyka, potem nachyla",
+```
+
+with:
+
+```javascript
+    "tilt.sequential_close": "Najpierw zamyka, potem nachyla zamknięte",
+    "tilt.sequential_open": "Najpierw zamyka, potem nachyla otwarte",
+```
+
+Replace the four `hints.sequential.*` keys (around lines 269-272) with:
+
+```javascript
+    "hints.sequential_close.travel_time_close": "Zacznij z roletą w pełni otwartą. Kliknij Zakończ, gdy roleta jest w pełni zamknięta, zanim listwy zaczną się nachylać.",
+    "hints.sequential_close.travel_time_open": "Zacznij z zamkniętą roletą i otwartymi listwami. Kliknij Zakończ, gdy roleta jest w pełni otwarta.",
+    "hints.sequential_close.tilt_time_close": "Zacznij z zamkniętą roletą, ale otwartymi listwami. Kliknij Zakończ, gdy listwy są w pełni zamknięte.",
+    "hints.sequential_close.tilt_time_open": "Zacznij z zamkniętą roletą i zamkniętymi listwami. Kliknij Zakończ, gdy listwy są otwarte.",
+    "hints.sequential_open.travel_time_close": "Zacznij z roletą w pełni otwartą i zamkniętymi listwami. Kliknij Zakończ, gdy roleta jest w pełni zamknięta, zanim listwy zaczną się nachylać otwarte.",
+    "hints.sequential_open.travel_time_open": "Zacznij z zamkniętą roletą i zamkniętymi listwami. Kliknij Zakończ, gdy roleta jest w pełni otwarta.",
+    "hints.sequential_open.tilt_time_close": "Zacznij z zamkniętą roletą, ale otwartymi listwami. Kliknij Zakończ, gdy listwy są w pełni zamknięte.",
+    "hints.sequential_open.tilt_time_open": "Zacznij z zamkniętą roletą i zamkniętymi listwami. Kliknij Zakończ, gdy listwy są w pełni otwarte.",
+```
+
+- [ ] **Step 4: Update the dropdown (around lines 1023-1035)**
+
+Find the tilt mode dropdown. Replace:
+
+```javascript
+          <option value="sequential" ?selected=${tiltMode === "sequential"}>
+            ${this._t("tilt.sequential")}
+          </option>
+```
+
+with:
+
+```javascript
+          <option value="sequential_close" ?selected=${tiltMode === "sequential_close"}>
+            ${this._t("tilt.sequential_close")}
+          </option>
+          <option value="sequential_open" ?selected=${tiltMode === "sequential_open"}>
+            ${this._t("tilt.sequential_open")}
+          </option>
+```
+
+- [ ] **Step 5: Update `_onTiltModeChange` (around lines 610-653)**
+
+The current handler checks `if (mode === "sequential")` to clear dual-motor fields. Both sequential variants want the same field-clearing behavior. Replace:
+
+```javascript
+      if (mode === "sequential") {
+        // Clear dual-motor fields when switching to sequential
+        updates.safe_tilt_position = null;
+        updates.max_tilt_allowed_position = null;
+        updates.tilt_open_switch = null;
+        updates.tilt_close_switch = null;
+        updates.tilt_stop_switch = null;
+      } else if (mode === "dual_motor") {
+```
+
+with:
+
+```javascript
+      if (mode === "sequential_close" || mode === "sequential_open") {
+        // Clear dual-motor fields when switching to either sequential variant
+        updates.safe_tilt_position = null;
+        updates.max_tilt_allowed_position = null;
+        updates.tilt_open_switch = null;
+        updates.tilt_close_switch = null;
+        updates.tilt_stop_switch = null;
+      } else if (mode === "dual_motor") {
+```
+
+- [ ] **Step 6: Grep for any remaining references to the old key**
+
+Run: `grep -n '"sequential"' custom_components/cover_time_based/frontend/cover-time-based-card.js`
+
+Expected: no matches (any match indicates a missed rename).
+
+Also: `grep -n 'hints\.sequential\.' custom_components/cover_time_based/frontend/cover-time-based-card.js`
+
+Expected: no matches.
+
+- [ ] **Step 7: Manual verification**
+
+This step is manual (frontend, no pytest coverage). Start a dev Home Assistant instance pointing at this repo, open the card, and verify:
+
+1. The Tilt Mode dropdown shows three entries besides `Not supported`: "Closes then tilts closed", "Closes then tilts open", "Separate tilt motor", "Tilts inline with travel".
+2. Selecting "Closes then tilts open" saves `tilt_mode: sequential_open` to the entry options.
+3. The Calibration tab's hint text for each attribute matches what the spec calls for in each mode.
+
+If you cannot run a dev HA instance, document this step as pending in the PR description.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add custom_components/cover_time_based/frontend/cover-time-based-card.js
+git commit -m "feat(ui): split sequential tilt into close/open variants"
+```
+
+---
+
+## Task 12: Update README
+
+Document the new mode in the tilt mode list.
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Update the tilt mode description**
+
+In `README.md`, find the "Tilt Mode" section (around line 117). Replace the `Sequential (closes then tilts)` bullet:
+
+```markdown
+- **Sequential (closes then tilts):** Tilting can only happen in the fully closed position. First the cover closes then the slats tilt closed. When opening, first the slats tilt open then the cover opens.
+```
+
+with:
+
+```markdown
+- **Sequential (closes then tilts closed):** Tilting can only happen in the fully closed position. First the cover closes then the slats tilt closed (motor drives further down past cover-closed to close the slats). When opening, the slats first tilt open (motor up) then the cover opens.
+- **Sequential (closes then tilts open):** Mirror image of the above — for covers where slats articulate *open* when the motor drives further down past cover-closed, not closed. First the cover closes then the slats tilt open (motor continues down). When opening, the slats first tilt closed (motor up) then the cover opens.
+```
+
+Also, update the "Features" bullet at line 22 if the text mentions the number of tilt modes — currently it says "three tilt modes". Change to "four tilt modes" (close/open sequential, inline, dual-motor):
+
+```markdown
+- **Control the tilt of your cover based on time** with four tilt modes: inline, sequential closes-then-tilts-closed, sequential closes-then-tilts-open, or separate tilt motor.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: document sequential_open tilt mode"
+```
+
+---
+
+## Final verification
+
+- [ ] **Step 1: Run the entire test suite**
+
+Run: `pytest tests/ -v`
+Expected: All tests pass, including new ones added for this feature.
+
+- [ ] **Step 2: Run type-checking**
+
+Run: `pyright custom_components/cover_time_based/`
+Expected: No new errors introduced by this change (pre-existing errors may remain — compare against the pre-change baseline if unsure).
+
+- [ ] **Step 3: Grep for stragglers**
+
+Run: `grep -rn '"sequential"' custom_components/cover_time_based/ | grep -v sequential_close | grep -v sequential_open`
+
+Expected: One line only — the legacy-alias branch in `_resolve_tilt_strategy` (the comment `# "sequential_close", legacy "sequential", or any unknown value → close variant`). Anything else indicates a missed rename.

--- a/docs/superpowers/specs/2026-04-14-inverted-sequential-tilt-design.md
+++ b/docs/superpowers/specs/2026-04-14-inverted-sequential-tilt-design.md
@@ -1,0 +1,173 @@
+# Inverted Sequential Tilt Mode — Design
+
+## Background
+
+Issue [#61](https://github.com/Sese-Schneider/ha-cover-time-based/issues/61) reports a cover design where slats articulate by the motor driving *further down* past the cover-closed position, rather than the conventional direction (motor briefly reversing up). The mechanical sequence is:
+
+1. **Top** — cover fully open
+2. **Middle** — cover closed, slats closed (a mechanical latch the motor does not stop at by itself)
+3. **Bottom** — cover closed, slats open (motor pushed past the middle latch)
+
+The existing `sequential` tilt mode assumes the opposite: at the closed position, tilt-open sends OPEN (motor up), tilt-close sends CLOSE (motor down). No existing configuration supports the reporter's hardware.
+
+## Goal
+
+Add a new tilt mode — display label "Closes then tilts open" — in which tilt direction is inverted relative to the existing sequential mode. Rename the existing mode to "Closes then tilts closed" for symmetry. Scope is limited to sequential; inline and dual-motor are unaffected.
+
+## Non-goals
+
+- No inverted variant for inline tilt (no reported hardware matches).
+- No changes to dual-motor, wrapped-cover, or control-mode (switch/pulse/toggle) code paths beyond the tilt direction abstraction.
+- No UI changes beyond the dropdown label and calibration hints.
+
+## Naming and config values
+
+| Internal `tilt_mode` | Display label (en)            | Status                                                  |
+| -------------------- | ----------------------------- | ------------------------------------------------------- |
+| `none`               | "Not supported"               | Unchanged                                               |
+| `sequential_close`   | "Closes then tilts closed"    | **Renamed from `sequential`**; behavior unchanged       |
+| `sequential_open`    | "Closes then tilts open"      | **New**; tilt direction inverted                        |
+| `inline`             | "Tilts inline with travel"    | Unchanged                                               |
+| `dual_motor`         | "Separate tilt motor"         | Unchanged                                               |
+
+## Config migration
+
+- Bump `ConfigEntry.VERSION` from `1` to `2`.
+- Add `async_migrate_entry` in `custom_components/cover_time_based/__init__.py` that rewrites `options[CONF_TILT_MODE] == "sequential"` → `"sequential_close"` and updates the entry version.
+- In `_resolve_tilt_strategy` ([cover.py:247](custom_components/cover_time_based/cover.py#L247)), accept `"sequential"` as a legacy alias for `"sequential_close"`. This protects YAML users and any migration edge case.
+
+## Strategy class hierarchy
+
+```
+TiltStrategy (base.py)
+├── InlineTilt
+├── DualMotorTilt
+└── SequentialTilt                 (abstract — shared planning & snap logic)
+    ├── SequentialCloseTilt        (implicit_tilt_during_travel = 100)
+    └── SequentialOpenTilt         (implicit_tilt_during_travel = 0)
+```
+
+`SequentialTilt` becomes an abstract base holding the shared logic. The two concrete subclasses differ only in two data points:
+
+- `name` — `"sequential_close"` or `"sequential_open"`
+- `implicit_tilt_during_travel` — `100` or `0` respectively
+
+`SequentialOpenTilt` also overrides `tilt_command_for` (see below).
+
+## Tilt direction abstraction
+
+Add a method to `TiltStrategy`:
+
+```python
+def tilt_command_for(self, closing_tilt: bool) -> str:
+    """Return the HA cover service to send for this tilt direction."""
+    return SERVICE_CLOSE_COVER if closing_tilt else SERVICE_OPEN_COVER
+```
+
+`SequentialOpenTilt` overrides it to return the inverted command. `InlineTilt`, `DualMotorTilt`, and `SequentialCloseTilt` inherit the default.
+
+**Call sites updated to consult the strategy:**
+
+| Location                                                                                     | Current logic                                                    |
+| -------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| [cover_base.py:582-589](custom_components/cover_time_based/cover_base.py#L582-L589)          | `_async_move_tilt_to_endpoint` single-motor branch               |
+| [cover_base.py:692-695](custom_components/cover_time_based/cover_base.py#L692-L695)          | `set_tilt_position` single-motor branch                          |
+| [cover_base.py:1371-1373](custom_components/cover_time_based/cover_base.py#L1371-L1373)      | `_start_tilt_restore` shared-motor branch                        |
+| [cover_calibration.py:116-125](custom_components/cover_time_based/cover_calibration.py#L116-L125) | `_start_simple_time_test` dispatch for `tilt_time_*` attributes |
+
+Each call site replaces `SERVICE_CLOSE_COVER if closing_tilt else SERVICE_OPEN_COVER` with `self._tilt_strategy.tilt_command_for(closing_tilt)`. The `dual_motor` branch (which uses `_send_tilt_open`/`_send_tilt_close` against dedicated tilt switches) is unaffected.
+
+## Physical-state semantics (`implicit_tilt_during_travel`)
+
+In sequential modes, the slats are physically constrained to a single tilt value while the cover is not at the closed position. For `sequential_close`, that value is 100 (slats open). For `sequential_open`, it is 0 (slats closed).
+
+The shared `SequentialTilt` base uses the `implicit_tilt_during_travel` property in two places:
+
+### `plan_move_position`
+
+Before starting travel, if `current_tilt != implicit_tilt_during_travel`, insert a `TiltTo(implicit_tilt_during_travel)` pre-step.
+
+```python
+def plan_move_position(self, target_pos, current_pos, current_tilt):
+    steps = []
+    if current_tilt != self.implicit_tilt_during_travel:
+        steps.append(TiltTo(self.implicit_tilt_during_travel))
+    steps.append(TravelTo(target_pos))
+    return steps
+```
+
+### `snap_trackers_to_physical`
+
+When the cover stops at `travel != 0`, force tilt to the implicit value to correct tracker drift:
+
+```python
+def snap_trackers_to_physical(self, travel_calc, tilt_calc):
+    current_travel = travel_calc.current_position()
+    current_tilt_pos = tilt_calc.current_position()
+    if current_travel is None or current_tilt_pos is None:
+        return
+    implicit = self.implicit_tilt_during_travel
+    if current_travel != 0 and current_tilt_pos != implicit:
+        tilt_calc.set_position(implicit)
+```
+
+`plan_move_tilt` is unchanged and identical in both variants (travel to 0, then TiltTo target).
+
+## Frontend / translations
+
+All strings live in [cover-time-based-card.js](custom_components/cover_time_based/frontend/cover-time-based-card.js).
+
+**Renamed keys** (5 per language × 3 languages = 15 total):
+- `tilt.sequential` → `tilt.sequential_close`
+- `hints.sequential.travel_time_close` → `hints.sequential_close.travel_time_close`
+- `hints.sequential.travel_time_open` → `hints.sequential_close.travel_time_open`
+- `hints.sequential.tilt_time_close` → `hints.sequential_close.tilt_time_close`
+- `hints.sequential.tilt_time_open` → `hints.sequential_close.tilt_time_open`
+
+**New keys** (5 per language × 3 languages = 15 total):
+- `tilt.sequential_open` — display label.
+- `hints.sequential_open.travel_time_close` — "Start with cover fully open and slats closed. Click Finish when the cover is fully closed, before the slats start tilting open."
+- `hints.sequential_open.travel_time_open` — "Start with cover closed and slats closed. Click Finish when the cover is fully open."
+- `hints.sequential_open.tilt_time_close` — "Start with cover closed but slats open. Click Finish when the slats are fully closed." (same wording as `sequential_close`)
+- `hints.sequential_open.tilt_time_open` — "Start with cover and slats closed. Click Finish when the slats are fully open." (same wording as `sequential_close`)
+
+**Dropdown updates** ([card.js:1028](custom_components/cover_time_based/frontend/cover-time-based-card.js#L1028)): replace the single `sequential` `<option>` with two options for `sequential_close` and `sequential_open`.
+
+**`_onTiltModeChange` handler** ([card.js:610](custom_components/cover_time_based/frontend/cover-time-based-card.js#L610)): the existing `mode === "sequential"` branch becomes `mode === "sequential_close" || mode === "sequential_open"` (same field-clearing logic applies to both).
+
+## Testing
+
+New tests live alongside the existing `test_tilt_strategy.py`, `test_config_flow.py`, and `test_calibration.py` tests.
+
+### Unit — `SequentialOpenTilt` behavior
+
+- `plan_move_position` with `current_tilt != 0` inserts `TiltTo(0)` pre-step; with `current_tilt == 0` skips it.
+- `plan_move_tilt` identical to `SequentialCloseTilt` (travel to 0 then TiltTo target).
+- `snap_trackers_to_physical` forces tilt to 0 when travel != 0.
+- `tilt_command_for(True)` returns `SERVICE_OPEN_COVER` (inverted from default).
+- `tilt_command_for(False)` returns `SERVICE_CLOSE_COVER` (inverted from default).
+- `implicit_tilt_during_travel == 0`.
+
+### Unit — `SequentialCloseTilt` parity
+
+- Assert that renaming did not change behavior: `implicit_tilt_during_travel == 100`, planning and snap match the current `SequentialTilt` tests.
+
+### Integration — calibration direction
+
+- With `tilt_strategy = SequentialOpenTilt()`, calling `start_calibration(attribute="tilt_time_open")` dispatches `SERVICE_CLOSE_COVER` (asserting the call-site change routes through `tilt_command_for`).
+- With `tilt_strategy = SequentialOpenTilt()`, `tilt_time_close` dispatches `SERVICE_OPEN_COVER`.
+- With `tilt_strategy = SequentialCloseTilt()`, existing behavior preserved (parity test).
+
+### Integration — config migration
+
+- `ConfigEntry(version=1, options={"tilt_mode": "sequential", ...})` goes through `async_migrate_entry` and ends up with `version=2` and `options["tilt_mode"] == "sequential_close"`.
+- Idempotency: a v2 entry is not modified.
+
+### Integration — legacy alias
+
+- `_resolve_tilt_strategy("sequential", tilt_time_close=1, tilt_time_open=1)` returns a `SequentialCloseTilt` instance.
+
+## Out of scope / follow-ups
+
+- Inline-inverted variant (`inline_open`) for covers where slats articulate mid-travel. Revisit if a user reports such hardware.
+- UI consolidation (grouping the two sequential variants under a single dropdown with a sub-toggle) — not worth the extra surface for two options.

--- a/docs/superpowers/specs/2026-04-14-inverted-sequential-tilt-design.md
+++ b/docs/superpowers/specs/2026-04-14-inverted-sequential-tilt-design.md
@@ -32,7 +32,7 @@ Add a new tilt mode — display label "Closes then tilts open" — in which tilt
 
 ## Config migration
 
-- Bump `ConfigEntry.VERSION` from `1` to `2`.
+- Bump `CoverTimeBasedConfigFlow.VERSION` from `2` to `3` in [config_flow.py:21](custom_components/cover_time_based/config_flow.py#L21).
 - Add `async_migrate_entry` in `custom_components/cover_time_based/__init__.py` that rewrites `options[CONF_TILT_MODE] == "sequential"` → `"sequential_close"` and updates the entry version.
 - In `_resolve_tilt_strategy` ([cover.py:247](custom_components/cover_time_based/cover.py#L247)), accept `"sequential"` as a legacy alias for `"sequential_close"`. This protects YAML users and any migration edge case.
 
@@ -160,8 +160,8 @@ New tests live alongside the existing `test_tilt_strategy.py`, `test_config_flow
 
 ### Integration — config migration
 
-- `ConfigEntry(version=1, options={"tilt_mode": "sequential", ...})` goes through `async_migrate_entry` and ends up with `version=2` and `options["tilt_mode"] == "sequential_close"`.
-- Idempotency: a v2 entry is not modified.
+- `ConfigEntry(version=2, options={"tilt_mode": "sequential", ...})` goes through `async_migrate_entry` and ends up with `version=3` and `options["tilt_mode"] == "sequential_close"`.
+- Idempotency: a v3 entry is not modified.
 
 ### Integration — legacy alias
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,6 +82,7 @@ def make_cover(make_hass):
         tilt_stop_switch=None,
         safe_tilt_position=None,
         max_tilt_allowed_position=None,
+        sequential_button_behavior=None,
     ):
         if cover_entity_id is not None:
             options = {
@@ -133,6 +134,11 @@ def make_cover(make_hass):
             options[CONF_SAFE_TILT_POSITION] = safe_tilt_position
         if max_tilt_allowed_position is not None:
             options[CONF_MAX_TILT_ALLOWED_POSITION] = max_tilt_allowed_position
+        if sequential_button_behavior is not None:
+            from custom_components.cover_time_based.const import (
+                CONF_SEQUENTIAL_BUTTON_BEHAVIOR,
+            )
+            options[CONF_SEQUENTIAL_BUTTON_BEHAVIOR] = sequential_button_behavior
 
         cover = _create_cover_from_options(
             options,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -138,6 +138,7 @@ def make_cover(make_hass):
             from custom_components.cover_time_based.const import (
                 CONF_SEQUENTIAL_BUTTON_BEHAVIOR,
             )
+
             options[CONF_SEQUENTIAL_BUTTON_BEHAVIOR] = sequential_button_behavior
 
         cover = _create_cover_from_options(

--- a/tests/integration/test_lifecycle.py
+++ b/tests/integration/test_lifecycle.py
@@ -96,3 +96,64 @@ async def test_position_restored_on_restart(hass: HomeAssistant, setup_input_boo
 
     await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
+
+
+async def test_migrate_v2_sequential_to_v3_sequential_close(hass: HomeAssistant):
+    """v2 entries with tilt_mode='sequential' migrate to v3 'sequential_close'."""
+    from custom_components.cover_time_based import async_migrate_entry
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=2,
+        title="Test",
+        data={},
+        options={"tilt_mode": "sequential", "travel_time_open": 10},
+    )
+    entry.add_to_hass(hass)
+
+    result = await async_migrate_entry(hass, entry)
+
+    assert result is True
+    assert entry.version == 3
+    assert entry.options["tilt_mode"] == "sequential_close"
+    assert entry.options["travel_time_open"] == 10
+
+
+async def test_migrate_v2_non_sequential_bumps_version_only(hass: HomeAssistant):
+    """v2 entries whose tilt_mode is not 'sequential' only bump the version."""
+    from custom_components.cover_time_based import async_migrate_entry
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=2,
+        title="Test",
+        data={},
+        options={"tilt_mode": "inline"},
+    )
+    entry.add_to_hass(hass)
+
+    result = await async_migrate_entry(hass, entry)
+
+    assert result is True
+    assert entry.version == 3
+    assert entry.options["tilt_mode"] == "inline"
+
+
+async def test_migrate_v3_is_idempotent(hass: HomeAssistant):
+    """v3 entries are not modified."""
+    from custom_components.cover_time_based import async_migrate_entry
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=3,
+        title="Test",
+        data={},
+        options={"tilt_mode": "sequential_close"},
+    )
+    entry.add_to_hass(hass)
+
+    result = await async_migrate_entry(hass, entry)
+
+    assert result is True
+    assert entry.version == 3
+    assert entry.options["tilt_mode"] == "sequential_close"

--- a/tests/integration/test_tilt.py
+++ b/tests/integration/test_tilt.py
@@ -160,3 +160,96 @@ async def test_sequential_tilt_rejected_when_not_at_endpoint(
 
     await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
+
+
+async def test_sequential_open_close_drives_close_relay_from_top(
+    hass: HomeAssistant, setup_input_booleans
+):
+    """sequential_open: closing from the top sends the close relay (motor down).
+
+    End-to-end check that the inverted tilt direction doesn't leak into the
+    main travel direction — close is still the close relay, open is still
+    the open relay. Slats stay at implicit (tilt=0) during the travel.
+    """
+    options = {
+        "control_mode": "switch",
+        "open_switch_entity_id": "input_boolean.open_switch",
+        "close_switch_entity_id": "input_boolean.close_switch",
+        "travel_time_open": 10.0,
+        "travel_time_close": 10.0,
+        "tilt_mode": "sequential_open",
+        "tilt_time_open": 2.0,
+        "tilt_time_close": 2.0,
+        "endpoint_runon_time": 0,
+    }
+    entry = MockConfigEntry(
+        domain=DOMAIN, version=3, title="Test Cover", data={}, options=options
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    cover = _get_cover_entity(hass)
+    await cover.set_known_position(position=100)
+    await cover.set_known_tilt_position(tilt_position=0)
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "cover", "close_cover", {"entity_id": "cover.test_cover"}, blocking=True
+    )
+    await hass.async_block_till_done()
+
+    # Close switch on, open switch off — travel driven by the close relay
+    # (tilt=0 is implicit, no tilt pre-step needed).
+    assert hass.states.get("input_boolean.close_switch").state == "on"
+    assert hass.states.get("input_boolean.open_switch").state == "off"
+
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+
+async def test_sequential_open_tilt_open_drives_close_relay(
+    hass: HomeAssistant, setup_input_booleans
+):
+    """sequential_open: opening the tilt sends the close relay (motor further down).
+
+    This is the key inversion: articulating slats "open" physically requires
+    driving the motor down past the cover-closed position.
+    """
+    options = {
+        "control_mode": "switch",
+        "open_switch_entity_id": "input_boolean.open_switch",
+        "close_switch_entity_id": "input_boolean.close_switch",
+        "travel_time_open": 10.0,
+        "travel_time_close": 10.0,
+        "tilt_mode": "sequential_open",
+        "tilt_time_open": 2.0,
+        "tilt_time_close": 2.0,
+        "endpoint_runon_time": 0,
+    }
+    entry = MockConfigEntry(
+        domain=DOMAIN, version=3, title="Test Cover", data={}, options=options
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    cover = _get_cover_entity(hass)
+    await cover.set_known_position(position=0)
+    await cover.set_known_tilt_position(tilt_position=0)
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "cover",
+        "open_cover_tilt",
+        {"entity_id": "cover.test_cover"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    # Inverted: opening the tilt drives the motor DOWN.
+    assert hass.states.get("input_boolean.close_switch").state == "on"
+    assert hass.states.get("input_boolean.open_switch").state == "off"
+
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()

--- a/tests/test_base_movement.py
+++ b/tests/test_base_movement.py
@@ -1749,6 +1749,58 @@ class TestSequentialOpenTiltEndpoint:
         assert cover._open_switch_entity_id not in activated
         assert cover._last_command == SERVICE_CLOSE_COVER
 
+    @pytest.mark.asyncio
+    async def test_sequential_open_set_tilt_position_sends_close(self, make_cover):
+        """SequentialOpenTilt: moving tilt from 0->50 sends CLOSE (motor down)."""
+        cover = make_cover(
+            tilt_time_close=5.0,
+            tilt_time_open=5.0,
+            tilt_mode="sequential_open",
+        )
+        cover.travel_calc.set_position(0)
+        cover.tilt_calc.set_position(0)
+
+        with patch.object(cover, "async_write_ha_state"):
+            await cover.set_tilt_position(50)
+
+        calls = cover.hass.services.async_call.call_args_list
+        turn_on_calls = [
+            c
+            for c in calls
+            if c[0][0] == "homeassistant" and c[0][1] == "turn_on"
+        ]
+        activated = [c[0][2]["entity_id"] for c in turn_on_calls]
+        # Opening the tilt (target 50 > current 0) should drive CLOSE relay.
+        assert cover._close_switch_entity_id in activated
+        assert cover._open_switch_entity_id not in activated
+        assert cover._last_command == SERVICE_CLOSE_COVER
+
+    @pytest.mark.asyncio
+    async def test_sequential_open_set_tilt_position_sends_open(self, make_cover):
+        """SequentialOpenTilt: moving tilt from 100->50 sends OPEN (motor up)."""
+        cover = make_cover(
+            tilt_time_close=5.0,
+            tilt_time_open=5.0,
+            tilt_mode="sequential_open",
+        )
+        cover.travel_calc.set_position(0)
+        cover.tilt_calc.set_position(100)
+
+        with patch.object(cover, "async_write_ha_state"):
+            await cover.set_tilt_position(50)
+
+        calls = cover.hass.services.async_call.call_args_list
+        turn_on_calls = [
+            c
+            for c in calls
+            if c[0][0] == "homeassistant" and c[0][1] == "turn_on"
+        ]
+        activated = [c[0][2]["entity_id"] for c in turn_on_calls]
+        # Closing the tilt (target 50 < current 100) should drive OPEN relay.
+        assert cover._open_switch_entity_id in activated
+        assert cover._close_switch_entity_id not in activated
+        assert cover._last_command == SERVICE_OPEN_COVER
+
 
 # ===================================================================
 # Wrapped cover + dual_motor: tilt via cover entity services

--- a/tests/test_base_movement.py
+++ b/tests/test_base_movement.py
@@ -1712,9 +1712,7 @@ class TestSequentialOpenTiltEndpoint:
 
         calls = cover.hass.services.async_call.call_args_list
         turn_on_calls = [
-            c
-            for c in calls
-            if c[0][0] == "homeassistant" and c[0][1] == "turn_on"
+            c for c in calls if c[0][0] == "homeassistant" and c[0][1] == "turn_on"
         ]
         activated = [c[0][2]["entity_id"] for c in turn_on_calls]
         # Inverted: closing the tilt should activate the OPEN relay.
@@ -1739,9 +1737,7 @@ class TestSequentialOpenTiltEndpoint:
 
         calls = cover.hass.services.async_call.call_args_list
         turn_on_calls = [
-            c
-            for c in calls
-            if c[0][0] == "homeassistant" and c[0][1] == "turn_on"
+            c for c in calls if c[0][0] == "homeassistant" and c[0][1] == "turn_on"
         ]
         activated = [c[0][2]["entity_id"] for c in turn_on_calls]
         # Inverted: opening the tilt should activate the CLOSE relay.
@@ -1765,9 +1761,7 @@ class TestSequentialOpenTiltEndpoint:
 
         calls = cover.hass.services.async_call.call_args_list
         turn_on_calls = [
-            c
-            for c in calls
-            if c[0][0] == "homeassistant" and c[0][1] == "turn_on"
+            c for c in calls if c[0][0] == "homeassistant" and c[0][1] == "turn_on"
         ]
         activated = [c[0][2]["entity_id"] for c in turn_on_calls]
         # Opening the tilt (target 50 > current 0) should drive CLOSE relay.
@@ -1791,9 +1785,7 @@ class TestSequentialOpenTiltEndpoint:
 
         calls = cover.hass.services.async_call.call_args_list
         turn_on_calls = [
-            c
-            for c in calls
-            if c[0][0] == "homeassistant" and c[0][1] == "turn_on"
+            c for c in calls if c[0][0] == "homeassistant" and c[0][1] == "turn_on"
         ]
         activated = [c[0][2]["entity_id"] for c in turn_on_calls]
         # Closing the tilt (target 50 < current 100) should drive OPEN relay.

--- a/tests/test_base_movement.py
+++ b/tests/test_base_movement.py
@@ -2690,3 +2690,260 @@ class TestExternalMovementSkipsTiltPlanning:
         assert cover.tilt_calc._travel_to_position == 0
         assert cover.travel_calc._travel_to_position == 100
         assert cover._pending_travel_target is None
+
+
+# ===================================================================
+# sequential_button_behavior: close/open buttons articulate slats
+# ===================================================================
+
+
+class TestSequentialButtonBehaviorNever:
+    """Default: close/open buttons only drive travel; tilt is unchanged.
+
+    The resting slat position (implicit_tilt_during_travel) is enforced by
+    snap_trackers_to_physical; articulation requires the explicit tilt
+    buttons.
+    """
+
+    @pytest.mark.asyncio
+    async def test_close_never_only_travels(self, make_cover):
+        cover = make_cover(
+            tilt_time_close=4.0,
+            tilt_time_open=4.0,
+            tilt_mode="sequential_open",
+            sequential_button_behavior="never",
+        )
+        cover.travel_calc.set_position(100)
+        cover.tilt_calc.set_position(0)
+
+        with patch.object(cover, "async_write_ha_state"):
+            await cover.async_close_cover()
+
+        # Travel tracker heads to 0; tilt tracker untouched (remains at 0 = implicit).
+        assert cover.travel_calc._travel_to_position == 0
+        assert cover.tilt_calc._travel_to_position == 0
+        assert not cover.tilt_calc.is_traveling()
+
+    @pytest.mark.asyncio
+    async def test_close_never_at_rest_is_noop(self, make_cover):
+        """Second close click when already at travel=0 + tilt=implicit: no-op."""
+        cover = make_cover(
+            tilt_time_close=4.0,
+            tilt_time_open=4.0,
+            tilt_mode="sequential_open",
+            sequential_button_behavior="never",
+        )
+        cover.travel_calc.set_position(0)
+        cover.tilt_calc.set_position(0)
+
+        with patch.object(cover, "async_write_ha_state"):
+            await cover.async_close_cover()
+
+        assert not cover.tilt_calc.is_traveling()
+
+
+class TestSequentialButtonBehaviorOnRepeat:
+    """Two-press UX: first click behaves as 'never'; a second click from the
+    resting closed state articulates slats (close) or restores them (open)
+    in a separate motor motion.
+    """
+
+    @pytest.mark.asyncio
+    async def test_close_on_repeat_first_click_travels(self, make_cover):
+        cover = make_cover(
+            tilt_time_close=4.0,
+            tilt_time_open=4.0,
+            tilt_mode="sequential_open",
+            sequential_button_behavior="on_repeat",
+        )
+        cover.travel_calc.set_position(100)
+        cover.tilt_calc.set_position(0)
+
+        with patch.object(cover, "async_write_ha_state"):
+            await cover.async_close_cover()
+
+        # First click: same as 'never' — travel only.
+        assert cover.travel_calc._travel_to_position == 0
+        assert not cover.tilt_calc.is_traveling()
+
+    @pytest.mark.asyncio
+    async def test_close_on_repeat_second_click_articulates(self, make_cover):
+        """sequential_open: second close from (travel=0, tilt=0) → tilt=100."""
+        cover = make_cover(
+            tilt_time_close=4.0,
+            tilt_time_open=4.0,
+            tilt_mode="sequential_open",
+            sequential_button_behavior="on_repeat",
+        )
+        cover.travel_calc.set_position(0)
+        cover.tilt_calc.set_position(0)
+
+        with patch.object(cover, "async_write_ha_state"):
+            await cover.async_close_cover()
+
+        # Articulated to tilt=100 (opposite of implicit=0).
+        assert cover.tilt_calc._travel_to_position == 100
+        assert cover.tilt_calc.is_traveling()
+
+    @pytest.mark.asyncio
+    async def test_close_on_repeat_sequential_close_variant(self, make_cover):
+        """sequential_close: second close from (travel=0, tilt=100) → tilt=0."""
+        cover = make_cover(
+            tilt_time_close=4.0,
+            tilt_time_open=4.0,
+            tilt_mode="sequential_close",
+            sequential_button_behavior="on_repeat",
+        )
+        cover.travel_calc.set_position(0)
+        cover.tilt_calc.set_position(100)
+
+        with patch.object(cover, "async_write_ha_state"):
+            await cover.async_close_cover()
+
+        # Articulated to tilt=0 (opposite of implicit=100).
+        assert cover.tilt_calc._travel_to_position == 0
+        assert cover.tilt_calc.is_traveling()
+
+    @pytest.mark.asyncio
+    async def test_open_on_repeat_first_click_restores_tilt(self, make_cover):
+        """From (travel=0, tilt=100) on sequential_open, first open click only
+        closes the slats back to implicit (tilt=0), stopping at the middle."""
+        cover = make_cover(
+            tilt_time_close=4.0,
+            tilt_time_open=4.0,
+            tilt_mode="sequential_open",
+            sequential_button_behavior="on_repeat",
+        )
+        cover.travel_calc.set_position(0)
+        cover.tilt_calc.set_position(100)
+
+        with patch.object(cover, "async_write_ha_state"):
+            await cover.async_open_cover()
+
+        # Tilt restoring to implicit (0); travel not engaged.
+        assert cover.tilt_calc._travel_to_position == 0
+        assert cover.tilt_calc.is_traveling()
+        assert cover.travel_calc._travel_to_position == 0
+
+    @pytest.mark.asyncio
+    async def test_open_on_repeat_second_click_travels(self, make_cover):
+        """From middle (travel=0, tilt=implicit), second open click travels."""
+        cover = make_cover(
+            tilt_time_close=4.0,
+            tilt_time_open=4.0,
+            tilt_mode="sequential_open",
+            sequential_button_behavior="on_repeat",
+        )
+        cover.travel_calc.set_position(0)
+        cover.tilt_calc.set_position(0)  # implicit for sequential_open
+
+        with patch.object(cover, "async_write_ha_state"):
+            await cover.async_open_cover()
+
+        # Travels up; no tilt motion (already at implicit).
+        assert cover.travel_calc._travel_to_position == 100
+
+
+class TestSequentialButtonBehaviorOnePress:
+    """Single motor motion: close does travel + articulate in one click."""
+
+    @pytest.mark.asyncio
+    async def test_close_one_press_from_top_runs_full_motion(self, make_cover):
+        """From (travel=100, tilt=0), one_press close plans [TravelTo(0), TiltTo(100)]."""
+        cover = make_cover(
+            tilt_time_close=4.0,
+            tilt_time_open=4.0,
+            tilt_mode="sequential_open",
+            sequential_button_behavior="one_press",
+        )
+        cover.travel_calc.set_position(100)
+        cover.tilt_calc.set_position(0)
+
+        with patch.object(cover, "async_write_ha_state"):
+            await cover.async_close_cover()
+
+        # set_tilt_position(100) starts travel tracker toward 0 (pre-step)
+        # and queues tilt at 100 with a delay equal to travel_time_close.
+        assert cover.travel_calc._travel_to_position == 0
+        assert cover.tilt_calc._travel_to_position == 100
+
+    @pytest.mark.asyncio
+    async def test_close_one_press_from_middle_articulates(self, make_cover):
+        """From (travel=0, tilt=0), one_press close articulates only."""
+        cover = make_cover(
+            tilt_time_close=4.0,
+            tilt_time_open=4.0,
+            tilt_mode="sequential_open",
+            sequential_button_behavior="one_press",
+        )
+        cover.travel_calc.set_position(0)
+        cover.tilt_calc.set_position(0)
+
+        with patch.object(cover, "async_write_ha_state"):
+            await cover.async_close_cover()
+
+        assert cover.tilt_calc._travel_to_position == 100
+        assert cover.tilt_calc.is_traveling()
+
+    @pytest.mark.asyncio
+    async def test_close_one_press_sequential_close_variant(self, make_cover):
+        """sequential_close one_press: articulate to tilt=0 (opposite of implicit=100)."""
+        cover = make_cover(
+            tilt_time_close=4.0,
+            tilt_time_open=4.0,
+            tilt_mode="sequential_close",
+            sequential_button_behavior="one_press",
+        )
+        cover.travel_calc.set_position(100)
+        cover.tilt_calc.set_position(100)
+
+        with patch.object(cover, "async_write_ha_state"):
+            await cover.async_close_cover()
+
+        assert cover.travel_calc._travel_to_position == 0
+        assert cover.tilt_calc._travel_to_position == 0
+
+    @pytest.mark.asyncio
+    async def test_open_one_press_equivalent_to_never(self, make_cover):
+        """one_press open == never open: the default plan already combines
+        tilt restoration with travel."""
+        cover = make_cover(
+            tilt_time_close=4.0,
+            tilt_time_open=4.0,
+            tilt_mode="sequential_open",
+            sequential_button_behavior="one_press",
+        )
+        cover.travel_calc.set_position(0)
+        cover.tilt_calc.set_position(100)
+
+        with patch.object(cover, "async_write_ha_state"):
+            await cover.async_open_cover()
+
+        # plan_move_position(100, 0, 100) = [TiltTo(0), TravelTo(100)].
+        # tilt_calc targets 0, travel_calc targets 100 (with delay).
+        assert cover.tilt_calc._travel_to_position == 0
+        assert cover.travel_calc._travel_to_position == 100
+
+
+class TestSequentialButtonBehaviorIgnoredForNonSequential:
+    """Behavior is a no-op for non-sequential tilt strategies."""
+
+    @pytest.mark.asyncio
+    async def test_inline_ignores_on_repeat(self, make_cover):
+        cover = make_cover(
+            tilt_time_close=2.0,
+            tilt_time_open=2.0,
+            tilt_mode="inline",
+            sequential_button_behavior="on_repeat",
+        )
+        cover.travel_calc.set_position(0)
+        cover.tilt_calc.set_position(100)
+
+        with patch.object(cover, "async_write_ha_state"):
+            # Second close at travel=0 — with "on_repeat" we'd expect a
+            # sequential_* cover to articulate, but inline just does its
+            # own thing (close is a no-op at position 0 since nothing to do).
+            await cover.async_close_cover()
+
+        # No articulation happened (tilt tracker not re-engaged).
+        assert not cover.tilt_calc.is_traveling()

--- a/tests/test_base_movement.py
+++ b/tests/test_base_movement.py
@@ -2626,14 +2626,20 @@ class TestExternalMovementSkipsTiltPlanning:
         assert cover._self_initiated_movement is False
 
     @pytest.mark.asyncio
-    async def test_external_sequential_tilt_also_skipped(self, make_cover):
-        """External open also skips tilt planning for sequential mode."""
+    async def test_external_sequential_close_couples_tilt(self, make_cover):
+        """External open in sequential_close couples tilt so the tracker matches
+        the single motor's physical tilt-then-travel motion.
+
+        Starting from (travel=0, tilt=0) — slats articulated closed — pressing
+        the external up button physically lifts the motor through two phases:
+        first slats tilt to 100 (implicit rest), then cover travels to 100.
+        The travel tracker must be delayed by the tilt phase duration so both
+        calculators stay in sync with the real cover.
+        """
         cover = make_cover(
             tilt_time_close=5.0,
             tilt_time_open=5.0,
             tilt_mode="sequential",
-            safe_tilt_position=50,
-            max_tilt_allowed_position=50,
         )
         cover.travel_calc.set_position(0)
         cover.tilt_calc.set_position(0)
@@ -2645,6 +2651,42 @@ class TestExternalMovementSkipsTiltPlanning:
         finally:
             cover._triggered_externally = False
 
-        # Travel tracking starts directly, no tilt coupling
-        assert cover.travel_calc.is_traveling()
+        # Tilt is coupled: calculator now targets implicit (100) and is
+        # actively tracking toward it.
+        assert cover.tilt_calc.is_traveling()
+        assert cover.tilt_calc._travel_to_position == 100
+        # Travel is still tracking (target 100) but delayed until the tilt
+        # phase completes — no dual-motor pre-step was triggered.
+        assert cover.travel_calc._travel_to_position == 100
+        assert cover._pending_travel_target is None
+
+    @pytest.mark.asyncio
+    async def test_external_sequential_open_couples_tilt(self, make_cover):
+        """External open in sequential_open couples tilt when starting from
+        the articulated-open position (travel=0, tilt=100).
+
+        Mirror of the sequential_close case: the motor runs UP, first closing
+        the slats (tilt 100→0) and then lifting the cover (travel 0→100).
+        Without coupled tilt tracking, the tilt tracker would stay at 100 and
+        snap-to-implicit on the next stop would make the tilt appear to jump.
+        """
+        cover = make_cover(
+            tilt_time_close=4.0,
+            tilt_time_open=4.0,
+            tilt_mode="sequential_open",
+        )
+        cover.travel_calc.set_position(0)
+        cover.tilt_calc.set_position(100)
+
+        cover._triggered_externally = True
+        try:
+            with patch.object(cover, "async_write_ha_state"):
+                await cover.async_open_cover()
+        finally:
+            cover._triggered_externally = False
+
+        # Tilt is coupled: targeting implicit (0) and tracking.
+        assert cover.tilt_calc.is_traveling()
+        assert cover.tilt_calc._travel_to_position == 0
+        assert cover.travel_calc._travel_to_position == 100
         assert cover._pending_travel_target is None

--- a/tests/test_base_movement.py
+++ b/tests/test_base_movement.py
@@ -1682,6 +1682,75 @@ class TestDualMotorTiltOnlyCommands:
 
 
 # ===================================================================
+# SequentialOpenTilt: inverted motor direction for tilt endpoint commands
+# ===================================================================
+
+
+class TestSequentialOpenTiltEndpoint:
+    """SequentialOpenTilt inverts the motor direction for tilt endpoint moves.
+
+    Slats physically sit at tilt=0 (closed) while the cover is not at the
+    closed position. Closing the tilt (target=0) means driving the motor
+    UP (OPEN relay) back to the slats-closed position; opening the tilt
+    (target=100) means driving the motor further DOWN (CLOSE relay) past
+    the cover-closed position.
+    """
+
+    @pytest.mark.asyncio
+    async def test_sequential_open_tilt_close_sends_open_command(self, make_cover):
+        """SequentialOpenTilt: closing the tilt physically sends OPEN (motor up)."""
+        cover = make_cover(
+            tilt_time_close=5.0,
+            tilt_time_open=5.0,
+            tilt_mode="sequential_open",
+        )
+        cover.travel_calc.set_position(0)
+        cover.tilt_calc.set_position(100)
+
+        with patch.object(cover, "async_write_ha_state"):
+            await cover.async_close_cover_tilt()
+
+        calls = cover.hass.services.async_call.call_args_list
+        turn_on_calls = [
+            c
+            for c in calls
+            if c[0][0] == "homeassistant" and c[0][1] == "turn_on"
+        ]
+        activated = [c[0][2]["entity_id"] for c in turn_on_calls]
+        # Inverted: closing the tilt should activate the OPEN relay.
+        assert cover._open_switch_entity_id in activated
+        assert cover._close_switch_entity_id not in activated
+        # _last_command tracks the motor command actually sent.
+        assert cover._last_command == SERVICE_OPEN_COVER
+
+    @pytest.mark.asyncio
+    async def test_sequential_open_tilt_open_sends_close_command(self, make_cover):
+        """SequentialOpenTilt: opening the tilt physically sends CLOSE (motor down)."""
+        cover = make_cover(
+            tilt_time_close=5.0,
+            tilt_time_open=5.0,
+            tilt_mode="sequential_open",
+        )
+        cover.travel_calc.set_position(0)
+        cover.tilt_calc.set_position(0)
+
+        with patch.object(cover, "async_write_ha_state"):
+            await cover.async_open_cover_tilt()
+
+        calls = cover.hass.services.async_call.call_args_list
+        turn_on_calls = [
+            c
+            for c in calls
+            if c[0][0] == "homeassistant" and c[0][1] == "turn_on"
+        ]
+        activated = [c[0][2]["entity_id"] for c in turn_on_calls]
+        # Inverted: opening the tilt should activate the CLOSE relay.
+        assert cover._close_switch_entity_id in activated
+        assert cover._open_switch_entity_id not in activated
+        assert cover._last_command == SERVICE_CLOSE_COVER
+
+
+# ===================================================================
 # Wrapped cover + dual_motor: tilt via cover entity services
 # ===================================================================
 

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -215,6 +215,63 @@ class TestCalibrationTiltTime:
             await cover.start_calibration(attribute="tilt_time_open", timeout=30.0)
         assert cover._calibration.attribute == "tilt_time_open"
 
+    @pytest.mark.asyncio
+    async def test_sequential_open_tilt_time_open_sends_close(self, make_cover):
+        """With SequentialOpenTilt, calibrating tilt_time_open moves motor DOWN."""
+        cover = make_cover(
+            travel_time_open=10.0,
+            travel_time_close=10.0,
+            tilt_time_open=2.0,
+            tilt_time_close=2.0,
+            tilt_mode="sequential_open",
+        )
+        cover.travel_calc.set_position(0)
+        cover.tilt_calc.set_position(0)
+
+        with patch.object(cover, "async_write_ha_state"):
+            await cover.start_calibration(attribute="tilt_time_open", timeout=60.0)
+
+            turn_on_calls = [
+                c
+                for c in cover.hass.services.async_call.call_args_list
+                if c[0][0] == "homeassistant" and c[0][1] == "turn_on"
+            ]
+            activated = [c[0][2]["entity_id"] for c in turn_on_calls]
+            # tilt_time_open on sequential_open -> motor DOWN -> CLOSE relay.
+            assert cover._close_switch_entity_id in activated
+            assert cover._open_switch_entity_id not in activated
+
+            # Cleanup: cancel the running calibration.
+            await cover.stop_calibration(cancel=True)
+
+    @pytest.mark.asyncio
+    async def test_sequential_open_tilt_time_close_sends_open(self, make_cover):
+        """With SequentialOpenTilt, calibrating tilt_time_close moves motor UP."""
+        cover = make_cover(
+            travel_time_open=10.0,
+            travel_time_close=10.0,
+            tilt_time_open=2.0,
+            tilt_time_close=2.0,
+            tilt_mode="sequential_open",
+        )
+        cover.travel_calc.set_position(0)
+        cover.tilt_calc.set_position(100)
+
+        with patch.object(cover, "async_write_ha_state"):
+            await cover.start_calibration(attribute="tilt_time_close", timeout=60.0)
+
+            turn_on_calls = [
+                c
+                for c in cover.hass.services.async_call.call_args_list
+                if c[0][0] == "homeassistant" and c[0][1] == "turn_on"
+            ]
+            activated = [c[0][2]["entity_id"] for c in turn_on_calls]
+            # tilt_time_close on sequential_open -> motor UP -> OPEN relay.
+            assert cover._open_switch_entity_id in activated
+            assert cover._close_switch_entity_id not in activated
+
+            await cover.stop_calibration(cancel=True)
+
 
 class TestMotorOverheadCalibration:
     @pytest.mark.asyncio

--- a/tests/test_cover_factory.py
+++ b/tests/test_cover_factory.py
@@ -41,7 +41,8 @@ from custom_components.cover_time_based.cover_wrapped import WrappedCoverTimeBas
 from custom_components.cover_time_based.tilt_strategies import (
     DualMotorTilt,
     InlineTilt,
-    SequentialTilt,
+    SequentialCloseTilt,
+    SequentialOpenTilt,
 )
 
 
@@ -435,13 +436,18 @@ class TestResolveTiltStrategy:
 
     def test_sequential_close(self):
         result = _resolve_tilt_strategy("sequential_close", 2.0, 2.0)
-        assert isinstance(result, SequentialTilt)
+        assert isinstance(result, SequentialCloseTilt)
         assert result.name == "sequential_close"
 
+    def test_sequential_open(self):
+        result = _resolve_tilt_strategy("sequential_open", 2.0, 2.0)
+        assert isinstance(result, SequentialOpenTilt)
+        assert result.name == "sequential_open"
+
     def test_sequential_legacy_alias(self):
-        """Legacy 'sequential' value still resolves and normalizes to sequential_close."""
+        """Legacy 'sequential' value resolves to SequentialCloseTilt."""
         result = _resolve_tilt_strategy("sequential", 2.0, 2.0)
-        assert isinstance(result, SequentialTilt)
+        assert isinstance(result, SequentialCloseTilt)
         assert result.name == "sequential_close"
 
     def test_dual_motor_defaults(self):
@@ -471,9 +477,9 @@ class TestResolveTiltStrategy:
         result = _resolve_tilt_strategy("inline", 2.0, 2.0)
         assert isinstance(result, InlineTilt)
 
-    def test_unknown_mode_defaults_to_sequential(self):
+    def test_unknown_mode_defaults_to_sequential_close(self):
         result = _resolve_tilt_strategy("unknown_value", 2.0, 2.0)
-        assert isinstance(result, SequentialTilt)
+        assert isinstance(result, SequentialCloseTilt)
 
 
 # ===================================================================

--- a/tests/test_cover_factory.py
+++ b/tests/test_cover_factory.py
@@ -428,14 +428,21 @@ class TestResolveTiltStrategy:
         assert _resolve_tilt_strategy("none", 2.0, 2.0) is None
 
     def test_none_when_no_tilt_times(self):
-        assert _resolve_tilt_strategy("sequential", None, None) is None
+        assert _resolve_tilt_strategy("sequential_close", None, None) is None
 
     def test_none_when_partial_tilt_times(self):
-        assert _resolve_tilt_strategy("sequential", 2.0, None) is None
+        assert _resolve_tilt_strategy("sequential_close", 2.0, None) is None
 
-    def test_sequential(self):
+    def test_sequential_close(self):
+        result = _resolve_tilt_strategy("sequential_close", 2.0, 2.0)
+        assert isinstance(result, SequentialTilt)
+        assert result.name == "sequential_close"
+
+    def test_sequential_legacy_alias(self):
+        """Legacy 'sequential' value still resolves and normalizes to sequential_close."""
         result = _resolve_tilt_strategy("sequential", 2.0, 2.0)
         assert isinstance(result, SequentialTilt)
+        assert result.name == "sequential_close"
 
     def test_dual_motor_defaults(self):
         result = _resolve_tilt_strategy("dual_motor", 2.0, 2.0)

--- a/tests/test_cover_toggle_mode.py
+++ b/tests/test_cover_toggle_mode.py
@@ -1080,9 +1080,7 @@ class TestToggleExternalTravelWhileTraveling:
         cover._triggered_externally = True
         try:
             with patch.object(cover, "async_write_ha_state"):
-                await cover._handle_external_state_change(
-                    "switch.open", "off", "on"
-                )
+                await cover._handle_external_state_change("switch.open", "off", "on")
         finally:
             cover._triggered_externally = False
 
@@ -1099,9 +1097,7 @@ class TestToggleExternalTravelWhileTraveling:
         cover._triggered_externally = True
         try:
             with patch.object(cover, "async_write_ha_state"):
-                await cover._handle_external_state_change(
-                    "switch.close", "off", "on"
-                )
+                await cover._handle_external_state_change("switch.close", "off", "on")
         finally:
             cover._triggered_externally = False
 
@@ -1118,9 +1114,7 @@ class TestToggleExternalTravelWhileTraveling:
         cover._triggered_externally = True
         try:
             with patch.object(cover, "async_write_ha_state"):
-                await cover._handle_external_state_change(
-                    "switch.open", "off", "on"
-                )
+                await cover._handle_external_state_change("switch.open", "off", "on")
         finally:
             cover._triggered_externally = False
 

--- a/tests/test_cover_toggle_mode.py
+++ b/tests/test_cover_toggle_mode.py
@@ -1051,3 +1051,79 @@ class TestToggleExternalTiltCloseWhileTraveling:
         # Tilt should have stopped traveling
         assert not cover.tilt_calc.is_traveling()
         await _cancel_tasks(cover)
+
+
+# ===================================================================
+# Travel toggle while traveling stops (parity with tilt handler)
+# ===================================================================
+
+
+class TestToggleExternalTravelWhileTraveling:
+    """External travel toggle while the cover is moving should stop it.
+
+    Parity with the existing tilt-while-traveling handler: a second pulse on
+    the same direction button (or any travel button) while the motor is
+    running is interpreted as a stop, matching how toggle-style motor
+    controllers physically behave. Previously the travel handler unconditionally
+    re-issued the direction command, which on real hardware was ignored while
+    the motor was already running in that direction — the cover would not stop.
+    """
+
+    @pytest.mark.asyncio
+    async def test_external_open_while_opening_stops(self):
+        cover = _make_toggle_cover()
+        # Simulate currently opening
+        cover.travel_calc.set_position(0)
+        cover.travel_calc.start_travel_up()
+        assert cover.travel_calc.is_traveling()
+
+        cover._triggered_externally = True
+        try:
+            with patch.object(cover, "async_write_ha_state"):
+                await cover._handle_external_state_change(
+                    "switch.open", "off", "on"
+                )
+        finally:
+            cover._triggered_externally = False
+
+        assert not cover.travel_calc.is_traveling()
+        await _cancel_tasks(cover)
+
+    @pytest.mark.asyncio
+    async def test_external_close_while_closing_stops(self):
+        cover = _make_toggle_cover()
+        cover.travel_calc.set_position(100)
+        cover.travel_calc.start_travel_down()
+        assert cover.travel_calc.is_traveling()
+
+        cover._triggered_externally = True
+        try:
+            with patch.object(cover, "async_write_ha_state"):
+                await cover._handle_external_state_change(
+                    "switch.close", "off", "on"
+                )
+        finally:
+            cover._triggered_externally = False
+
+        assert not cover.travel_calc.is_traveling()
+        await _cancel_tasks(cover)
+
+    @pytest.mark.asyncio
+    async def test_external_open_when_idle_starts_opening(self):
+        """Sanity: idle + external open pulse still opens the cover."""
+        cover = _make_toggle_cover()
+        cover.travel_calc.set_position(0)
+        assert not cover.travel_calc.is_traveling()
+
+        cover._triggered_externally = True
+        try:
+            with patch.object(cover, "async_write_ha_state"):
+                await cover._handle_external_state_change(
+                    "switch.open", "off", "on"
+                )
+        finally:
+            cover._triggered_externally = False
+
+        assert cover.travel_calc.is_traveling()
+        assert cover.travel_calc._travel_to_position == 100
+        await _cancel_tasks(cover)

--- a/tests/test_state_monitoring.py
+++ b/tests/test_state_monitoring.py
@@ -333,7 +333,7 @@ class TestToggleModeExternalStateChange:
 
     @pytest.mark.asyncio
     async def test_debounce_ignores_rapid_second_pulse(self, make_cover):
-        """Second OFF->ON within debounce window is ignored."""
+        """Second OFF->ON within debounce window is ignored (contact bounce)."""
         cover = make_cover(control_mode=CONTROL_MODE_TOGGLE)
         cover.travel_calc.set_position(0)
 
@@ -349,6 +349,38 @@ class TestToggleModeExternalStateChange:
                 await cover._handle_external_state_change("switch.open", "off", "on")
                 assert cover._last_command == SERVICE_OPEN_COVER
                 assert cover.is_opening
+            finally:
+                cover._triggered_externally = False
+
+    @pytest.mark.asyncio
+    async def test_debounce_allows_second_click_after_1_second(self, make_cover):
+        """Second click ~1s after the first is a legitimate toggle, not a bounce.
+
+        Regression: an earlier debounce window of pulse_time + 0.5 (1.5s with
+        default pulse_time=1.0) swallowed deliberate clicks up to 1.5s apart,
+        so a "start then stop" cadence got stuck on the start.
+        """
+        import time as time_module
+
+        cover = make_cover(control_mode=CONTROL_MODE_TOGGLE)
+        cover.travel_calc.set_position(0)
+
+        with patch.object(cover, "async_write_ha_state"):
+            cover._triggered_externally = True
+            try:
+                # Click 1 starts opening
+                await cover._handle_external_state_change("switch.open", "off", "on")
+                assert cover.is_opening
+
+                # Backdate the recorded click so "now - last" == 1 second
+                cover._last_external_toggle_time["switch.open"] = (
+                    time_module.monotonic() - 1.0
+                )
+
+                # Click 2 at +1s should NOT be debounced → same-direction
+                # while opening → stops the motor.
+                await cover._handle_external_state_change("switch.open", "off", "on")
+                assert not cover.travel_calc.is_traveling()
             finally:
                 cover._triggered_externally = False
 

--- a/tests/test_state_monitoring.py
+++ b/tests/test_state_monitoring.py
@@ -293,8 +293,13 @@ class TestToggleModeExternalStateChange:
         assert cover._last_command == SERVICE_CLOSE_COVER
 
     @pytest.mark.asyncio
-    async def test_off_to_on_while_opening_reissues(self, make_cover):
-        """OFF->ON on open switch while opening re-issues open (no special stop)."""
+    async def test_off_to_on_while_opening_stops(self, make_cover):
+        """OFF->ON on open switch while opening stops the motor.
+
+        Toggle motor controllers latch OFF on a second same-direction pulse.
+        The integration mirrors that: a same-direction external toggle during
+        travel stops instead of re-issuing the direction.
+        """
         cover = make_cover(control_mode=CONTROL_MODE_TOGGLE)
         cover.travel_calc.set_position(50)
         cover.travel_calc.start_travel_up()
@@ -307,11 +312,11 @@ class TestToggleModeExternalStateChange:
             finally:
                 cover._triggered_externally = False
 
-        assert cover._last_command == SERVICE_OPEN_COVER
+        assert not cover.travel_calc.is_traveling()
 
     @pytest.mark.asyncio
-    async def test_off_to_on_while_closing_reissues(self, make_cover):
-        """OFF->ON on close switch while closing re-issues close (no special stop)."""
+    async def test_off_to_on_while_closing_stops(self, make_cover):
+        """OFF->ON on close switch while closing stops the motor (same-direction toggle)."""
         cover = make_cover(control_mode=CONTROL_MODE_TOGGLE)
         cover.travel_calc.set_position(50)
         cover.travel_calc.start_travel_down()
@@ -324,7 +329,7 @@ class TestToggleModeExternalStateChange:
             finally:
                 cover._triggered_externally = False
 
-        assert cover._last_command == SERVICE_CLOSE_COVER
+        assert not cover.travel_calc.is_traveling()
 
     @pytest.mark.asyncio
     async def test_debounce_ignores_rapid_second_pulse(self, make_cover):
@@ -348,8 +353,8 @@ class TestToggleModeExternalStateChange:
                 cover._triggered_externally = False
 
     @pytest.mark.asyncio
-    async def test_full_cycle_same_direction_reissues(self, make_cover):
-        """Click 1 starts, click 2 (same direction after debounce) re-issues open."""
+    async def test_full_cycle_same_direction_stops(self, make_cover):
+        """Click 1 starts, click 2 (same direction after debounce) stops."""
         import time as time_module
 
         cover = make_cover(control_mode=CONTROL_MODE_TOGGLE)
@@ -368,9 +373,10 @@ class TestToggleModeExternalStateChange:
                     time_module.monotonic() - cover._pulse_time - 0.5 - 0.1
                 )
 
-                # Click 2: same direction re-issues open (no special stop)
+                # Click 2: same direction stops the motor (matches toggle
+                # hardware where a second same-direction pulse latches OFF).
                 await cover._handle_external_state_change("switch.open", "off", "on")
-                assert cover._last_command == SERVICE_OPEN_COVER
+                assert not cover.travel_calc.is_traveling()
             finally:
                 cover._triggered_externally = False
 

--- a/tests/test_tilt_strategy.py
+++ b/tests/test_tilt_strategy.py
@@ -74,6 +74,9 @@ class TestSequentialTiltProperties:
     def test_restores_tilt(self):
         assert SequentialTilt().restores_tilt is False
 
+    def test_implicit_tilt_during_travel(self):
+        assert SequentialTilt().implicit_tilt_during_travel == 100
+
 
 class TestSequentialPlanMovePosition:
     def test_flattens_tilt_before_travel(self):

--- a/tests/test_tilt_strategy.py
+++ b/tests/test_tilt_strategy.py
@@ -5,6 +5,8 @@ from custom_components.cover_time_based.travel_calculator import TravelCalculato
 from custom_components.cover_time_based.tilt_strategies import (
     DualMotorTilt,
     InlineTilt,
+    SequentialCloseTilt,
+    SequentialOpenTilt,
     SequentialTilt,
     TiltTo,
     TravelTo,
@@ -564,3 +566,125 @@ class TestTiltCommandForDefault:
         strategy = DualMotorTilt()
         assert strategy.tilt_command_for(True) == SERVICE_CLOSE_COVER
         assert strategy.tilt_command_for(False) == SERVICE_OPEN_COVER
+
+
+# ===================================================================
+# SequentialCloseTilt (concrete, conventional direction)
+# ===================================================================
+
+
+class TestSequentialCloseTilt:
+    def test_name(self):
+        assert SequentialCloseTilt().name == "sequential_close"
+
+    def test_is_sequential_tilt(self):
+        assert isinstance(SequentialCloseTilt(), SequentialTilt)
+
+    def test_implicit_tilt_during_travel(self):
+        assert SequentialCloseTilt().implicit_tilt_during_travel == 100
+
+    def test_tilt_command_for_closing(self):
+        from homeassistant.const import SERVICE_CLOSE_COVER
+
+        assert SequentialCloseTilt().tilt_command_for(True) == SERVICE_CLOSE_COVER
+
+    def test_tilt_command_for_opening(self):
+        from homeassistant.const import SERVICE_OPEN_COVER
+
+        assert SequentialCloseTilt().tilt_command_for(False) == SERVICE_OPEN_COVER
+
+
+# ===================================================================
+# SequentialOpenTilt (concrete, inverted direction)
+# ===================================================================
+
+
+class TestSequentialOpenTilt:
+    def test_name(self):
+        assert SequentialOpenTilt().name == "sequential_open"
+
+    def test_is_sequential_tilt(self):
+        assert isinstance(SequentialOpenTilt(), SequentialTilt)
+
+    def test_implicit_tilt_during_travel(self):
+        assert SequentialOpenTilt().implicit_tilt_during_travel == 0
+
+    def test_uses_tilt_motor(self):
+        assert SequentialOpenTilt().uses_tilt_motor is False
+
+    def test_restores_tilt(self):
+        assert SequentialOpenTilt().restores_tilt is False
+
+    def test_can_calibrate_tilt(self):
+        assert SequentialOpenTilt().can_calibrate_tilt() is True
+
+    def test_tilt_command_for_closing_returns_open(self):
+        """Inverted: closing_tilt=True sends OPEN (motor up)."""
+        from homeassistant.const import SERVICE_OPEN_COVER
+
+        assert SequentialOpenTilt().tilt_command_for(True) == SERVICE_OPEN_COVER
+
+    def test_tilt_command_for_opening_returns_close(self):
+        """Inverted: closing_tilt=False sends CLOSE (motor further down)."""
+        from homeassistant.const import SERVICE_CLOSE_COVER
+
+        assert SequentialOpenTilt().tilt_command_for(False) == SERVICE_CLOSE_COVER
+
+
+class TestSequentialOpenPlanMovePosition:
+    def test_flattens_tilt_to_zero_before_travel(self):
+        strategy = SequentialOpenTilt()
+        steps = strategy.plan_move_position(
+            target_pos=70, current_pos=0, current_tilt=80
+        )
+        assert steps == [TiltTo(0), TravelTo(70)]
+
+    def test_skips_tilt_when_already_zero(self):
+        strategy = SequentialOpenTilt()
+        steps = strategy.plan_move_position(
+            target_pos=70, current_pos=0, current_tilt=0
+        )
+        assert steps == [TravelTo(70)]
+
+
+class TestSequentialOpenPlanMoveTilt:
+    def test_travels_to_closed_before_tilting(self):
+        strategy = SequentialOpenTilt()
+        steps = strategy.plan_move_tilt(
+            target_tilt=50, current_pos=70, current_tilt=0
+        )
+        assert steps == [TravelTo(0), TiltTo(50)]
+
+    def test_tilts_directly_when_at_closed(self):
+        strategy = SequentialOpenTilt()
+        steps = strategy.plan_move_tilt(target_tilt=100, current_pos=0, current_tilt=0)
+        assert steps == [TiltTo(100)]
+
+
+class TestSequentialOpenSnapTrackers:
+    def test_forces_tilt_to_zero_when_not_at_closed(self):
+        strategy = SequentialOpenTilt()
+        travel = TravelCalculator(10.0, 10.0)
+        tilt = TravelCalculator(2.0, 2.0)
+        travel.set_position(50)
+        tilt.set_position(80)
+        strategy.snap_trackers_to_physical(travel, tilt)
+        assert tilt.current_position() == 0
+
+    def test_no_op_when_at_closed(self):
+        strategy = SequentialOpenTilt()
+        travel = TravelCalculator(10.0, 10.0)
+        tilt = TravelCalculator(2.0, 2.0)
+        travel.set_position(0)
+        tilt.set_position(50)
+        strategy.snap_trackers_to_physical(travel, tilt)
+        assert tilt.current_position() == 50
+
+    def test_no_op_when_already_zero(self):
+        strategy = SequentialOpenTilt()
+        travel = TravelCalculator(10.0, 10.0)
+        tilt = TravelCalculator(2.0, 2.0)
+        travel.set_position(30)
+        tilt.set_position(0)
+        strategy.snap_trackers_to_physical(travel, tilt)
+        assert tilt.current_position() == 0

--- a/tests/test_tilt_strategy.py
+++ b/tests/test_tilt_strategy.py
@@ -526,3 +526,38 @@ class TestHasTravelPreStep:
 
     def test_empty(self):
         assert has_travel_pre_step([]) is False
+
+
+# ===================================================================
+# TiltStrategy.tilt_command_for (default implementation)
+# ===================================================================
+
+
+class TestTiltCommandForDefault:
+    """Default tilt_command_for maps closing_tilt to the standard direction."""
+
+    def test_closing_tilt_sends_close(self):
+        from homeassistant.const import SERVICE_CLOSE_COVER
+
+        strategy = InlineTilt()
+        assert strategy.tilt_command_for(closing_tilt=True) == SERVICE_CLOSE_COVER
+
+    def test_opening_tilt_sends_open(self):
+        from homeassistant.const import SERVICE_OPEN_COVER
+
+        strategy = InlineTilt()
+        assert strategy.tilt_command_for(closing_tilt=False) == SERVICE_OPEN_COVER
+
+    def test_default_applies_to_sequential(self):
+        from homeassistant.const import SERVICE_CLOSE_COVER, SERVICE_OPEN_COVER
+
+        strategy = SequentialTilt()
+        assert strategy.tilt_command_for(True) == SERVICE_CLOSE_COVER
+        assert strategy.tilt_command_for(False) == SERVICE_OPEN_COVER
+
+    def test_default_applies_to_dual_motor(self):
+        from homeassistant.const import SERVICE_CLOSE_COVER, SERVICE_OPEN_COVER
+
+        strategy = DualMotorTilt()
+        assert strategy.tilt_command_for(True) == SERVICE_CLOSE_COVER
+        assert strategy.tilt_command_for(False) == SERVICE_OPEN_COVER

--- a/tests/test_tilt_strategy.py
+++ b/tests/test_tilt_strategy.py
@@ -66,7 +66,7 @@ class TestSequentialTiltCanCalibrate:
 
 class TestSequentialTiltProperties:
     def test_name(self):
-        assert SequentialTilt().name == "sequential"
+        assert SequentialTilt().name == "sequential_close"
 
     def test_uses_tilt_motor(self):
         assert SequentialTilt().uses_tilt_motor is False

--- a/tests/test_tilt_strategy.py
+++ b/tests/test_tilt_strategy.py
@@ -650,9 +650,7 @@ class TestSequentialOpenPlanMovePosition:
 class TestSequentialOpenPlanMoveTilt:
     def test_travels_to_closed_before_tilting(self):
         strategy = SequentialOpenTilt()
-        steps = strategy.plan_move_tilt(
-            target_tilt=50, current_pos=70, current_tilt=0
-        )
+        steps = strategy.plan_move_tilt(target_tilt=50, current_pos=70, current_tilt=0)
         assert steps == [TravelTo(0), TiltTo(50)]
 
     def test_tilts_directly_when_at_closed(self):

--- a/tests/test_websocket_api.py
+++ b/tests/test_websocket_api.py
@@ -761,6 +761,37 @@ class TestTiltModeSchemaValidation:
             )
 
 
+class TestSequentialButtonBehaviorSchemaValidation:
+    """Verify update_config schema validates sequential_button_behavior values."""
+
+    @pytest.mark.parametrize("value", ["never", "on_repeat", "one_press"])
+    def test_valid_values_accepted(self, value):
+        schema = ws_update_config._ws_schema
+        result = schema(
+            {
+                "id": 1,
+                "type": "cover_time_based/update_config",
+                "entity_id": ENTITY_ID,
+                "sequential_button_behavior": value,
+            }
+        )
+        assert result["sequential_button_behavior"] == value
+
+    def test_invalid_value_rejected(self):
+        import voluptuous as vol
+
+        schema = ws_update_config._ws_schema
+        with pytest.raises(vol.Invalid):
+            schema(
+                {
+                    "id": 1,
+                    "type": "cover_time_based/update_config",
+                    "entity_id": ENTITY_ID,
+                    "sequential_button_behavior": "bogus",
+                }
+            )
+
+
 # ---------------------------------------------------------------------------
 # ws_update_config — timing field validation
 # ---------------------------------------------------------------------------

--- a/tests/test_websocket_api.py
+++ b/tests/test_websocket_api.py
@@ -384,6 +384,106 @@ class TestDualMotorFieldRoundTrip:
         assert result["tilt_close_switch"] is None
         assert result["tilt_stop_switch"] is None
 
+    @pytest.mark.asyncio
+    async def test_get_config_returns_sequential_button_behavior(self):
+        """Stored sequential_button_behavior is returned to the UI."""
+        hass = MagicMock()
+        connection = MagicMock()
+        config_entry = MagicMock()
+        config_entry.entry_id = ENTRY_ID
+        config_entry.domain = DOMAIN
+        config_entry.options = {
+            "tilt_mode": "sequential_open",
+            "sequential_button_behavior": "on_repeat",
+        }
+        msg = {"id": 1, "type": "cover_time_based/get_config", "entity_id": ENTITY_ID}
+
+        with patch(
+            "custom_components.cover_time_based.websocket_api._resolve_config_entry",
+            return_value=(config_entry, None),
+        ):
+            handler = _unwrap(ws_get_config)
+            await handler(hass, connection, msg)
+
+        result = connection.send_result.call_args[0][1]
+        assert result["sequential_button_behavior"] == "on_repeat"
+
+    @pytest.mark.asyncio
+    async def test_get_config_defaults_sequential_button_behavior(self):
+        """Missing sequential_button_behavior returns 'never' (default)."""
+        hass = MagicMock()
+        connection = MagicMock()
+        config_entry = MagicMock()
+        config_entry.entry_id = ENTRY_ID
+        config_entry.domain = DOMAIN
+        config_entry.options = {"tilt_mode": "sequential_open"}
+        msg = {"id": 1, "type": "cover_time_based/get_config", "entity_id": ENTITY_ID}
+
+        with patch(
+            "custom_components.cover_time_based.websocket_api._resolve_config_entry",
+            return_value=(config_entry, None),
+        ):
+            handler = _unwrap(ws_get_config)
+            await handler(hass, connection, msg)
+
+        result = connection.send_result.call_args[0][1]
+        assert result["sequential_button_behavior"] == "never"
+
+    @pytest.mark.asyncio
+    async def test_update_config_persists_sequential_button_behavior(self):
+        """update_config writes sequential_button_behavior to config entry options."""
+        hass = MagicMock()
+        connection = MagicMock()
+        config_entry = MagicMock()
+        config_entry.options = {"tilt_mode": "sequential_open"}
+        config_entry.domain = DOMAIN
+
+        msg = {
+            "id": 2,
+            "type": "cover_time_based/update_config",
+            "entity_id": ENTITY_ID,
+            "sequential_button_behavior": "on_repeat",
+        }
+
+        with patch(
+            "custom_components.cover_time_based.websocket_api._resolve_config_entry",
+            return_value=(config_entry, None),
+        ):
+            handler = _unwrap(ws_update_config)
+            await handler(hass, connection, msg)
+
+        new_opts = hass.config_entries.async_update_entry.call_args[1]["options"]
+        assert new_opts["sequential_button_behavior"] == "on_repeat"
+
+    @pytest.mark.asyncio
+    async def test_update_config_clears_sequential_button_behavior_on_none(self):
+        """Sending sequential_button_behavior=None removes the key from options."""
+        hass = MagicMock()
+        connection = MagicMock()
+        config_entry = MagicMock()
+        config_entry.options = {
+            "tilt_mode": "inline",
+            "sequential_button_behavior": "on_repeat",
+        }
+        config_entry.domain = DOMAIN
+
+        msg = {
+            "id": 3,
+            "type": "cover_time_based/update_config",
+            "entity_id": ENTITY_ID,
+            "sequential_button_behavior": None,
+        }
+
+        with patch(
+            "custom_components.cover_time_based.websocket_api._resolve_config_entry",
+            return_value=(config_entry, None),
+        ):
+            handler = _unwrap(ws_update_config)
+            await handler(hass, connection, msg)
+
+        new_opts = hass.config_entries.async_update_entry.call_args[1]["options"]
+        assert "sequential_button_behavior" not in new_opts
+
 
 # ---------------------------------------------------------------------------
 # ws_update_config

--- a/tests/test_websocket_api.py
+++ b/tests/test_websocket_api.py
@@ -670,14 +670,14 @@ class TestWsUpdateConfig:
                     "entity_id": ENTITY_ID,
                     "tilt_time_close": 5.0,
                     "tilt_time_open": 5.5,
-                    "tilt_mode": "sequential",
+                    "tilt_mode": "sequential_close",
                 },
             )
 
         new_options = hass.config_entries.async_update_entry.call_args[1]["options"]
         assert new_options[CONF_TILT_TIME_CLOSE] == 5.0
         assert new_options[CONF_TILT_TIME_OPEN] == 5.5
-        assert new_options[CONF_TILT_MODE] == "sequential"
+        assert new_options[CONF_TILT_MODE] == "sequential_close"
 
     @pytest.mark.asyncio
     async def test_clear_tilt_fields(self):
@@ -711,6 +711,54 @@ class TestWsUpdateConfig:
         assert CONF_TILT_TIME_CLOSE not in new_options
         assert CONF_TILT_TIME_OPEN not in new_options
         assert new_options[CONF_TILT_MODE] == "none"
+
+
+# ---------------------------------------------------------------------------
+# ws_update_config — tilt_mode schema validation
+# ---------------------------------------------------------------------------
+
+
+class TestTiltModeSchemaValidation:
+    """Verify the update_config schema accepts all tilt_mode variants the UI emits."""
+
+    @pytest.mark.parametrize(
+        "tilt_mode",
+        [
+            "none",
+            "sequential_close",
+            "sequential_open",
+            "sequential",  # legacy alias retained as defense in depth
+            "dual_motor",
+            "inline",
+        ],
+    )
+    def test_valid_tilt_modes_accepted(self, tilt_mode):
+        """Each valid tilt_mode string must pass schema validation."""
+        schema = ws_update_config._ws_schema
+        result = schema(
+            {
+                "id": 1,
+                "type": "cover_time_based/update_config",
+                "entity_id": ENTITY_ID,
+                "tilt_mode": tilt_mode,
+            }
+        )
+        assert result["tilt_mode"] == tilt_mode
+
+    def test_invalid_tilt_mode_rejected(self):
+        """Unknown tilt_mode strings must fail schema validation."""
+        import voluptuous as vol
+
+        schema = ws_update_config._ws_schema
+        with pytest.raises(vol.Invalid):
+            schema(
+                {
+                    "id": 1,
+                    "type": "cover_time_based/update_config",
+                    "entity_id": ENTITY_ID,
+                    "tilt_mode": "bogus_mode",
+                }
+            )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds a new `sequential_open` tilt mode for covers whose slats articulate by the motor driving *further down* past the cover-closed position (issue [Sese-Schneider#61](https://github.com/Sese-Schneider/ha-cover-time-based/issues/61)), and a `sequential_button_behavior` config option controlling how the main close/open buttons interact with slat articulation.

Along the way, fixed four bugs surfaced during live testing on the cover-main Docker instance.

## Features

- **Sequential tilt split into `sequential_close` and `sequential_open`.** `SequentialTilt` becomes a shared base parameterised on `implicit_tilt_during_travel` (100 for close, 0 for open) and a new `tilt_command_for(closing_tilt)` hook on `TiltStrategy` that the inverted variant overrides. Four call sites (`_async_move_tilt_to_endpoint`, `set_tilt_position`, `_start_tilt_restore`, `_start_simple_time_test`) now ask the strategy for motor direction instead of hard-coding.
- **Config migration v2 → v3.** Stored `tilt_mode: "sequential"` rewrites to `"sequential_close"`; resolver and WS schema also accept the legacy string as defense in depth.
- **`sequential_button_behavior` option** (applies to sequential_* only):
  - `"never"` (default): buttons only drive travel.
  - `"on_repeat"`: two-press UX. Second close from the resting closed state articulates slats; second open from the articulated state restores them.
  - `"one_press"`: close does travel + articulation in a single motor motion.
- **Frontend card** gains a behavior dropdown under the Tilt Mode section with descriptive hints per value, and both languages (en/pt/pl) plus the tilt-mode dropdown/hints are updated for the split.

## Bug fixes

- **External movements now couple tilt tracking for shared-motor strategies.** Physical button presses were skipping tilt planning entirely, so on sequential_open the tracker reported a 10 s movement when the motor actually ran for 14 s. The skip is now scoped to dual-motor externals only.
- **Toggle mode: same-direction pulse while traveling stops the motor** (matching toggle motor controllers that latch OFF on the second same-direction pulse). Opposite-direction pulses continue to reverse.
- **Toggle mode debounce shortened** from `pulse_time + 0.5 s` (swallowed legitimate rapid clicks) to 100 ms (handles contact bounce without impeding humans).
- **Calibration UI** allowed-attributes logic was inverted for `sequential_open` at the two closed-cover known positions; the correct set now depends on which tilt value is the strategy's resting state.

## Test plan

- [x] Full test suite: 766 pass (unit + integration), ruff clean, format applied.
- [x] Backend: per-strategy unit tests, migration tests, resolver alias tests, call-site integration tests, WS schema validation tests, WS config round-trip tests.
- [x] End-to-end integration tests for `sequential_open` covering the inverted tilt direction and uninverted travel direction.
- [x] Live manual testing on cover-main Docker instance across all three config option values and both sequential tilt modes.
- [ ] Frontend JS is not covered by automated tests; manual verification was done in a running Home Assistant instance.

## Artefacts on the branch

- Design spec: `docs/superpowers/specs/2026-04-14-inverted-sequential-tilt-design.md`
- Implementation plan: `docs/superpowers/plans/2026-04-14-inverted-sequential-tilt.md`