### PR TITLE
Migrate ha-textfield to ha-input with fallback

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,19 @@ jobs:
       - name: Run tests
         run: pytest tests/ -v
 
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Run frontend tests
+        run: node --test tests/frontend/*.test.mjs
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/custom_components/cover_time_based/frontend/cover-time-based-card.js
+++ b/custom_components/cover_time_based/frontend/cover-time-based-card.js
@@ -2,7 +2,7 @@
  * Cover Time Based Configuration Card
  *
  * A Lovelace card for configuring and calibrating cover_time_based entities.
- * Uses HA built-in elements (ha-entity-picker, ha-textfield, ha-checkbox,
+ * Uses HA built-in elements (ha-entity-picker, ha-input/ha-textfield, ha-checkbox,
  * ha-button) for consistent look and feel.
  *
  * All user-visible strings are translatable. Translations are embedded below.
@@ -14,6 +14,7 @@ import {
   css,
 } from "https://unpkg.com/lit-element@2.4.0/lit-element.js?module";
 import { filterEntitiesByValidEntries } from "./entity-filter.js";
+import { renderTextfield } from "./textfield-render.js";
 
 const DOMAIN = "cover_time_based";
 
@@ -964,16 +965,16 @@ class CoverTimeBasedCard extends LitElement {
         ${showPulseTime
           ? html`
               <div class="inline-field">
-                <ha-textfield
-                  type="number"
-                  min="0.1"
-                  max="10"
-                  step="0.1"
-                  suffix="s"
-                  label=${this._t("control_mode.pulse_time")}
-                  .value=${String(c.pulse_time || 1.0)}
-                  @change=${this._onPulseTimeChange}
-                ></ha-textfield>
+                ${renderTextfield({
+                  type: "number",
+                  min: "0.1",
+                  max: "10",
+                  step: "0.1",
+                  suffix: "s",
+                  label: this._t("control_mode.pulse_time"),
+                  value: String(c.pulse_time || 1.0),
+                  onChange: this._onPulseTimeChange,
+                })}
               </div>
             `
           : ""}
@@ -1102,36 +1103,39 @@ class CoverTimeBasedCard extends LitElement {
         </div>
         ` : ""}
         <div class="dual-motor-config">
-          <ha-textfield
-            type="number"
-            min="0"
-            max="100"
-            step="1"
-            label=${this._t("tilt_motor.safe_position")}
-            helper=${this._t("tilt_motor.safe_position_helper")}
-            .value=${String(c.safe_tilt_position ?? 100)}
-            @change=${(e) => {
+          ${renderTextfield({
+            type: "number",
+            min: "0",
+            max: "100",
+            step: "1",
+            label: this._t("tilt_motor.safe_position"),
+            hint: this._t("tilt_motor.safe_position_helper"),
+            value: String(c.safe_tilt_position ?? 100),
+            onChange: (e) => {
               const v = parseInt(e.target.value);
               if (!isNaN(v) && v >= 0 && v <= 100) {
                 this._updateLocal({ safe_tilt_position: v });
               }
-            }}
-          ></ha-textfield>
-          <ha-textfield
-            type="number"
-            min="0"
-            max="100"
-            step="1"
-            label=${this._t("tilt_motor.max_allowed_position")}
-            helper=${this._t("tilt_motor.max_allowed_helper")}
-            .value=${c.max_tilt_allowed_position != null ? String(c.max_tilt_allowed_position) : ""}
-            @change=${(e) => {
+            },
+          })}
+          ${renderTextfield({
+            type: "number",
+            min: "0",
+            max: "100",
+            step: "1",
+            label: this._t("tilt_motor.max_allowed_position"),
+            hint: this._t("tilt_motor.max_allowed_helper"),
+            value:
+              c.max_tilt_allowed_position != null
+                ? String(c.max_tilt_allowed_position)
+                : "",
+            onChange: (e) => {
               const v = e.target.value.trim();
               this._updateLocal({
                 max_tilt_allowed_position: v === "" ? null : parseInt(v),
               });
-            }}
-          ></ha-textfield>
+            },
+          })}
         </div>
       </div>
     `;
@@ -1593,7 +1597,8 @@ class CoverTimeBasedCard extends LitElement {
         margin-top: 12px;
       }
 
-      .dual-motor-config ha-textfield {
+      .dual-motor-config ha-textfield,
+      .dual-motor-config ha-input {
         flex: 1;
       }
 
@@ -1671,13 +1676,13 @@ class CoverTimeBasedCard extends LitElement {
 
       .value-cell {
         font-family: var(--code-font-family, monospace);
-        display: flex;
-        align-items: center;
-        gap: 4px;
+        text-align: right;
+        white-space: nowrap;
       }
 
       .timing-input {
-        width: 80px;
+        box-sizing: content-box;
+        width: 14ch;
         padding: 4px 8px;
         border: 1px solid var(--divider-color, #e0e0e0);
         border-radius: 4px;

--- a/custom_components/cover_time_based/frontend/textfield-render.js
+++ b/custom_components/cover_time_based/frontend/textfield-render.js
@@ -1,0 +1,56 @@
+/**
+ * Lit template for a HA text-field input, rendering <ha-input> on HA
+ * 2026.4+ or <ha-textfield> on older versions.
+ *
+ * Property differences handled here:
+ *   - <ha-textfield helper="..." suffix="s">  (old)
+ *   - <ha-input hint="..."> ... <span slot="end">s</span></ha-input>  (new)
+ */
+
+import { html } from "https://unpkg.com/lit-element@2.4.0/lit-element.js?module";
+import { textfieldTagName } from "./textfield.js";
+
+export function renderTextfield({
+  type,
+  min,
+  max,
+  step,
+  label = "",
+  hint = "",
+  suffix = "",
+  placeholder = "",
+  value,
+  onChange,
+}) {
+  if (textfieldTagName() === "ha-input") {
+    return html`
+      <ha-input
+        type=${type}
+        min=${min}
+        max=${max}
+        step=${step}
+        label=${label}
+        hint=${hint}
+        placeholder=${placeholder}
+        .value=${value}
+        @change=${onChange}
+      >
+        ${suffix ? html`<span slot="end">${suffix}</span>` : ""}
+      </ha-input>
+    `;
+  }
+  return html`
+    <ha-textfield
+      type=${type}
+      min=${min}
+      max=${max}
+      step=${step}
+      label=${label}
+      helper=${hint}
+      suffix=${suffix}
+      placeholder=${placeholder}
+      .value=${value}
+      @change=${onChange}
+    ></ha-textfield>
+  `;
+}

