### PR TITLE
fix: register card JS at integration load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Bug Fixes
+
+- Card JS is now registered when the integration loads, not when the first config entry is set up, so dashboards referencing `custom:cover-time-based-card` render correctly even before any cover_time_based entity exists.
+
 ### Features
 
 - **Sequential tilt split into two variants:** `sequential_close` (conventional — slats close when the motor drives further down past cover-closed) and `sequential_open` (for covers where slats *open* by driving further down past cover-closed, e.g. certain tilting shutters). Existing `sequential` configs auto-migrate to `sequential_close` (issue #61). On sequential modes, external close (physical switch or automation) tracks the full motor journey — travel then articulate — assuming the motor runs past cover-closed to the mechanical end. HA UI buttons remain travel-only for `close`/`open` and tilt-only for `close_tilt`/`open_tilt`.

--- a/custom_components/cover_time_based/__init__.py
+++ b/custom_components/cover_time_based/__init__.py
@@ -8,6 +8,7 @@ from homeassistant.components.http import StaticPathConfig
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN
 from .position_storage import async_get_position_store
@@ -15,33 +16,28 @@ from .websocket_api import async_register_websocket_api
 
 _LOGGER = logging.getLogger(__name__)
 PLATFORMS: list[Platform] = [Platform.COVER]
-_FRONTEND_KEY = f"{DOMAIN}_frontend_registered"
+_PANEL_URL = f"/{DOMAIN}_panel"
+_CARD_JS_URL = f"{_PANEL_URL}/cover-time-based-card.js"
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Register the Lovelace card and WebSocket API once per HA session."""
+    async_register_websocket_api(hass)
+    await hass.http.async_register_static_paths(
+        [
+            StaticPathConfig(
+                _PANEL_URL,
+                str(Path(__file__).parent / "frontend"),
+                cache_headers=False,
+            )
+        ]
+    )
+    frontend.add_extra_js_url(hass, _CARD_JS_URL)
+    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Cover Time Based from a config entry."""
-    # Register frontend and WebSocket API once (not per entry).
-    # Done before platform setup so the card works even if the entity fails.
-    if _FRONTEND_KEY not in hass.data:
-        hass.data[_FRONTEND_KEY] = True
-
-        async_register_websocket_api(hass)
-
-        if hass.http is not None:
-            await hass.http.async_register_static_paths(
-                [
-                    StaticPathConfig(
-                        "/cover_time_based_panel",
-                        str(Path(__file__).parent / "frontend"),
-                        cache_headers=False,
-                    )
-                ]
-            )
-
-            frontend.add_extra_js_url(
-                hass, "/cover_time_based_panel/cover-time-based-card.js"
-            )
-
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(async_update_options))
 

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -1,6 +1,10 @@
 """Smoke test: verify integration loads and creates an entity."""
 
+from homeassistant.components.frontend import DATA_EXTRA_MODULE_URL
 from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from .conftest import DOMAIN
 
 
 async def test_integration_loads(hass: HomeAssistant, setup_cover):
@@ -8,3 +12,16 @@ async def test_integration_loads(hass: HomeAssistant, setup_cover):
     state = hass.states.get("cover.test_cover")
     assert state is not None
     assert state.state in ("open", "closed", "unknown")
