### PR TITLE
fix: persist cover positions to a dedicated Store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 ### Bug Fixes
 
+- **Position restore on restart:** Positions are now written to a dedicated Store whenever they stabilise (stop, `set_known_position`, movement completion) and reloaded on startup. Previously relied on HA's `RestoreEntity` state save, which misses position when shutdown is non-graceful or the entity is unavailable at save time. Store entries are cleaned up when a config entry is removed.
 - Fixed wrapped cover treating `unknown`/`unavailable` state as an external stop — stateless covers (e.g. Somfy RTS via Overkiz) now track position correctly (#59)
 - Fixed calibration direction override for tilt attributes — server now derives direction from attribute name instead of card sending position-based guess
 - Fixed calibration overhead calculation for tilt (3 steps vs 8 travel steps)

--- a/custom_components/cover_time_based/__init__.py
+++ b/custom_components/cover_time_based/__init__.py
@@ -10,6 +10,7 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
+from .position_storage import async_get_position_store
 from .websocket_api import async_register_websocket_api
 
 _LOGGER = logging.getLogger(__name__)
@@ -65,6 +66,12 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+
+async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Remove a config entry — drop its saved position."""
+    store = await async_get_position_store(hass)
+    await store.async_remove(entry.entry_id)
 
 
 async def async_update_options(hass: HomeAssistant, entry: ConfigEntry) -> None:

--- a/custom_components/cover_time_based/cover_base.py
+++ b/custom_components/cover_time_based/cover_base.py
@@ -31,6 +31,7 @@ from .travel_calculator import TravelCalculator, TravelStatus
 
 from .calibration import CalibrationState
 from .cover_calibration import CalibrationMixin
+from .position_storage import async_get_position_store
 from .const import (
     CONF_ENDPOINT_RUNON_TIME,
     CONF_MIN_MOVEMENT_TIME,
@@ -127,23 +128,52 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         """Log a debug message prefixed with the entity ID."""
         _LOGGER.debug("(%s) " + msg, self.entity_id, *args)
 
+    async def _async_load_restored_positions(self) -> tuple[int | None, int | None]:
+        """Return (position, tilt_position) for restore.
+
+        PositionStore is authoritative; RestoreEntity state is only used
+        when the Store has no record for this entry (pre-Store installs
+        or fresh entries).
+        """
+        if self._config_entry_id is not None:
+            store = await async_get_position_store(self.hass)
+            stored = await store.async_get(self._config_entry_id)
+            if stored is not None:
+                return stored.get("position"), stored.get("tilt_position")
+
+        old_state = await self.async_get_last_state()
+        self._log("async_added_to_hass :: oldState %s", old_state)
+        if old_state is None:
+            return None, None
+        return (
+            old_state.attributes.get(ATTR_CURRENT_POSITION),
+            old_state.attributes.get(ATTR_CURRENT_TILT_POSITION),
+        )
+
+    async def _async_persist_position(self) -> None:
+        """Write the current travel/tilt position to the position store."""
+        if self._config_entry_id is None:
+            return
+        data: dict[str, int] = {}
+        position = self.travel_calc.current_position()
+        if position is not None:
+            data["position"] = int(position)
+        if self._has_tilt_support():
+            tilt_position = self.tilt_calc.current_position()
+            if tilt_position is not None:
+                data["tilt_position"] = int(tilt_position)
+        store = await async_get_position_store(self.hass)
+        await store.async_save(self._config_entry_id, data)
+
     # -----------------------------------------------------------------------
     # Lifecycle
     # -----------------------------------------------------------------------
 
     async def async_added_to_hass(self):
         """Only cover's position and tilt matters."""
-        old_state = await self.async_get_last_state()
-        self._log("async_added_to_hass :: oldState %s", old_state)
-        pos = (
-            old_state.attributes.get(ATTR_CURRENT_POSITION)
-            if old_state is not None
-            else None
-        )
-        if old_state is not None and self.travel_calc is not None and pos is not None:
+        pos, tilt_pos = await self._async_load_restored_positions()
+        if self.travel_calc is not None and pos is not None:
             self.travel_calc.set_position(int(pos))
-
-            tilt_pos = old_state.attributes.get(ATTR_CURRENT_TILT_POSITION)
             if self._has_tilt_support() and tilt_pos is not None:
                 self.tilt_calc.set_position(int(tilt_pos))
 
@@ -367,6 +397,7 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
                 await self._send_tilt_stop()
         self.async_write_ha_state()
         self._last_command = None
+        await self._async_persist_position()
 
     async def async_close_cover_tilt(self, **kwargs):
         """Tilt the cover fully closed."""
@@ -403,6 +434,7 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
                 self.travel_calc, self.tilt_calc
             )
         self.async_write_ha_state()
