### PR TITLE
fix: filter orphaned cover entities from configuration card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Bug Fixes
 
+- Configuration card no longer lists orphaned cover entities whose config entry has been deleted (HA's "this device is no longer provided by this integration" state). The entity-registry filter now cross-checks against the live `config_entries/get` list and excludes entries pointing at a non-existent config entry.
 - Card JS is now registered when the integration loads, not when the first config entry is set up, so dashboards referencing `custom:cover-time-based-card` render correctly even before any cover_time_based entity exists.
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Click here:
 
 The configuration card provides a visual interface for all settings and supports built-in calibration to measure timing parameters automatically.
 
+> **Create at least one cover first.** The configuration card is delivered as a frontend asset of this integration, and Home Assistant only loads an integration's frontend assets once the integration is loaded — which requires at least one config entry to exist. If you add the card to a dashboard before creating any cover, Lovelace will show a red **Configuration error** ("custom element doesn't exist: cover-time-based-card"). Create a cover via the steps above, then add the card.
+
 1. Go to **Settings → Dashboards**.
 2. Click **Add dashboard → New dashboard from scratch**.
 3. Fill in a name and make sure **Add to sidebar** is selected.

--- a/custom_components/cover_time_based/frontend/cover-time-based-card.js
+++ b/custom_components/cover_time_based/frontend/cover-time-based-card.js
@@ -448,7 +448,10 @@ class CoverTimeBasedCard extends LitElement {
       );
       this.requestUpdate();
     } catch (err) {
-      console.error("Failed to load entity registry:", err);
+      console.error(
+        "Failed to load entity registry / config entries:",
+        err
+      );
       this._configEntryEntities = [];
     }
   }

--- a/custom_components/cover_time_based/frontend/cover-time-based-card.js
+++ b/custom_components/cover_time_based/frontend/cover-time-based-card.js
@@ -13,6 +13,7 @@ import {
   html,
   css,
 } from "https://unpkg.com/lit-element@2.4.0/lit-element.js?module";
+import { filterEntitiesByValidEntries } from "./entity-filter.js";
 
 const DOMAIN = "cover_time_based";
 
