### PR TITLE
fix: close tilt when toggle hits articulated state in sequential modes (#70)

### DIFF
--- a/custom_components/cover_time_based/cover_base.py
+++ b/custom_components/cover_time_based/cover_base.py
@@ -365,9 +365,15 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         # Externals have their own redirect inside _async_move_to_endpoint
         # that drives the full mechanical journey (set_tilt_position to the
         # articulated extreme), so this fast path is for self-initiated only.
+        # Gate on travel_direction (not is_traveling/current_position, which
+        # both share the same int(...) truncation and could simultaneously
+        # report "at 0, not traveling" in the final 1% of a close). The
+        # direction stays at DIRECTION_DOWN until the auto-updater calls
+        # stop() on the calculator, so it's a clean "motor settled" signal.
         if (
             not self._triggered_externally
             and isinstance(self._tilt_strategy, SequentialTilt)
+            and self.travel_calc.travel_direction == TravelStatus.STOPPED
             and self.travel_calc.current_position() == 0
             and self.tilt_calc.current_position() not in (None, 0)
         ):

--- a/custom_components/cover_time_based/cover_base.py
+++ b/custom_components/cover_time_based/cover_base.py
@@ -358,6 +358,25 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
             self._log("async_close_cover :: currently opening, stopping first")
             await self.async_stop_cover()
             await self._direction_change_delay()
+        # Sequential modes: "fully closed" requires both travel=0 AND tilt=0.
+        # If travel is already at 0 but the slats are still open (the state
+        # HA's Toggle action lands in after one close press — issue #70),
+        # close the tilt instead of emitting a no-op travel resync.
+        # Externals have their own redirect inside _async_move_to_endpoint
+        # that drives the full mechanical journey (set_tilt_position to the
+        # articulated extreme), so this fast path is for self-initiated only.
+        if (
+            not self._triggered_externally
+            and isinstance(self._tilt_strategy, SequentialTilt)
+            and self.travel_calc.current_position() == 0
+            and self.tilt_calc.current_position() not in (None, 0)
+        ):
+            self._log(
+                "async_close_cover :: sequential, travel already closed but "
+                "tilt open → closing tilt"
+            )
+            await self._async_move_tilt_to_endpoint(target=0)
+            return
         await self._async_move_to_endpoint(target=0)
 
     async def async_open_cover(self, **kwargs):

--- a/tests/test_base_movement.py
+++ b/tests/test_base_movement.py
@@ -249,9 +249,7 @@ class TestCloseFromArticulatedSequential:
         assert cover._last_command == SERVICE_OPEN_COVER
 
     @pytest.mark.asyncio
-    async def test_sequential_open_close_from_fully_open_only_travels(
-        self, make_cover
-    ):
+    async def test_sequential_open_close_from_fully_open_only_travels(self, make_cover):
         """sequential_open at (100, 0): close just travels down. Tilt sits
         at implicit=0 throughout — no tilt step planned."""
         cover = make_cover(

--- a/tests/test_base_movement.py
+++ b/tests/test_base_movement.py
@@ -164,7 +164,7 @@ class TestCloseWithTiltCoupling:
 
 class TestCloseFromArticulatedSequential:
     """Issue #70: async_close_cover when travel is already closed but the
-    slats are not should drive the tilt closed instead of emitting a no-op
+    slats are not, should drive the tilt closed instead of emitting a no-op
     travel resync. This is the second-toggle scenario HA hits because
     is_closed = travel_closed AND tilt_closed."""
 
@@ -283,6 +283,42 @@ class TestCloseFromArticulatedSequential:
         assert cover.travel_calc.is_traveling()
         assert not cover.tilt_calc.is_traveling()
         assert cover._last_command == SERVICE_OPEN_COVER
+
+    @pytest.mark.asyncio
+    async def test_fast_path_skipped_while_travel_still_in_progress(self, make_cover):
+        """current_position() truncates with int(...), so it can briefly
+        return 0 in the final 1% of a close. is_traveling() shares the same
+        truncation and flips to False at the same moment, so the fast path
+        gates on travel_direction (set when the motor was started, cleared
+        only when the auto-updater stops it). Otherwise a re-issued close
+        near the endpoint would skip the planned travel finish."""
+        from custom_components.cover_time_based.travel_calculator import (
+            TravelStatus,
+        )
+
+        cover = make_cover(
+            tilt_time_close=5.0, tilt_time_open=5.0, tilt_mode="sequential_close"
+        )
+        cover.travel_calc.set_position(100)
+        cover.tilt_calc.set_position(100)
+        # Simulate an in-flight close that has reached the int-truncated 0
+        # while still traveling (last 1% of journey).
+        cover.travel_calc.start_travel_down()
+        cover.travel_calc._last_known_position = 0
+        assert cover.travel_calc.current_position() == 0
+        assert cover.travel_calc.travel_direction == TravelStatus.DIRECTION_DOWN
+
+        with patch.object(cover, "async_write_ha_state"):
+            await cover.async_close_cover()
+
+        # The fast path must not fire mid-close — the slats must not start
+        # closing before the cover is confirmed at rest. Either the regular
+        # path takes over (driving travel to the real endpoint) or it's a
+        # no-op, but tilt must not be driven by the fast path here.
+        assert cover.tilt_calc.travel_direction == TravelStatus.STOPPED, (
+            "tilt should not have been driven by the fast path while travel "
+            "was still in progress"
+        )
 
 
 # ===================================================================

--- a/tests/test_base_movement.py
+++ b/tests/test_base_movement.py
@@ -162,6 +162,131 @@ class TestCloseWithTiltCoupling:
         assert cover.tilt_calc.is_traveling()
 
 
+class TestCloseFromArticulatedSequential:
+    """Issue #70: async_close_cover when travel is already closed but the
+    slats are not should drive the tilt closed instead of emitting a no-op
+    travel resync. This is the second-toggle scenario HA hits because
+    is_closed = travel_closed AND tilt_closed."""
+
+    @pytest.mark.asyncio
+    async def test_sequential_close_drives_tilt_closed_when_travel_at_0(
+        self, make_cover
+    ):
+        """sequential_close at travel=0, tilt=100 (slats open): close
+        should travel the tilt toward 0 (slats closed)."""
+        cover = make_cover(
+            tilt_time_close=5.0, tilt_time_open=5.0, tilt_mode="sequential_close"
+        )
+        cover.travel_calc.set_position(0)
+        cover.tilt_calc.set_position(100)
+
+        with patch.object(cover, "async_write_ha_state"):
+            await cover.async_close_cover()
+
+        assert cover.tilt_calc.is_traveling(), (
+            "tilt should be closing; instead async_close_cover emitted a "
+            "travel-only resync (issue #70)"
+        )
+        assert cover._last_command == SERVICE_CLOSE_COVER
+
+    @pytest.mark.asyncio
+    async def test_sequential_open_drives_tilt_closed_when_travel_at_0(
+        self, make_cover
+    ):
+        """sequential_open at travel=0, tilt=100 (slats articulated open):
+        close should drive the tilt back to 0 (slats closed). tilt_command
+        for sequential_open closing is OPEN (motor up)."""
+        cover = make_cover(
+            tilt_time_close=5.0, tilt_time_open=5.0, tilt_mode="sequential_open"
+        )
+        cover.travel_calc.set_position(0)
+        cover.tilt_calc.set_position(100)
+
+        with patch.object(cover, "async_write_ha_state"):
+            await cover.async_close_cover()
+
+        assert cover.tilt_calc.is_traveling()
+        assert cover._last_command == SERVICE_OPEN_COVER
+
+    @pytest.mark.asyncio
+    async def test_sequential_close_open_from_fully_closed_drives_both(
+        self, make_cover
+    ):
+        """sequential_close at (0, 0): async_open_cover should plan both
+        tilt 0→100 and travel 0→100 (single motor-up phase)."""
+        cover = make_cover(
+            tilt_time_close=5.0, tilt_time_open=5.0, tilt_mode="sequential_close"
+        )
+        cover.travel_calc.set_position(0)
+        cover.tilt_calc.set_position(0)
+
+        with patch.object(cover, "async_write_ha_state"):
+            await cover.async_open_cover()
+
+        assert cover.travel_calc.is_traveling()
+        assert cover.tilt_calc.is_traveling()
+        assert cover._last_command == SERVICE_OPEN_COVER
+
+    @pytest.mark.asyncio
+    async def test_sequential_open_open_from_articulated_plans_full_journey(
+        self, make_cover
+    ):
+        """sequential_open at (0, 100) (articulated): async_open_cover must
+        close the tilt back to 0 first, then travel up to 100. Both phases
+        run on a single motor-up command."""
+        cover = make_cover(
+            tilt_time_close=5.0, tilt_time_open=5.0, tilt_mode="sequential_open"
+        )
+        cover.travel_calc.set_position(0)
+        cover.tilt_calc.set_position(100)
+
+        with patch.object(cover, "async_write_ha_state"):
+            await cover.async_open_cover()
+
+        # Both trackers should be moving; the planning step couples them.
+        assert cover.travel_calc.is_traveling()
+        assert cover.tilt_calc.is_traveling()
+        assert cover._last_command == SERVICE_OPEN_COVER
+
+    @pytest.mark.asyncio
+    async def test_sequential_open_close_from_fully_open_only_travels(
+        self, make_cover
+    ):
+        """sequential_open at (100, 0): close just travels down. Tilt sits
+        at implicit=0 throughout — no tilt step planned."""
+        cover = make_cover(
+            tilt_time_close=5.0, tilt_time_open=5.0, tilt_mode="sequential_open"
+        )
+        cover.travel_calc.set_position(100)
+        cover.tilt_calc.set_position(0)
+
+        with patch.object(cover, "async_write_ha_state"):
+            await cover.async_close_cover()
+
+        assert cover.travel_calc.is_traveling()
+        assert not cover.tilt_calc.is_traveling()
+        assert cover._last_command == SERVICE_CLOSE_COVER
+
+    @pytest.mark.asyncio
+    async def test_sequential_open_open_from_fully_closed_only_travels(
+        self, make_cover
+    ):
+        """sequential_open at (0, 0): open just travels up. Tilt already at
+        implicit=0 — no tilt step planned."""
+        cover = make_cover(
+            tilt_time_close=5.0, tilt_time_open=5.0, tilt_mode="sequential_open"
+        )
+        cover.travel_calc.set_position(0)
+        cover.tilt_calc.set_position(0)
+
+        with patch.object(cover, "async_write_ha_state"):
+            await cover.async_open_cover()
+
+        assert cover.travel_calc.is_traveling()
+        assert not cover.tilt_calc.is_traveling()
+        assert cover._last_command == SERVICE_OPEN_COVER
+
+
 # ===================================================================
 # Tilt endpoint movement (async_close_cover_tilt / async_open_cover_tilt)
 # ===================================================================


### PR DESCRIPTION
## Summary

Fixes #70 — HA's Tile Card Toggle action gets stuck on sequential covers after the first close press.

- HA's `cover.toggle` reads `is_closed` (travel AND tilt closed). After one Toggle close on a sequential cover, the cover sits at `travel=0, tilt=100` (slats still open), so `is_closed=False`. The next Toggle calls `async_close_cover` again, which hit the resync branch in `_async_move_to_endpoint` and emitted a no-op `CLOSE`/`STOP` click without ever closing the tilt — leaving HA and the physical state out of sync (worse when `endpoint_runon_time > 0`).
- Self-initiated `async_close_cover` now detects the sequential articulated-at-closed state (`SequentialTilt`, `travel=0`, `tilt!=0`, not externally triggered) and routes to `_async_move_tilt_to_endpoint(target=0)`, so a second Toggle drives the cover to fully closed. The external-close redirect (set_tilt_position to the articulated extreme) is unchanged.

## Test plan

- [x] Added `TestCloseFromArticulatedSequential` with 6 cases covering both sequential modes — the articulated-state close (the bug), and round-trip scenarios that lock in the symmetric open/close paths.
- [x] Full unit test suite green: 793 passed.
- [ ] Manual: on a `sequential_close` cover, exercise Tile Card Toggle from fully open → second Toggle should drive the slats closed (state goes to "closed"). Repeat for `sequential_open` from the articulated state.