+        await self._async_persist_position()
 
     async def set_known_tilt_position(self, **kwargs):
         """Set the tilt to a known position (0=closed, 100=open)."""
@@ -411,6 +443,7 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         position = kwargs[ATTR_TILT_POSITION]
         self.tilt_calc.set_position(position)
         self.async_write_ha_state()
+        await self._async_persist_position()
 
     # -----------------------------------------------------------------------
     # Movement orchestration
@@ -1099,6 +1132,7 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
                         self.travel_calc, self.tilt_calc
                     )
                 self._last_command = None
+                await self._async_persist_position()
                 return
 
             if self._tilt_restore_active:
@@ -1113,6 +1147,7 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
                         self.travel_calc, self.tilt_calc
                     )
                 self._last_command = None
+                await self._async_persist_position()
                 return
 
             if self._pending_travel_target is not None:
@@ -1155,6 +1190,7 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
             else:
                 await self._async_handle_command(SERVICE_STOP_COVER)
             self._last_command = None
+            await self._async_persist_position()
 
     async def _delayed_stop(self, delay):
         """Stop the relay after a delay."""

--- a/custom_components/cover_time_based/position_storage.py
+++ b/custom_components/cover_time_based/position_storage.py
@@ -44,7 +44,7 @@ class PositionStore:
         if current.get(entry_id) == data:
             return
         current[entry_id] = data
-        self._store.async_delay_save(lambda: self._data, SAVE_DELAY)
+        self._store.async_delay_save(lambda: current, SAVE_DELAY)
 
     async def async_remove(self, entry_id: str) -> None:
         """Remove an entry — writes synchronously so cleanup is durable."""
@@ -52,6 +52,12 @@ class PositionStore:
         if entry_id in current:
             del current[entry_id]
             await self._store.async_save(current)
+
+    async def async_flush(self) -> None:
+        """Force any pending debounced writes to disk."""
+        if self._data is None:
+            return
+        await self._store.async_save(self._data)
 
 
 @singleton(_DATA_STORE)