@@ -435,12 +436,16 @@ class CoverTimeBasedCard extends LitElement {
   async _loadEntityList() {
     if (!this.hass) return;
     try {
-      const entries = await this.hass.callWS({
-        type: "config/entity_registry/list",
-      });
-      this._configEntryEntities = entries
-        .filter((e) => e.platform === "cover_time_based" && e.config_entry_id)
-        .map((e) => e.entity_id);
+      const [registry, configEntries] = await Promise.all([
+        this.hass.callWS({ type: "config/entity_registry/list" }),
+        this.hass.callWS({ type: "config_entries/get", domain: DOMAIN }),
+      ]);
+      const validEntryIds = configEntries.map((e) => e.entry_id);
+      this._configEntryEntities = filterEntitiesByValidEntries(
+        registry,
+        validEntryIds,
+        DOMAIN
+      );
       this.requestUpdate();
     } catch (err) {
       console.error("Failed to load entity registry:", err);

--- a/custom_components/cover_time_based/frontend/entity-filter.js
+++ b/custom_components/cover_time_based/frontend/entity-filter.js
@@ -1,0 +1,26 @@
+/**
+ * Filter entity registry entries to those backed by a live config entry.
+ *
+ * HA can retain entity registry records after a config entry is deleted
+ * (the "this device is no longer provided by this integration" state).
+ * Such orphans still carry the deleted entry's id, so a naive filter that
+ * only checks `config_entry_id` truthiness lists phantom covers.  This
+ * helper additionally requires the id to appear in the live config-entry
+ * set passed by the caller.
+ */
+
+export function filterEntitiesByValidEntries(
+  entityRegistry,
+  validConfigEntryIds,
+  platform
+) {
+  const valid = new Set(validConfigEntryIds);
+  return entityRegistry
+    .filter(
+      (e) =>
+        e.platform === platform &&
+        e.config_entry_id &&
+        valid.has(e.config_entry_id)
+    )
+    .map((e) => e.entity_id);
+}

--- a/custom_components/cover_time_based/frontend/package.json
+++ b/custom_components/cover_time_based/frontend/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/tests/frontend/entity_filter.test.mjs
+++ b/tests/frontend/entity_filter.test.mjs
@@ -1,0 +1,61 @@
+/**
+ * Tests for entity-filter.js — the cover-time-based-card's entity filter.
+ *
+ * Run: node --test tests/frontend/entity_filter.test.mjs
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { filterEntitiesByValidEntries } from "../../custom_components/cover_time_based/frontend/entity-filter.js";
+
+const PLATFORM = "cover_time_based";
+
+test("includes entities backed by a live config entry", () => {
+  const registry = [
+    { entity_id: "cover.live", platform: PLATFORM, config_entry_id: "live_entry" },
+  ];
+  const result = filterEntitiesByValidEntries(registry, ["live_entry"], PLATFORM);
+  assert.deepEqual(result, ["cover.live"]);
+});
+
+test("excludes orphaned entities whose config_entry_id no longer exists", () => {
+  // Reproduces the bug where an entity registry entry is retained after
+  // its config entry was deleted, causing the card to list a phantom cover.
+  const registry = [
+    { entity_id: "cover.live", platform: PLATFORM, config_entry_id: "live_entry" },
+    { entity_id: "cover.orphaned", platform: PLATFORM, config_entry_id: "deleted_entry" },
+  ];
+  const result = filterEntitiesByValidEntries(registry, ["live_entry"], PLATFORM);
+  assert.deepEqual(result, ["cover.live"]);
+});
+
+test("excludes entities with no config_entry_id (YAML-configured)", () => {
+  const registry = [
+    { entity_id: "cover.yaml", platform: PLATFORM, config_entry_id: null },
+    { entity_id: "cover.ui", platform: PLATFORM, config_entry_id: "abc" },
+  ];
+  const result = filterEntitiesByValidEntries(registry, ["abc"], PLATFORM);
+  assert.deepEqual(result, ["cover.ui"]);
+});
+
+test("excludes entities from other platforms", () => {
+  const registry = [
+    { entity_id: "cover.ours", platform: PLATFORM, config_entry_id: "abc" },
+    { entity_id: "cover.theirs", platform: "other_platform", config_entry_id: "abc" },
+  ];
+  const result = filterEntitiesByValidEntries(registry, ["abc"], PLATFORM);
+  assert.deepEqual(result, ["cover.ours"]);
+});
+
+test("returns empty array when no valid entries exist", () => {
+  const registry = [
+    { entity_id: "cover.orphaned", platform: PLATFORM, config_entry_id: "deleted_entry" },
+  ];
+  const result = filterEntitiesByValidEntries(registry, [], PLATFORM);
+  assert.deepEqual(result, []);
+});
+
+test("returns empty array for empty registry", () => {
+  const result = filterEntitiesByValidEntries([], ["abc"], PLATFORM);
+  assert.deepEqual(result, []);
+});


### PR DESCRIPTION
## Summary

- The configuration card lists entries from the entity registry filtered on `platform === "cover_time_based" && config_entry_id`. When HA retains an entity record after its config entry is deleted (the "this device is no longer provided by this integration" state), the orphan still has a truthy `config_entry_id` pointing to the deleted entry, so the card showed a phantom cover.
- The fix cross-checks the entity registry against the live `config_entries/get` list and excludes entries whose `config_entry_id` is no longer valid.
- Filter logic is extracted into a pure module (`frontend/entity-filter.js`) with Node-native unit tests covering live entries, orphans, YAML-configured covers, foreign platforms, and empty inputs.
- Also documents in the README that at least one cover must be created before adding the configuration card to a dashboard, since HA only loads an integration's frontend assets once the integration itself is loaded (which requires a config entry).

## Test plan

- [x] `node --test tests/frontend/entity_filter.test.mjs` — 6 new tests pass
- [x] `pytest tests/` — all 787 existing Python tests pass (no regressions)
- [x] `node --check custom_components/cover_time_based/frontend/cover-time-based-card.js` — syntax OK
- [ ] Manual smoke test: create a cover, verify the configuration card lists only it (orphan scenario requires reproducing the "deleted-entry-with-retained-entity" state, which is outside the normal flow)