### PR TITLE
fix: use configured tilt_mode for calibration before tilt times are set (#61)

### DIFF
--- a/custom_components/cover_time_based/cover.py
+++ b/custom_components/cover_time_based/cover.py
@@ -299,6 +299,7 @@ def _create_cover_from_options(options, device_id="", name=""):
         device_id=device_id,
         name=name,
         tilt_strategy=tilt_strategy,
+        tilt_mode_str=tilt_mode_str,
         travel_time_close=options.get(CONF_TRAVEL_TIME_CLOSE),
         travel_time_open=options.get(CONF_TRAVEL_TIME_OPEN),
         tilt_time_close=options.get(CONF_TILT_TIME_CLOSE),

--- a/custom_components/cover_time_based/cover_base.py
+++ b/custom_components/cover_time_based/cover_base.py
@@ -73,11 +73,15 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         tilt_open_switch=None,
         tilt_close_switch=None,
         tilt_stop_switch=None,
+        tilt_mode_str="none",
     ):
         """Initialize the cover."""
         self._unique_id = device_id
 
         self._tilt_strategy = tilt_strategy
+        # Keep the raw configured mode so calibration can still pick the right
+        # relay before tilt times are set (when _tilt_strategy is None).
+        self._tilt_mode_str = tilt_mode_str
         self._travel_time_close = travel_time_close
         self._travel_time_open = travel_time_open
         self._tilting_time_close = tilt_time_close

--- a/custom_components/cover_time_based/cover_calibration.py
+++ b/custom_components/cover_time_based/cover_calibration.py
@@ -118,15 +118,30 @@ class CalibrationMixin:
         assert self._calibration is not None
         if direction:
             move_command = self._resolve_direction(direction, None)
-        elif attribute.startswith("tilt_") and self._tilt_strategy is not None:
+        elif attribute.startswith("tilt_"):
             closing_tilt = "close" in attribute
-            move_command = self._tilt_strategy.tilt_command_for(closing_tilt)
+            move_command = self._tilt_calibration_command(closing_tilt)
         elif "close" in attribute:
             move_command = SERVICE_CLOSE_COVER
         else:
             move_command = SERVICE_OPEN_COVER
         self._calibration.move_command = move_command
         await self._async_handle_command(move_command)
+
+    def _tilt_calibration_command(self, closing_tilt: bool) -> str:
+        """Resolve the relay direction for tilt calibration.
+
+        Prefers the live tilt strategy, but falls back to the raw configured
+        tilt_mode string when the strategy hasn't been resolved yet — this
+        happens before both tilt times are set, i.e. during first-time
+        calibration. Without this fallback sequential_open would send the
+        sequential_close-shaped default (issue #61).
+        """
+        if self._tilt_strategy is not None:
+            return self._tilt_strategy.tilt_command_for(closing_tilt)
+        if getattr(self, "_tilt_mode_str", None) == "sequential_open":
+            return SERVICE_OPEN_COVER if closing_tilt else SERVICE_CLOSE_COVER
+        return SERVICE_CLOSE_COVER if closing_tilt else SERVICE_OPEN_COVER
 
     async def _start_overhead_test(self, attribute, direction):
         """Start automated step test for motor overhead."""

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -272,6 +272,73 @@ class TestCalibrationTiltTime:
 
             await cover.stop_calibration(cancel=True)
 
+    @pytest.mark.asyncio
+    async def test_sequential_open_tilt_time_close_without_tilt_times_set(
+        self, make_cover
+    ):
+        """First-time tilt_time_close calibration on sequential_open must press OPEN.
+
+        When the user configures tilt_mode=sequential_open but hasn't yet
+        calibrated either tilt time, _tilt_strategy resolves to None (because
+        has_tilt_times=False).  The calibration dispatch must still consult
+        tilt_mode to pick the correct relay — otherwise it falls back to the
+        SequentialCloseTilt-shaped default (tilt_time_close → CLOSE relay),
+        which is inverted for sequential_open.  Reported in issue #61 after
+        beta.3: user saw `down` relay fire when calibrating tilt_time_close
+        with mode "Closes then tilts open".
+        """
+        cover = make_cover(
+            travel_time_open=10.0,
+            travel_time_close=10.0,
+            # Neither tilt time set — user is calibrating for the first time.
+            tilt_mode="sequential_open",
+        )
+        cover.travel_calc.set_position(0)
+
+        with patch.object(cover, "async_write_ha_state"):
+            await cover.start_calibration(attribute="tilt_time_close", timeout=60.0)
+
+            turn_on_calls = [
+                c
+                for c in cover.hass.services.async_call.call_args_list
+                if c[0][0] == "homeassistant" and c[0][1] == "turn_on"
+            ]
+            activated = [c[0][2]["entity_id"] for c in turn_on_calls]
+            assert cover._open_switch_entity_id in activated, (
+                f"expected OPEN relay, got {activated}"
+            )
+            assert cover._close_switch_entity_id not in activated
+
+            await cover.stop_calibration(cancel=True)
+
+    @pytest.mark.asyncio
+    async def test_sequential_open_tilt_time_open_without_tilt_times_set(
+        self, make_cover
+    ):
+        """First-time tilt_time_open calibration on sequential_open must press CLOSE."""
+        cover = make_cover(
+            travel_time_open=10.0,
+            travel_time_close=10.0,
+            tilt_mode="sequential_open",
+        )
+        cover.travel_calc.set_position(0)
+
+        with patch.object(cover, "async_write_ha_state"):
+            await cover.start_calibration(attribute="tilt_time_open", timeout=60.0)
+
+            turn_on_calls = [
+                c
+                for c in cover.hass.services.async_call.call_args_list
+                if c[0][0] == "homeassistant" and c[0][1] == "turn_on"
+            ]
+            activated = [c[0][2]["entity_id"] for c in turn_on_calls]
+            assert cover._close_switch_entity_id in activated, (
+                f"expected CLOSE relay, got {activated}"
+            )
+            assert cover._open_switch_entity_id not in activated
+
+            await cover.stop_calibration(cancel=True)
+
 
 class TestMotorOverheadCalibration:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Follow-up fix for #63. The sequential_open tilt mode shipped in #61 was sending the wrong relay when users calibrated tilt times for the first time.

## Root cause

`_resolve_tilt_strategy` returns `None` whenever either `tilt_time_close` or `tilt_time_open` isn't configured. Calibration dispatch in `_start_simple_time_test` only consulted `tilt_command_for()` when `_tilt_strategy is not None` — otherwise it fell through to a `sequential_close`-shaped default:

- `tilt_time_close` → `SERVICE_CLOSE_COVER`
- `tilt_time_open` → `SERVICE_OPEN_COVER`

For `sequential_open` this is inverted (slats close by motor up, articulate open by motor down), so first-time calibration fired the wrong relay. `sequential_close` users never noticed because the fallback matched their mode by coincidence.

## Fix

Store the raw `tilt_mode` string on the entity so calibration can consult it even before the strategy resolves. New helper `_tilt_calibration_command` uses the live strategy when available, else falls back on the stored mode string (`sequential_open` inverts, everything else matches the previous default).

## Test plan

- [x] Two new regression tests in `TestCalibrationTiltTime` cover first-time `sequential_open` calibration with neither tilt time configured — both failed before the fix (`expected OPEN relay, got ['switch.close']`) and pass after.
- [x] Full suite: 769 passed.
- [ ] Manual test on reporter's hardware (issue #61 follow-up).