+
+
+async def test_card_js_registered_without_config_entry(hass: HomeAssistant):
+    """Card JS URL is registered when the integration loads, even with zero entries.
+
+    Users with dashboard cards referencing custom:cover-time-based-card need
+    the JS available regardless of whether any cover_time_based entity exists.
+    """
+    assert await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+
+    urls = hass.data[DATA_EXTRA_MODULE_URL].urls
+    assert any("cover-time-based-card.js" in url for url in urls)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,11 +1,10 @@
 """Tests for __init__.py integration setup/teardown."""
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock
-
-from homeassistant.components.frontend import DATA_EXTRA_MODULE_URL
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from custom_components.cover_time_based import (
+    async_setup,
     async_setup_entry,
     async_unload_entry,
     async_update_options,
@@ -18,9 +17,7 @@ class TestIntegrationSetup:
     @pytest.mark.asyncio
     async def test_setup_entry_forwards_platforms(self):
         hass = MagicMock()
-        hass.data = {DATA_EXTRA_MODULE_URL: set()}
         hass.config_entries.async_forward_entry_setups = AsyncMock()
-        hass.http.async_register_static_paths = AsyncMock()
         entry = MagicMock()
         entry.async_on_unload = MagicMock()
         entry.add_update_listener = MagicMock()
@@ -30,6 +27,66 @@ class TestIntegrationSetup:
         assert result is True
         hass.config_entries.async_forward_entry_setups.assert_awaited_once()
         entry.async_on_unload.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_setup_entry_does_not_register_frontend(self):
+        """Frontend is registered by async_setup, not per-entry."""
+        hass = MagicMock()
+        hass.config_entries.async_forward_entry_setups = AsyncMock()
+        hass.http.async_register_static_paths = AsyncMock()
+        entry = MagicMock()
+        entry.async_on_unload = MagicMock()
+        entry.add_update_listener = MagicMock()
+
+        with (
+            patch("homeassistant.components.frontend.add_extra_js_url") as mock_add_js,
+            patch(
+                "custom_components.cover_time_based.async_register_websocket_api"
+            ) as mock_reg_ws,
+        ):
+            await async_setup_entry(hass, entry)
+
+        mock_add_js.assert_not_called()
+        mock_reg_ws.assert_not_called()
+        hass.http.async_register_static_paths.assert_not_awaited()
+
+
+class TestGlobalSetup:
+    """Tests for async_setup — runs once when the integration loads."""
+
+    @pytest.mark.asyncio
+    async def test_setup_registers_websocket_api(self):
+        hass = MagicMock()
+        hass.http.async_register_static_paths = AsyncMock()
+
+        with (
+            patch(
+                "custom_components.cover_time_based.async_register_websocket_api"
+            ) as mock_reg_ws,
+            patch("homeassistant.components.frontend.add_extra_js_url"),
+        ):
+            result = await async_setup(hass, {})
+
+        assert result is True
+        mock_reg_ws.assert_called_once_with(hass)
+
+    @pytest.mark.asyncio
+    async def test_setup_registers_static_path_and_card_js(self):
+        hass = MagicMock()
+        hass.http.async_register_static_paths = AsyncMock()
+
+        with patch("homeassistant.components.frontend.add_extra_js_url") as mock_add_js:
+            result = await async_setup(hass, {})
+
+        assert result is True
+        hass.http.async_register_static_paths.assert_awaited_once()
+        mock_add_js.assert_called_once()
+        _, js_url = mock_add_js.call_args.args
+        assert js_url.endswith("/cover-time-based-card.js")
+
+
+class TestIntegrationTeardown:
+    """Test the integration teardown."""
 
     @pytest.mark.asyncio
     async def test_unload_entry_unloads_platforms(self):


### PR DESCRIPTION
## Summary

- Moves Lovelace card JS + WebSocket API registration from `async_setup_entry` to a new `async_setup` in `__init__.py`, so the card renders on dashboards even before any `cover_time_based` config entry exists.
- Previously, a dashboard referencing `custom:cover-time-based-card` displayed a configuration error until the first entity was created — the JS wasn't loaded because `async_setup_entry` hadn't run yet.
- Drops the now-redundant `_FRONTEND_KEY` idempotency guard and `hass.http is not None` branch (HA calls `async_setup` exactly once and guarantees `hass.http` is ready via the `http` dependency in the manifest). Extracts the two hand-rolled URL strings to module constants derived from `DOMAIN`.

## Test plan

- [x] New unit tests in `tests/test_init.py` covering `async_setup` registers the WebSocket API, static path, and card JS URL
- [x] New unit test verifies `async_setup_entry` no longer touches frontend resources
- [x] New integration test `tests/integration/test_smoke.py::test_card_js_registered_without_config_entry` loads the integration with zero config entries and asserts `cover-time-based-card.js` is in `hass.data[DATA_EXTRA_MODULE_URL].urls`
- [x] Full suite: 773 passed