### PR TITLE
fix: skip endpoint run-on at closed endpoint for sequential tilt modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 ### Bug Fixes
 
+- Endpoint run-on is now skipped at the closed (0%) endpoint under `sequential_close` and `sequential_open` tilt modes, where the motor is already driven past cover-closed for the tilt phase. Run-on still applies at the open (100%) endpoint.
 - **Position restore on restart:** Positions are now written to a dedicated Store whenever they stabilise (stop, `set_known_position`, movement completion) and reloaded on startup. Previously relied on HA's `RestoreEntity` state save, which misses position when shutdown is non-graceful or the entity is unavailable at save time. Store entries are cleaned up when a config entry is removed.
 - Fixed wrapped cover treating `unknown`/`unavailable` state as an external stop — stateless covers (e.g. Somfy RTS via Overkiz) now track position correctly (#59)
 - Fixed calibration direction override for tilt attributes — server now derives direction from attribute name instead of card sending position-based guess

--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ Recommended values: 0.05 - 0.15 seconds. Can be configured separately for travel
 
 Position tracking is not exact and can drift over time. To reduce drift, the position tracker resyncs itself whenever the cover is sent to the 0% or 100% endpoints. The motor continues running for the number of seconds specified in the **Endpoint Run-on Time** in case the physical cover hasn't quite reached the endpoint. Defaults to 2s.
 
+Under the **sequential closes-then-tilts-closed** and **sequential closes-then-tilts-open** tilt modes, run-on is skipped at the closed (0%) endpoint, because the motor is already driven past cover-closed for the tilt phase. Run-on still applies at the open (100%) endpoint.
+
 #### Min movement time
 
 Prevents position drift by blocking relay activations too brief to physically move the cover. Movements to 0% or 100% are always allowed. Recommended values: 0.5 - 1.5 seconds.

--- a/custom_components/cover_time_based/cover_base.py
+++ b/custom_components/cover_time_based/cover_base.py
@@ -1173,10 +1173,15 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
                 return
 
             current_travel = self.travel_calc.current_position()
+            runon_allowed_by_strategy = (
+                self._tilt_strategy is None
+                or self._tilt_strategy.allows_endpoint_runon(current_travel)
+            )
             if (
                 self._endpoint_runon_time is not None
                 and self._endpoint_runon_time > 0
                 and current_travel in (0, 100)
+                and runon_allowed_by_strategy
             ):
                 self._log(
                     "auto_stop_if_necessary :: at endpoint (position=%d),"

--- a/custom_components/cover_time_based/cover_base.py
+++ b/custom_components/cover_time_based/cover_base.py
@@ -1173,15 +1173,15 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
                 return
 
             current_travel = self.travel_calc.current_position()
-            runon_allowed_by_strategy = (
-                self._tilt_strategy is None
-                or self._tilt_strategy.allows_endpoint_runon(current_travel)
-            )
             if (
                 self._endpoint_runon_time is not None
                 and self._endpoint_runon_time > 0
+                and current_travel is not None
                 and current_travel in (0, 100)
-                and runon_allowed_by_strategy
+                and (
+                    self._tilt_strategy is None
+                    or self._tilt_strategy.allows_endpoint_runon(current_travel)
+                )
             ):
                 self._log(
                     "auto_stop_if_necessary :: at endpoint (position=%d),"

--- a/custom_components/cover_time_based/tilt_strategies/base.py
+++ b/custom_components/cover_time_based/tilt_strategies/base.py
@@ -78,6 +78,15 @@ class TiltStrategy(ABC):
         """Whether tilt is allowed at the given cover position."""
         return True
 
+    def allows_endpoint_runon(self, _position: int) -> bool:
+        """Whether endpoint run-on should fire at the given endpoint.
+
+        Strategies that run a tilt phase at an endpoint (e.g. sequential
+        modes at position 0) should return False there, so that run-on
+        does not extend the motor beyond the tilt phase.
+        """
+        return True
+
     def tilt_command_for(self, closing_tilt: bool) -> str:
         """Return the HA cover service to send for this tilt direction.
 

--- a/custom_components/cover_time_based/tilt_strategies/sequential.py
+++ b/custom_components/cover_time_based/tilt_strategies/sequential.py
@@ -72,6 +72,12 @@ class SequentialTilt(TiltStrategy):
         steps.append(TiltTo(target_tilt))
         return steps
 
+    def allows_endpoint_runon(self, position: int) -> bool:
+        # At position 0 sequential modes run a tilt phase (TiltTo after
+        # TravelTo(0)). Run-on there would keep the motor driving after
+        # that tilt phase completes, adding unwanted motor travel.
+        return position != 0
+
     def snap_trackers_to_physical(self, travel_calc, tilt_calc):
         current_travel = travel_calc.current_position()
         current_tilt_pos = tilt_calc.current_position()

--- a/custom_components/cover_time_based/tilt_strategies/sequential.py
+++ b/custom_components/cover_time_based/tilt_strategies/sequential.py
@@ -73,9 +73,11 @@ class SequentialTilt(TiltStrategy):
         return steps
 
     def allows_endpoint_runon(self, position: int) -> bool:
-        # At position 0 sequential modes run a tilt phase (TiltTo after
-        # TravelTo(0)). Run-on there would keep the motor driving after
-        # that tilt phase completes, adding unwanted motor travel.
+        # Run-on at position 0 would drive the motor further down past
+        # cover-closed — which for sequential modes is a slat-articulation
+        # direction (tilt-close for sequential_close; tilt-open for
+        # sequential_open). Blocking here is correct for both the post-
+        # TiltTo(0) case and for a bare TravelTo(0) with no trailing tilt.
         return position != 0
 
     def snap_trackers_to_physical(self, travel_calc, tilt_calc):

--- a/tests/test_base_movement.py
+++ b/tests/test_base_movement.py
@@ -758,6 +758,84 @@ class TestRelayDelayAtEnd:
         # startup delay task was created rather than is_traveling)
         assert cover._startup_delay_task is not None or cover.travel_calc.is_traveling()
 
+    @pytest.mark.asyncio
+    async def test_no_runon_at_closed_for_sequential_close(self, make_cover):
+        """Sequential close-tilt runs a tilt phase at position 0.
+
+        Run-on there would extend the motor past the tilt phase, so
+        the relay should stop immediately at the closed endpoint.
+        """
+        cover = make_cover(
+            tilt_time_close=5.0,
+            tilt_time_open=5.0,
+            tilt_mode="sequential_close",
+            endpoint_runon_time=4.0,
+        )
+        cover.travel_calc.set_position(0)
+        cover.travel_calc.start_travel(0)
+        cover.travel_calc.set_position(0)
+
+        with patch.object(cover, "async_write_ha_state"):
+            await cover.auto_stop_if_necessary()
+
+        assert cover._delay_task is None
+
+    @pytest.mark.asyncio
+    async def test_runon_at_open_for_sequential_close(self, make_cover):
+        """Open endpoint has no trailing tilt phase — run-on still applies."""
+        cover = make_cover(
+            tilt_time_close=5.0,
+            tilt_time_open=5.0,
+            tilt_mode="sequential_close",
+            endpoint_runon_time=4.0,
+        )
+        cover.travel_calc.set_position(0)
+        cover.travel_calc.start_travel(100)
+        cover.travel_calc.set_position(100)
+
+        with patch.object(cover, "async_write_ha_state"):
+            await cover.auto_stop_if_necessary()
+
+        assert cover._delay_task is not None
+        cover._delay_task.cancel()
+
+    @pytest.mark.asyncio
+    async def test_no_runon_at_closed_for_sequential_open(self, make_cover):
+        """Sequential open-tilt also runs a tilt phase at position 0."""
+        cover = make_cover(
+            tilt_time_close=5.0,
+            tilt_time_open=5.0,
+            tilt_mode="sequential_open",
+            endpoint_runon_time=4.0,
+        )
+        cover.travel_calc.set_position(0)
+        cover.travel_calc.start_travel(0)
+        cover.travel_calc.set_position(0)
+
+        with patch.object(cover, "async_write_ha_state"):
+            await cover.auto_stop_if_necessary()
+
+        assert cover._delay_task is None
+
+    @pytest.mark.asyncio
+    async def test_runon_at_open_for_sequential_open(self, make_cover):
+        """Open endpoint has no trailing tilt phase — run-on still applies."""
+        cover = make_cover(
+            tilt_time_close=5.0,
+            tilt_time_open=5.0,
+            tilt_mode="sequential_open",
+            endpoint_runon_time=4.0,
+        )
+        cover.travel_calc.set_position(0)
+        cover.travel_calc.start_travel(100)
+        cover.travel_calc.set_position(100)
+
+        with patch.object(cover, "async_write_ha_state"):
+            await cover.auto_stop_if_necessary()
+
+        assert cover._delay_task is not None
+        cover._delay_task.cancel()
+
 
 # ===================================================================
 # Stop cover

--- a/tests/test_tilt_strategy.py
+++ b/tests/test_tilt_strategy.py
@@ -80,6 +80,33 @@ class TestSequentialTiltProperties:
         assert SequentialTilt().implicit_tilt_during_travel == 100
 
 
+class TestSequentialAllowsEndpointRunon:
+    """Sequential tilt modes execute a tilt phase at position 0.
+
+    Run-on at the closed endpoint would keep the motor running after
+    that tilt phase, adding unwanted motor travel. The open endpoint
+    has no trailing tilt phase, so run-on is allowed there.
+    """
+
+    def test_disallowed_at_closed_endpoint(self):
+        assert SequentialTilt().allows_endpoint_runon(0) is False
+
+    def test_allowed_at_open_endpoint(self):
+        assert SequentialTilt().allows_endpoint_runon(100) is True
+
+    def test_sequential_close_disallowed_at_closed(self):
+        assert SequentialCloseTilt().allows_endpoint_runon(0) is False
+
+    def test_sequential_close_allowed_at_open(self):
+        assert SequentialCloseTilt().allows_endpoint_runon(100) is True
+
+    def test_sequential_open_disallowed_at_closed(self):
+        assert SequentialOpenTilt().allows_endpoint_runon(0) is False
+
+    def test_sequential_open_allowed_at_open(self):
+        assert SequentialOpenTilt().allows_endpoint_runon(100) is True
+
+
 class TestSequentialPlanMovePosition:
     def test_flattens_tilt_before_travel(self):
         strategy = SequentialTilt()
@@ -216,6 +243,16 @@ class TestDualMotorTiltProperties:
 
     def test_restores_tilt(self):
         assert DualMotorTilt().restores_tilt is True
+
+
+class TestDualMotorAllowsEndpointRunon:
+    """Dual-motor uses a separate tilt motor — travel run-on not affected."""
+
+    def test_allowed_at_closed(self):
+        assert DualMotorTilt().allows_endpoint_runon(0) is True
+
+    def test_allowed_at_open(self):
+        assert DualMotorTilt().allows_endpoint_runon(100) is True
 
 
 class TestDualMotorPlanMovePosition:
@@ -384,6 +421,16 @@ class TestInlineTiltProperties:
 
     def test_can_calibrate_tilt(self):
         assert InlineTilt().can_calibrate_tilt() is True
+
+
+class TestInlineAllowsEndpointRunon:
+    """Inline tilt has no trailing tilt phase at endpoints — run-on allowed."""
+
+    def test_allowed_at_closed(self):
+        assert InlineTilt().allows_endpoint_runon(0) is True
+
+    def test_allowed_at_open(self):
+        assert InlineTilt().allows_endpoint_runon(100) is True
 
 
 class TestInlinePlanMovePosition:


### PR DESCRIPTION
## Summary

- Under `sequential_close` and `sequential_open` tilt modes, closing the cover runs `[TravelTo(0), TiltTo(target_tilt)]`. Once the tilt phase completes at position 0, endpoint run-on was firing and continuing to drive the motor for another N seconds — extending the motor past the just-completed tilt.
- Fix: `TiltStrategy` now exposes `allows_endpoint_runon(position)` (default `True`); `SequentialTilt` overrides it to return `False` at position 0. `cover_base.auto_stop_if_necessary` consults this before starting the run-on delay.
- Run-on at the open endpoint (100%) is unchanged — no trailing tilt phase there.

## Test plan

- [x] New unit tests in `tests/test_tilt_strategy.py` cover `allows_endpoint_runon` for `SequentialTilt`, `SequentialCloseTilt`, `SequentialOpenTilt`, `InlineTilt`, `DualMotorTilt`.
- [x] New `TestRelayDelayAtEnd` cases in `tests/test_base_movement.py` verify no delay task at position 0 and delay task at position 100 for both sequential variants.
- [x] Existing run-on tests (no tilt / inline / dual-motor) still green — full suite: 781 passed.