--- a/custom_components/cover_time_based/frontend/textfield.js
+++ b/custom_components/cover_time_based/frontend/textfield.js
@@ -1,0 +1,18 @@
+/**
+ * Text-field element shim — picker only.
+ *
+ * HA 2026.4 introduced <ha-input> as the successor to <ha-textfield>;
+ * <ha-textfield> is scheduled for removal in 2026.5. Prefer ha-input
+ * when the custom element is registered, fall back to ha-textfield on
+ * older HA versions.
+ *
+ * Kept lit-free so it can be unit-tested under plain Node without a DOM.
+ * The lit-rendering counterpart lives in textfield-render.js.
+ */
+
+export function textfieldTagName(
+  registry = typeof customElements !== "undefined" ? customElements : null,
+) {
+  if (registry && registry.get("ha-input")) return "ha-input";
+  return "ha-textfield";
+}

--- a/tests/frontend/textfield.test.mjs
+++ b/tests/frontend/textfield.test.mjs
@@ -1,0 +1,35 @@
+/**
+ * Tests for textfield.js — picks ha-input (HA 2026.4+) or falls back to
+ * ha-textfield (removed in 2026.5).
+ *
+ * Run: node --test tests/frontend/textfield.test.mjs
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { textfieldTagName } from "../../custom_components/cover_time_based/frontend/textfield.js";
+
+const registry = (names) => ({
+  get: (name) => (names.includes(name) ? class {} : undefined),
+});
+
+test("prefers ha-input when registered", () => {
+  assert.equal(
+    textfieldTagName(registry(["ha-input", "ha-textfield"])),
+    "ha-input",
+  );
+});
+
+test("returns ha-input even if ha-textfield is absent", () => {
+  assert.equal(textfieldTagName(registry(["ha-input"])), "ha-input");
+});
+
+test("falls back to ha-textfield when ha-input is not registered", () => {
+  assert.equal(textfieldTagName(registry(["ha-textfield"])), "ha-textfield");
+});
+
+test("falls back to ha-textfield when neither is registered", () => {
+  // We have to render *something*; ha-textfield is the safer guess on
+  // older HA versions where ha-input does not exist yet.
+  assert.equal(textfieldTagName(registry([])), "ha-textfield");
+});


### PR DESCRIPTION
## Summary
- HA 2026.4 introduced `<ha-input>` as the successor to `<ha-textfield>`; `<ha-textfield>` is scheduled for removal in 2026.5 ([HA 2026.4 frontend release notes](https://developers.home-assistant.io/blog/2026/03/25/frontend-component-updates-2026.4/)). The pulse-time and dual-motor tilt position fields now render `<ha-input>` on 2026.4+ and fall back to `<ha-textfield>` on older versions via a small picker helper.
- The picker (`textfieldTagName`) is split into its own lit-free module so it can be unit-tested under plain Node; a small lit-based renderer (`renderTextfield`) maps the API differences between the two elements (`helper`→`hint`, `suffix` attribute → `slot="end"` span).
- Adds a Node frontend job to `.github/workflows/tests.yml` so `tests/frontend/*.test.mjs` actually runs on every push/PR — previously those tests only executed if invoked manually.

## Test plan
- [x] `node --test tests/frontend/*.test.mjs` passes locally (4 cases covering picker priority + fallbacks)
- [x] `pytest tests/` passes locally (787 tests)
- [ ] Visual check on HA 2026.4+: pulse-time + dual-motor tilt fields render as `<ha-input>`
- [ ] Visual check on HA stable: same fields fall back to `<ha-textfield>` and look unchanged