--- a/custom_components/cover_time_based/position_storage.py
+++ b/custom_components/cover_time_based/position_storage.py
@@ -1,0 +1,60 @@
+"""Dedicated storage for cover positions.
+
+HA's RestoreEntity saves state periodically (every 15 min) and at graceful
+shutdown. Positions are lost if HA is killed or the entity is unavailable
+at save time. This Store is written whenever position stabilises, so
+restore survives those cases.
+"""
+
+from __future__ import annotations
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.singleton import singleton
+from homeassistant.helpers.storage import Store
+
+from .const import DOMAIN
+
+STORAGE_KEY = f"{DOMAIN}.positions"
+STORAGE_VERSION = 1
+SAVE_DELAY = 1.0  # Coalesce bursts of saves into one disk write.
+_DATA_STORE = f"{DOMAIN}_position_store"
+
+
+class PositionStore:
+    """Persist cover positions keyed by config entry id."""
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        self._store: Store[dict[str, dict]] = Store(hass, STORAGE_VERSION, STORAGE_KEY)
+        self._data: dict[str, dict] | None = None
+
+    async def _ensure_loaded(self) -> dict[str, dict]:
+        if self._data is None:
+            self._data = await self._store.async_load() or {}
+        return self._data
+
+    async def async_get(self, entry_id: str) -> dict | None:
+        """Return stored data for an entry, or None."""
+        return (await self._ensure_loaded()).get(entry_id)
+
+    async def async_save(self, entry_id: str, data: dict[str, int]) -> None:
+        """Save entry data, debounced. Skips if nothing would change."""
+        if not data:
+            return
+        current = await self._ensure_loaded()
+        if current.get(entry_id) == data:
+            return
+        current[entry_id] = data
+        self._store.async_delay_save(lambda: self._data, SAVE_DELAY)
+
+    async def async_remove(self, entry_id: str) -> None:
+        """Remove an entry — writes synchronously so cleanup is durable."""
+        current = await self._ensure_loaded()
+        if entry_id in current:
+            del current[entry_id]
+            await self._store.async_save(current)
+
+
+@singleton(_DATA_STORE)
+async def async_get_position_store(hass: HomeAssistant) -> PositionStore:
+    """Return the per-hass singleton PositionStore."""
+    return PositionStore(hass)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@
 import asyncio
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from custom_components.cover_time_based.cover import (
     CONF_CLOSE_SWITCH_ENTITY_ID,
@@ -57,7 +57,21 @@ def make_hass():
 
 
 @pytest.fixture
-def make_cover(make_hass):
+def _mock_position_store():
+    """Stub the PositionStore so unit tests with a MagicMock hass don't hit real Store."""
+    fake = MagicMock()
+    fake.async_get = AsyncMock(return_value=None)
+    fake.async_save = AsyncMock()
+    fake.async_remove = AsyncMock()
+    with patch(
+        "custom_components.cover_time_based.cover_base.async_get_position_store",
+        AsyncMock(return_value=fake),
+    ):
+        yield fake
+
+
+@pytest.fixture
+def make_cover(make_hass, _mock_position_store):
     """Return a factory that creates the appropriate cover subclass wired to a mock hass."""
     covers = []
 

--- a/tests/integration/test_lifecycle.py
+++ b/tests/integration/test_lifecycle.py
@@ -5,9 +5,12 @@ Tests correct entity creation from config and position restore on restart.
 
 from __future__ import annotations
 
-from homeassistant.components.cover import CoverEntityFeature
-from homeassistant.core import HomeAssistant
-from pytest_homeassistant_custom_component.common import MockConfigEntry
+from homeassistant.components.cover import ATTR_CURRENT_POSITION, CoverEntityFeature
+from homeassistant.core import HomeAssistant, State
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    mock_restore_cache,
+)
 
 from .conftest import DOMAIN
 
@@ -157,3 +160,80 @@ async def test_migrate_v3_is_idempotent(hass: HomeAssistant):
     assert result is True
     assert entry.version == 3
     assert entry.options["tilt_mode"] == "sequential_close"
