### PR TITLE
fix: cover runs to endpoint when retargeting position mid-move (toggle mode)

### DIFF
--- a/custom_components/cover_time_based/cover_base.py
+++ b/custom_components/cover_time_based/cover_base.py
@@ -814,6 +814,17 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
 
         self._last_command = command
 
+        # If the cover is already travelling the right way, the motor is
+        # running and only the stop target needs to change. Re-issuing the
+        # start command would, in toggle mode, pulse the direction switch a
+        # second time and stop the motor — desyncing it from the position
+        # tracker (a later auto-stop pulse then restarts it and runs the cover
+        # to the endpoint). Tilt coupling is still recomputed below for the new
+        # target before we retarget.
+        already_moving_same_dir = (
+            not is_direction_change and self.travel_calc.is_traveling()
+        )
+
         current_tilt = (
             self.tilt_calc.current_position() if self._tilt_strategy else None
         )
@@ -823,8 +834,24 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         if started:
             return
 
-        await self._async_handle_command(command)
         coupled_calc = self.tilt_calc if tilt_target is not None else None
+
+        if already_moving_same_dir:
+            # Retarget the running calculators without re-commanding the motor
+            # and without re-applying the startup delay (the motor is already
+            # up to speed). Otherwise mirrors the normal start below.
+            self._log("set_position :: retargeting active movement to %d", target)
+            self._begin_movement(
+                target,
+                tilt_target,
+                self.travel_calc,
+                coupled_calc,
+                None,
+                pre_step_delay,
+            )
+            return
+
+        await self._async_handle_command(command)
         self._begin_movement(
             target,
             tilt_target,

--- a/tests/integration/test_modes.py
+++ b/tests/integration/test_modes.py
@@ -5,11 +5,11 @@ Tests toggle mode stop-before-reverse and pulse mode relay pulsing.
 
 from __future__ import annotations
 
-import asyncio
 from datetime import timedelta
 from unittest.mock import patch
 import time as time_mod
 
+import pytest
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 from pytest_homeassistant_custom_component.common import (
@@ -48,11 +48,6 @@ async def test_toggle_in_motion_close_stops(hass: HomeAssistant, setup_input_boo
     Reversing direction now requires either a second click or a
     set_cover_position call (which keeps its stop-then-reverse behavior).
     """
-    real_sleep = asyncio.sleep
-
-    async def instant_sleep(delay, *args, **kwargs):
-        await real_sleep(0)
-
     options = {
         "control_mode": "toggle",
         "open_switch_entity_id": "input_boolean.open_switch",
@@ -60,7 +55,7 @@ async def test_toggle_in_motion_close_stops(hass: HomeAssistant, setup_input_boo
         "travel_time_open": 10.0,
         "travel_time_close": 10.0,
         "endpoint_runon_time": 0,
-        "pulse_time": 0.5,
+        "pulse_time": 0,
     }
     entry = MockConfigEntry(
         domain=DOMAIN, version=2, title="Test Cover", data={}, options=options
@@ -70,7 +65,7 @@ async def test_toggle_in_motion_close_stops(hass: HomeAssistant, setup_input_boo
     await hass.async_block_till_done()
 
     mt = MockTime()
-    with patch("time.time", mt.time), patch("asyncio.sleep", instant_sleep):
+    with patch("time.time", mt.time):
         cover = _get_cover_entity(hass)
 
         await cover.set_known_position(position=50)
@@ -103,22 +98,29 @@ async def test_toggle_in_motion_close_stops(hass: HomeAssistant, setup_input_boo
     await hass.async_block_till_done()
 
 
-async def test_pulse_mode_relay_pulsing(hass: HomeAssistant, setup_input_booleans):
-    """Pulse mode: open switch pulses on then off after pulse_time."""
-    real_sleep = asyncio.sleep
+async def test_toggle_same_direction_retarget_does_not_repulse(
+    hass: HomeAssistant, setup_input_booleans
+):
+    """Toggle mode: retargeting in the same direction must not re-pulse.
 
-    async def instant_sleep(delay, *args, **kwargs):
-        await real_sleep(0)
+    Reproduces the runaway-cover bug: a cover was moving (closing) when a
+    second set_cover_position arrived for a still-lower target (same
+    direction). The old code re-issued the CLOSE command, which in toggle
+    mode is a second same-direction pulse that *stops* the motor — desyncing
+    it from the position tracker. The later auto-stop pulse then restarted
+    the motor, which ran to the endpoint.
 
+    The motor is already moving the right way, so no new directional pulse
+    should be sent: only the initial start pulse and the final stop pulse.
+    """
     options = {
-        "control_mode": "pulse",
+        "control_mode": "toggle",
         "open_switch_entity_id": "input_boolean.open_switch",
         "close_switch_entity_id": "input_boolean.close_switch",
-        "stop_switch_entity_id": "input_boolean.stop_switch",
         "travel_time_open": 10.0,
         "travel_time_close": 10.0,
         "endpoint_runon_time": 0,
-        "pulse_time": 0.5,
+        "pulse_time": 0,
     }
     entry = MockConfigEntry(
         domain=DOMAIN, version=2, title="Test Cover", data={}, options=options
@@ -128,7 +130,85 @@ async def test_pulse_mode_relay_pulsing(hass: HomeAssistant, setup_input_boolean
     await hass.async_block_till_done()
 
     mt = MockTime()
-    with patch("time.time", mt.time), patch("asyncio.sleep", instant_sleep):
+    with patch("time.time", mt.time):
+        cover = _get_cover_entity(hass)
+        # Fire HA time changes off a single base, with offsets that match the
+        # cumulative MockTime advance, so the scheduler and TravelCalculator
+        # clocks stay aligned.
+        now = dt_util.utcnow()
+
+        # Cover fully open
+        await cover.set_known_position(position=100)
+        await hass.async_block_till_done()
+
+        with patch.object(cover, "_send_close", wraps=cover._send_close) as send_close:
+            # First target: start closing toward 60
+            await hass.services.async_call(
+                "cover",
+                "set_cover_position",
+                {"entity_id": "cover.test_cover", "position": 60},
+                blocking=True,
+            )
+            await hass.async_block_till_done()
+            assert cover.is_closing
+            assert send_close.call_count == 1, "initial close should pulse once"
+
+            # Let it travel partway (to ~80)
+            mt.advance(2.0)
+            async_fire_time_changed(hass, now + timedelta(seconds=2), fire_all=True)
+            await hass.async_block_till_done()
+
+            # Second target while still closing: lower again (same direction).
+            # Must NOT re-pulse the close switch.
+            await hass.services.async_call(
+                "cover",
+                "set_cover_position",
+                {"entity_id": "cover.test_cover", "position": 30},
+                blocking=True,
+            )
+            await hass.async_block_till_done()
+            assert cover.is_closing
+            assert send_close.call_count == 1, (
+                "same-direction retarget must not re-pulse the motor"
+            )
+
+            # Travel long enough to reach the new target (30) and stop.
+            mt.advance(6.0)
+            async_fire_time_changed(hass, now + timedelta(seconds=8), fire_all=True)
+            await hass.async_block_till_done()
+
+        # Stopped at the new target, not the original one.
+        assert not cover.is_closing
+        assert cover.current_cover_position == 30
+        # Exactly one directional start was issued for the whole sequence.
+        # (The auto-stop goes through _send_stop, not _send_close.)
+        assert send_close.call_count == 1
+
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+
+async def test_pulse_mode_relay_pulsing(hass: HomeAssistant, setup_input_booleans):
+    """Pulse mode: open switch pulses on then off after pulse_time."""
+    options = {
+        "control_mode": "pulse",
+        "open_switch_entity_id": "input_boolean.open_switch",
+        "close_switch_entity_id": "input_boolean.close_switch",
+        "stop_switch_entity_id": "input_boolean.stop_switch",
+        "travel_time_open": 10.0,
+        "travel_time_close": 10.0,
+        "endpoint_runon_time": 0,
+        "pulse_time": 0,
+    }
+    entry = MockConfigEntry(
+        domain=DOMAIN, version=2, title="Test Cover", data={}, options=options
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    mt = MockTime()
+    with patch("time.time", mt.time):
         cover = _get_cover_entity(hass)
 
         await cover.set_known_position(position=50)
@@ -140,8 +220,7 @@ async def test_pulse_mode_relay_pulsing(hass: HomeAssistant, setup_input_boolean
         )
         await hass.async_block_till_done()
 
-        # In pulse mode, switch should pulse on then off
-        # With instant sleep, the pulse completes immediately
+        # In pulse mode, switch should pulse on then off (instant with pulse_time=0)
         assert hass.states.get("input_boolean.open_switch").state == "off"
         assert cover.is_opening
 
@@ -157,10 +236,98 @@ async def test_pulse_mode_relay_pulsing(hass: HomeAssistant, setup_input_boolean
         )
         await hass.async_block_till_done()
 
-        # Stop switch should have pulsed (on then off with instant sleep)
+        # Stop switch should have pulsed (on then off, instant with pulse_time=0)
         assert hass.states.get("input_boolean.stop_switch").state == "off"
         assert not cover.is_opening
         assert not cover.is_closing
+
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+
+@pytest.mark.parametrize(
+    "extra_options",
+    [
+        pytest.param({"control_mode": "switch"}, id="switch"),
+        pytest.param(
+            {
+                "control_mode": "pulse",
+                "stop_switch_entity_id": "input_boolean.stop_switch",
+                "pulse_time": 0,
+            },
+            id="pulse",
+        ),
+    ],
+)
+async def test_same_direction_retarget_does_not_repulse(
+    hass: HomeAssistant, setup_input_booleans, extra_options
+):
+    """Switch and pulse modes: same-direction retarget must not re-command.
+
+    These modes never had the toggle-mode runaway (a held relay / a
+    dedicated stop switch absorb a redundant directional command), but the
+    shared set_position fix should still skip the redundant command so a
+    same-direction slider drag issues exactly one directional start.
+    """
+    options = {
+        "open_switch_entity_id": "input_boolean.open_switch",
+        "close_switch_entity_id": "input_boolean.close_switch",
+        "travel_time_open": 10.0,
+        "travel_time_close": 10.0,
+        "endpoint_runon_time": 0,
+        **extra_options,
+    }
+    entry = MockConfigEntry(
+        domain=DOMAIN, version=2, title="Test Cover", data={}, options=options
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    mt = MockTime()
+    with patch("time.time", mt.time):
+        cover = _get_cover_entity(hass)
+        now = dt_util.utcnow()
+
+        await cover.set_known_position(position=100)
+        await hass.async_block_till_done()
+
+        with patch.object(cover, "_send_close", wraps=cover._send_close) as send_close:
+            await hass.services.async_call(
+                "cover",
+                "set_cover_position",
+                {"entity_id": "cover.test_cover", "position": 60},
+                blocking=True,
+            )
+            await hass.async_block_till_done()
+            assert cover.is_closing
+            assert send_close.call_count == 1
+
+            mt.advance(2.0)
+            async_fire_time_changed(hass, now + timedelta(seconds=2), fire_all=True)
+            await hass.async_block_till_done()
+
+            # Same-direction retarget while still closing.
+            await hass.services.async_call(
+                "cover",
+                "set_cover_position",
+                {"entity_id": "cover.test_cover", "position": 30},
+                blocking=True,
+            )
+            await hass.async_block_till_done()
+            assert cover.is_closing
+            assert send_close.call_count == 1, (
+                "same-direction retarget must not re-command the motor"
+            )
+
+            # Reaches the new target and stops there.
+            mt.advance(6.0)
+            async_fire_time_changed(hass, now + timedelta(seconds=8), fire_all=True)
+            await hass.async_block_till_done()
+
+        assert not cover.is_closing
+        assert cover.current_cover_position == 30
+        assert send_close.call_count == 1
 
     await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()

--- a/tests/integration/test_tilt.py
+++ b/tests/integration/test_tilt.py
@@ -253,3 +253,86 @@ async def test_sequential_open_tilt_open_drives_close_relay(
 
     await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
+
+
+async def test_same_direction_retarget_tilt_cover_does_not_reissue_command(
+    hass: HomeAssistant, setup_input_booleans
+):
+    """Same-direction retarget on a tilt cover must not re-issue travel.
+
+    The same-direction retarget fast-path is taken for tilt-coupled covers
+    too. It must recompute tilt coupling for the new target (it runs through
+    _plan_tilt_for_travel like a normal move) while skipping the redundant
+    travel command, and the cover must still stop at the new target.
+    """
+    options = {
+        "control_mode": "switch",
+        "open_switch_entity_id": "input_boolean.open_switch",
+        "close_switch_entity_id": "input_boolean.close_switch",
+        "travel_time_open": 10.0,
+        "travel_time_close": 10.0,
+        "tilt_mode": "inline",
+        "tilt_time_open": 1.0,
+        "tilt_time_close": 1.0,
+        "endpoint_runon_time": 0,
+    }
+    entry = MockConfigEntry(
+        domain=DOMAIN, version=2, title="Test Cover", data={}, options=options
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    mt = MockTime()
+    with patch("time.time", mt.time):
+        cover = _get_cover_entity(hass)
+        # Fire HA time changes off a single base with offsets matching the
+        # cumulative MockTime advance, keeping the scheduler and
+        # TravelCalculator clocks aligned.
+        now = dt_util.utcnow()
+
+        await cover.set_known_position(position=100)
+        await cover.set_known_tilt_position(tilt_position=50)
+        await hass.async_block_till_done()
+
+        with patch.object(cover, "_send_close", wraps=cover._send_close) as send_close:
+            # Mid-position move (closing).
+            await hass.services.async_call(
+                "cover",
+                "set_cover_position",
+                {"entity_id": "cover.test_cover", "position": 60},
+                blocking=True,
+            )
+            await hass.async_block_till_done()
+            assert cover.is_closing
+            assert send_close.call_count == 1
+
+            # Let the inline tilt pre-step finish and travel get underway.
+            mt.advance(2.0)
+            async_fire_time_changed(hass, now + timedelta(seconds=2), fire_all=True)
+            await hass.async_block_till_done()
+            assert cover.travel_calc.is_traveling()
+
+            # Retarget (same direction) to a lower mid-position.
+            await hass.services.async_call(
+                "cover",
+                "set_cover_position",
+                {"entity_id": "cover.test_cover", "position": 30},
+                blocking=True,
+            )
+            await hass.async_block_till_done()
+            assert cover.is_closing
+            assert send_close.call_count == 1, (
+                "same-direction retarget must not re-command a tilt cover"
+            )
+
+            # Reaches the new target and stops there.
+            mt.advance(8.0)
+            async_fire_time_changed(hass, now + timedelta(seconds=10), fire_all=True)
+            await hass.async_block_till_done()
+
+        assert not cover.is_closing
+        assert cover.current_cover_position == 30
+
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()

--- a/tests/test_cover_wrapped.py
+++ b/tests/test_cover_wrapped.py
@@ -164,3 +164,32 @@ class TestWrappedAsyncAddedToHass:
         # Verify the entity list includes the wrapped cover
         assert mock_track.call_args[0][1] == ["cover.inner"]
         assert unsub in cover._state_listener_unsubs
+
+
+class TestWrappedSameDirectionRetarget:
+    """Same-direction retarget must not re-issue the directional command.
+
+    Wrapped mode never had the toggle-mode runaway (it delegates STOP to the
+    underlying cover's real stop_cover), but the shared set_position fix
+    should still skip the redundant close_cover call when the cover is
+    already travelling the right way.
+    """
+
+    @pytest.mark.asyncio
+    async def test_retarget_same_direction_does_not_reissue_command(self):
+        cover = _make_wrapped_cover(cover_entity_id="cover.inner")
+        # Avoid scheduling a real auto-updater / writing state on the mock hass.
+        cover.start_auto_updater = MagicMock()
+        cover.async_write_ha_state = MagicMock()
+        cover.async_schedule_update_ha_state = MagicMock()
+        cover.travel_calc.set_position(100)  # fully open
+
+        with patch.object(cover, "_send_close", wraps=cover._send_close) as send_close:
+            await cover.set_position(60)
+            assert cover.travel_calc.is_traveling()
+            assert send_close.call_count == 1
+
+            # Same direction (still closing), lower target.
+            await cover.set_position(30)
+            assert send_close.call_count == 1
+            assert cover.travel_calc._travel_to_position == 30


### PR DESCRIPTION
## Problem

If you set a new cover position while the cover is **already moving in the same direction** (e.g. the cover is closing and you drag the slider to a still-lower position), the cover can run all the way to the endpoint while the entity reports the intended intermediate position.

Real-world repro from a debug log (toggle mode, cover open at 100):

1. `set_cover_position: 91` → `CLOSE` pulse, motor starts closing.
2. ~2.8s later, still closing at ~97: `set_cover_position: 80` → a **second `CLOSE` pulse**.
3. Tracker reaches 80 → `STOP`.

In **toggle mode** a same-direction pulse *stops* the motor, and `STOP` is itself a re-press of the direction button. So the motor saw `start → stop → start`, while the integration believed it sent `start … stop`. The motor restarted on the final pulse with tracking already finished, and ran to the bottom limit. Net: cover fully closed, entity says 80.

## Root cause

In `set_position`, the only "already moving" case handled was a **direction change** (stop-and-reverse). A **same-direction** retarget fell through and re-issued the start command via `_async_handle_command(command)`. That's harmless when a relay is simply held (switch mode) or there's a dedicated stop switch (pulse/wrapped), but in toggle mode the redundant pulse desyncs the motor from the tracker.

## Fix

When already travelling in the same direction, retarget the running travel calculator and let the active auto-updater stop at the new target — **without** re-issuing the directional command. The motor is already moving the right way.

This fixes the toggle-mode runaway and, in switch/pulse/wrapped modes (which were already correct), removes a redundant relay command and a startup-delay restart that briefly froze position tracking on every same-direction retarget.

## Tests

Regression tests for all four control modes asserting a same-direction retarget issues exactly one directional start (and, for switch/pulse, that the cover stops at the new target). Each was confirmed to fail without the fix.

Full suite: 850 passed.