+
+
+async def test_state_has_position_attribute_after_movement(
+    hass: HomeAssistant, setup_input_booleans
+):
+    """After set_known_position, the HA state should expose current_position.
+
+    This is what RestoreStateData saves to disk at HA shutdown. If the
+    attribute is missing, position cannot be restored on restart.
+    """
+    options = {
+        "control_mode": "switch",
+        "open_switch_entity_id": "input_boolean.open_switch",
+        "close_switch_entity_id": "input_boolean.close_switch",
+        "travel_time_open": 30.0,
+        "travel_time_close": 30.0,
+    }
+    entry = MockConfigEntry(
+        domain=DOMAIN, version=2, title="Test Cover", data={}, options=options
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    cover = _get_cover_entity(hass)
+    await cover.set_known_position(position=37)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("cover.test_cover")
+    assert state is not None
+    assert state.attributes.get(ATTR_CURRENT_POSITION) == 37
+
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+
+async def test_position_restored_from_ha_restart(
+    hass: HomeAssistant, setup_input_booleans
+):
+    """Position is restored from RestoreStateData after a full HA restart.
+
+    Simulates a real HA restart (not just config entry reload) by seeding
+    the restore cache with a prior state, then setting up the config entry.
+    The cover should read the saved state and restore its position.
+    """
+    options = {
+        "control_mode": "switch",
+        "open_switch_entity_id": "input_boolean.open_switch",
+        "close_switch_entity_id": "input_boolean.close_switch",
+        "travel_time_open": 30.0,
+        "travel_time_close": 30.0,
+    }
+    entry = MockConfigEntry(
+        domain=DOMAIN, version=2, title="Test Cover", data={}, options=options
+    )
+    entry.add_to_hass(hass)
+
+    # Seed the restore cache as if HA had saved state before restart.
+    mock_restore_cache(
+        hass,
+        [
+            State(
+                "cover.test_cover",
+                "open",
+                {ATTR_CURRENT_POSITION: 42},
+            )
+        ],
+    )
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    cover = _get_cover_entity(hass)
+    assert cover.current_cover_position == 42
+
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()

--- a/tests/integration/test_position_store.py
+++ b/tests/integration/test_position_store.py
@@ -17,7 +17,6 @@ from homeassistant.util import dt as dt_util
 from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
     async_fire_time_changed,
-    flush_store,
 )
 
 from custom_components.cover_time_based.position_storage import (
@@ -82,7 +81,7 @@ async def _advance_time(hass: HomeAssistant, mock_time: _MockTime, seconds: floa
 async def _flush_position_store(hass: HomeAssistant) -> None:
     """Force any debounced writes from PositionStore to disk."""
     store = await async_get_position_store(hass)
-    await flush_store(store._store)
+    await store.async_flush()
 
 
 async def test_set_known_position_writes_to_store(
@@ -247,6 +246,37 @@ async def test_position_loaded_from_store_on_startup(
 
     cover = _get_cover_entity(hass)
     assert cover.current_cover_position == 73
+
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+
+async def test_tilt_position_loaded_from_store_on_startup(
+    hass: HomeAssistant, hass_storage, setup_input_booleans
+):
+    """Tilt position from the Store is restored on startup alongside travel."""
+    options = {
+        **BASIC_OPTIONS,
+        "tilt_mode": "sequential_close",
+        "tilt_time_open": 2.0,
+        "tilt_time_close": 2.0,
+    }
+    entry = _make_entry(options)
+    entry.add_to_hass(hass)
+
+    hass_storage[POSITION_STORE_KEY] = {
+        "version": 1,
+        "minor_version": 1,
+        "key": POSITION_STORE_KEY,
+        "data": {entry.entry_id: {"position": 60, "tilt_position": 25}},
+    }
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    cover = _get_cover_entity(hass)
+    assert cover.current_cover_position == 60
+    assert cover.current_cover_tilt_position == 25
 
     await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()

--- a/tests/integration/test_position_store.py
+++ b/tests/integration/test_position_store.py
@@ -1,0 +1,252 @@
+"""Integration tests for the dedicated position storage.
+
+The integration writes cover positions to its own Store so that position
+survives even when Home Assistant does not persist entity state to disk
+(e.g. non-graceful shutdown, unavailable states, intermediate crashes).
+"""
+
+from __future__ import annotations
+
+import time as time_mod
+from datetime import timedelta
+from unittest.mock import patch
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+    flush_store,
+)
+
+from custom_components.cover_time_based.position_storage import (
+    STORAGE_KEY,
+    async_get_position_store,
+)
+
+from .conftest import DOMAIN
+
+POSITION_STORE_KEY = STORAGE_KEY
+
+
+def _get_cover_entity(hass: HomeAssistant):
+    entity_comp = hass.data["entity_components"]["cover"]
+    entities = [e for e in entity_comp.entities if e.entity_id == "cover.test_cover"]
+    assert entities, "Cover entity not found"
+    return entities[0]
+
+
+def _make_entry(options):
+    return MockConfigEntry(
+        domain=DOMAIN, version=2, title="Test Cover", data={}, options=options
+    )
+
+
+BASIC_OPTIONS = {
+    "control_mode": "switch",
+    "open_switch_entity_id": "input_boolean.open_switch",
+    "close_switch_entity_id": "input_boolean.close_switch",
+    "travel_time_open": 10.0,
+    "travel_time_close": 10.0,
+    "endpoint_runon_time": 0,
+}
+
+
+class _MockTime:
+    def __init__(self):
+        self._base = time_mod.time()
+        self._offset = 0.0
+
+    def time(self):
+        return self._base + self._offset
+
+    def advance(self, seconds: float):
+        self._offset += seconds
+
+
+@pytest.fixture
+def mock_time():
+    mt = _MockTime()
+    with patch("time.time", mt.time):
+        yield mt
+
+
+async def _advance_time(hass: HomeAssistant, mock_time: _MockTime, seconds: float):
+    mock_time.advance(seconds)
+    future = dt_util.utcnow() + timedelta(seconds=seconds)
+    async_fire_time_changed(hass, future, fire_all=True)
+    await hass.async_block_till_done()
+
+
+async def _flush_position_store(hass: HomeAssistant) -> None:
+    """Force any debounced writes from PositionStore to disk."""
+    store = await async_get_position_store(hass)
+    await flush_store(store._store)
+
+
+async def test_set_known_position_writes_to_store(
+    hass: HomeAssistant, hass_storage, setup_input_booleans
+):
+    """set_known_position should persist the position to our Store."""
+    entry = _make_entry(BASIC_OPTIONS)
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    cover = _get_cover_entity(hass)
+    await cover.set_known_position(position=42)
+    await hass.async_block_till_done()
+    await _flush_position_store(hass)
+
+    stored = hass_storage.get(POSITION_STORE_KEY)
+    assert stored is not None, "Position store file was not created"
+    assert stored["data"][entry.entry_id]["position"] == 42
+
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+
+async def test_store_entry_removed_when_config_entry_removed(
+    hass: HomeAssistant, hass_storage, setup_input_booleans
+):
+    """Removing a config entry must purge its data from the position store."""
+    entry = _make_entry(BASIC_OPTIONS)
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    cover = _get_cover_entity(hass)
+    await cover.set_known_position(position=42)
+    await hass.async_block_till_done()
+    await _flush_position_store(hass)
+    assert entry.entry_id in hass_storage[POSITION_STORE_KEY]["data"]
+
+    await hass.config_entries.async_remove(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.entry_id not in hass_storage[POSITION_STORE_KEY]["data"]
+
+
+async def test_set_known_tilt_position_writes_to_store(
+    hass: HomeAssistant, hass_storage, setup_input_booleans
+):
+    """set_known_tilt_position should persist tilt to the Store."""
+    options = {
+        **BASIC_OPTIONS,
+        "tilt_mode": "sequential_close",
+        "tilt_time_open": 2.0,
+        "tilt_time_close": 2.0,
+    }
+    entry = _make_entry(options)
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    cover = _get_cover_entity(hass)
+    await cover.set_known_position(position=50)
+    await cover.set_known_tilt_position(tilt_position=30)
+    await hass.async_block_till_done()
+    await _flush_position_store(hass)
+
+    stored = hass_storage[POSITION_STORE_KEY]["data"][entry.entry_id]
+    assert stored["position"] == 50
+    assert stored["tilt_position"] == 30
+
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+
+async def test_movement_completion_writes_to_store(
+    hass: HomeAssistant, hass_storage, setup_input_booleans, mock_time
+):
+    """When a movement finishes at an endpoint, position should be saved."""
+    entry = _make_entry(BASIC_OPTIONS)
+    entry.add_to_hass(hass)
+    hass_storage[POSITION_STORE_KEY] = {
+        "version": 1,
+        "minor_version": 1,
+        "key": POSITION_STORE_KEY,
+        "data": {entry.entry_id: {"position": 0}},
+    }
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    cover = _get_cover_entity(hass)
+    assert cover.current_cover_position == 0
+
+    await cover.async_open_cover()
+    await hass.async_block_till_done()
+
+    # Advance past full travel — auto-stop should fire and persist.
+    await _advance_time(hass, mock_time, 11.0)
+    await _flush_position_store(hass)
+
+    assert cover.current_cover_position == 100
+    assert hass_storage[POSITION_STORE_KEY]["data"][entry.entry_id]["position"] == 100
+
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+
+async def test_mid_movement_stop_writes_to_store(
+    hass: HomeAssistant, hass_storage, setup_input_booleans, mock_time
+):
+    """Stopping mid-travel should save the intermediate position."""
+    entry = _make_entry(BASIC_OPTIONS)
+    entry.add_to_hass(hass)
+    hass_storage[POSITION_STORE_KEY] = {
+        "version": 1,
+        "minor_version": 1,
+        "key": POSITION_STORE_KEY,
+        "data": {entry.entry_id: {"position": 0}},
+    }
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    cover = _get_cover_entity(hass)
+    assert cover.current_cover_position == 0
+
+    await cover.async_open_cover()
+    await hass.async_block_till_done()
+
+    await _advance_time(hass, mock_time, 3.0)
+    await cover.async_stop_cover()
+    await hass.async_block_till_done()
+    await _flush_position_store(hass)
+
+    saved = hass_storage[POSITION_STORE_KEY]["data"][entry.entry_id]["position"]
+    assert 10 <= saved <= 50, f"Expected mid-travel position, got {saved}"
+
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+
+async def test_position_loaded_from_store_on_startup(
+    hass: HomeAssistant, hass_storage, setup_input_booleans
+):
+    """When the Store has a position, the cover should use it on startup.
+
+    HA's async_get_last_state is cleared to simulate the production failure
+    mode where HA never persisted the state (non-graceful shutdown). The
+    Store must be the authoritative source in that case.
+    """
+    entry = _make_entry(BASIC_OPTIONS)
+    entry.add_to_hass(hass)
+
+    hass_storage[POSITION_STORE_KEY] = {
+        "version": 1,
+        "minor_version": 1,
+        "key": POSITION_STORE_KEY,
+        "data": {entry.entry_id: {"position": 73}},
+    }
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    cover = _get_cover_entity(hass)
+    assert cover.current_cover_position == 73
+
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()


### PR DESCRIPTION
## Summary

- Positions previously relied on HA's `RestoreEntity` state save, which misses them after non-graceful shutdowns (SIGKILL after stop-timeout, container crash, power loss) or when the entity is in an `unavailable` state at save time.
- A dedicated `PositionStore` (`.storage/cover_time_based.positions`, keyed by config entry ID) is now written on every movement stop (`async_stop_cover`, all terminal branches of `auto_stop_if_necessary`, `set_known_position`, `set_known_tilt_position`) and read from on startup.
- Writes go through `Store.async_delay_save` (1s debounce) so bursts coalesce, and HA's final-write listener guarantees a flush on shutdown.
- Store entries are purged via `async_remove_entry` when a config entry is deleted.
- The existing `RestoreEntity` state is still used as a fallback for entries that pre-date this change.

## Test plan

- [x] `pytest tests/` — 707 passing
- [x] New integration tests in `tests/integration/test_position_store.py`:
  - `set_known_position` / `set_known_tilt_position` write to the Store
  - Mid-travel stop persists the intermediate position
  - Full-travel completion persists the endpoint position
  - Store takes precedence over `async_get_last_state` on startup (position and tilt)
  - Config entry removal purges the Store entry
- [x] New regression tests in `tests/integration/test_lifecycle.py` covering the `RestoreEntity` fallback path