### PR TITLE
Allow script entities as open/close/stop targets in pulse mode (#82)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@ __pycache__/
 *.iml
 .coverage
 docs/plans/
+docs/superpowers/
 .ha-changes-state.json
 HA_CHANGES_REPORT.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 4.1.0 (2026-05-30)
+
+### Features
+
+- **Use scripts as open/close/stop switches in Pulse mode** ([#82](https://github.com/Sese-Schneider/ha-cover-time-based/issues/82)): the open, close, and stop targets (and the dual-motor tilt targets) can now be `script` entities as well as `switch` entities when the control mode is **Pulse** — handy for covers driven by IR remotes, where each script fires an open/close/stop command. Switch and Toggle modes still require `switch` entities, since they rely on a held on-state a script can't provide. Note that a script still running when the configured **Pulse time** elapses will be stopped.
+
 ## 4.0.0 (2026-05-23)
 
 If you're coming from v2.3.2, this is essentially a new integration.

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ Three input modes are available to describe how the switch entities for switch-b
 | **Pulse**  | Momentary pulse buttons. A brief ON-OFF pulse latches the motor on. Requires a stop button to stop movement, or movement stops when the hardware reaches its endpoint. |
 | **Toggle** | Toggle-style relays. A brief ON-OFF pulse latches the motor on. A second pulse on the same direction button stops the motor.                                           |
 
+> **Scripts in Pulse mode.** In **Pulse** mode the Open / Close / Stop entities (and the dual-motor tilt entities) may be `script` entities as well as `switch` entities — for example, IR-remote-controlled covers where each script fires an open / close / stop IR command. **Switch** and **Toggle** modes require `switch` entities: they rely on the entity reporting a held/latched on-state, which a script (which auto-returns to `off`) cannot provide.
+
 #### Pulse time
 
 With the **Pulse** and **Toggle** input modes, the **Pulse time** configures how long the switch should send the ON signal before it turns OFF. Defaults to **1s**.
@@ -320,9 +322,9 @@ cover:
 | Name                   | Type    | Requirement                                     | Description                                                             | Default |
 | ---------------------- | ------- | ----------------------------------------------- | ----------------------------------------------------------------------- | ------- |
 | name                   | string  | **Required**                                    | Name of the created entity                                              |         |
-| open_switch_entity_id  | entity  | **Required** or `cover_entity_id`               | Entity ID of the switch for opening the cover                           |         |
-| close_switch_entity_id | entity  | **Required** or `cover_entity_id`               | Entity ID of the switch for closing the cover                           |         |
-| stop_switch_entity_id  | entity  | _Optional_                                      | Entity ID of the switch for stopping the cover                          | None    |
+| open_switch_entity_id  | entity  | **Required** or `cover_entity_id`               | Entity ID of the switch for opening the cover. Accepts a `script` entity when `input_mode: pulse` |         |
+| close_switch_entity_id | entity  | **Required** or `cover_entity_id`               | Entity ID of the switch for closing the cover. Accepts a `script` entity when `input_mode: pulse` |         |
+| stop_switch_entity_id  | entity  | _Optional_                                      | Entity ID of the switch for stopping the cover. Accepts a `script` entity when `input_mode: pulse` | None    |
 | cover_entity_id        | entity  | **Required** or `open_\|close_switch_entity_id` | Entity ID of an existing cover entity                                   |         |
 | is_button              | boolean | _Optional_                                      | Set to `true` for momentary pulse buttons (same as `input_mode: pulse`) | false   |
 | travelling_time_down   | float   | _Optional_                                      | Time in seconds to close the cover                                      | 30      |

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Three input modes are available to describe how the switch entities for switch-b
 | **Pulse**  | Momentary pulse buttons. A brief ON-OFF pulse latches the motor on. Requires a stop button to stop movement, or movement stops when the hardware reaches its endpoint. |
 | **Toggle** | Toggle-style relays. A brief ON-OFF pulse latches the motor on. A second pulse on the same direction button stops the motor.                                           |
 
-> **Scripts in Pulse mode.** In **Pulse** mode the Open / Close / Stop entities (and the dual-motor tilt entities) may be `script` entities as well as `switch` entities — for example, IR-remote-controlled covers where each script fires an open / close / stop IR command. **Switch** and **Toggle** modes require `switch` entities: they rely on the entity reporting a held/latched on-state, which a script (which auto-returns to `off`) cannot provide.
+> **Scripts in Pulse mode.** In **Pulse** mode the Open / Close / Stop entities (and the dual-motor tilt entities) may be `script` entities as well as `switch` entities — for example, IR-remote-controlled covers where each script fires an open / close / stop IR command. **Switch** and **Toggle** modes require `switch` entities: they rely on the entity reporting a held/latched on-state, which a script (which auto-returns to `off`) cannot provide. Keep the scripts short: after **Pulse time** elapses the integration turns the entity off again, which cancels any script still running — so a script whose own internal `delay` is longer than the pulse time would be cut short.
 
 #### Pulse time
 

--- a/custom_components/cover_time_based/frontend/cover-time-based-card.js
+++ b/custom_components/cover_time_based/frontend/cover-time-based-card.js
@@ -45,6 +45,10 @@ const EN = {
   "entities.open_switch": "Open switch",
   "entities.close_switch": "Close switch",
   "entities.stop_switch": "Stop switch",
+  "entities.switch_entities_pulse": "Switch / Script Entities",
+  "entities.open_switch_pulse": "Open switch or script",
+  "entities.close_switch_pulse": "Close switch or script",
+  "entities.stop_switch_pulse": "Stop switch or script",
   "tilt.label": "Tilt Mode",
   "tilt.none": "Not supported",
   "tilt.sequential_close": "Closes then tilts closed",
@@ -55,6 +59,10 @@ const EN = {
   "tilt_motor.open_switch": "Tilt open switch",
   "tilt_motor.close_switch": "Tilt close switch",
   "tilt_motor.stop_switch": "Tilt stop switch",
+  "tilt_motor.label_pulse": "Tilt Motor (switch or script)",
+  "tilt_motor.open_switch_pulse": "Tilt open switch or script",
+  "tilt_motor.close_switch_pulse": "Tilt close switch or script",
+  "tilt_motor.stop_switch_pulse": "Tilt stop switch or script",
   "tilt_motor.safe_position": "Safe tilt position",
   "tilt_motor.safe_position_helper": "Tilt moves here before travel (100 = fully open)",
   "tilt_motor.max_allowed_position": "Max tilt allowed position (optional)",
@@ -142,6 +150,10 @@ const TRANSLATIONS = {
     "entities.open_switch": "Interruptor de abrir",
     "entities.close_switch": "Interruptor de fechar",
     "entities.stop_switch": "Interruptor de parar",
+    "entities.switch_entities_pulse": "Entidades de Interruptor / Script",
+    "entities.open_switch_pulse": "Interruptor ou script de abrir",
+    "entities.close_switch_pulse": "Interruptor ou script de fechar",
+    "entities.stop_switch_pulse": "Interruptor ou script de parar",
     "tilt.label": "Inclinação",
     "tilt.none": "Não suportado",
     "tilt.sequential_close": "Fecha e depois inclina fechadas",
@@ -152,6 +164,10 @@ const TRANSLATIONS = {
     "tilt_motor.open_switch": "Interruptor de abrir inclinação",
     "tilt_motor.close_switch": "Interruptor de fechar inclinação",
     "tilt_motor.stop_switch": "Interruptor de parar inclinação",
+    "tilt_motor.label_pulse": "Motor de Inclinação (interruptor ou script)",
+    "tilt_motor.open_switch_pulse": "Interruptor ou script de abrir inclinação",
+    "tilt_motor.close_switch_pulse": "Interruptor ou script de fechar inclinação",
+    "tilt_motor.stop_switch_pulse": "Interruptor ou script de parar inclinação",
     "tilt_motor.safe_position": "Posição de inclinação segura",
     "tilt_motor.safe_position_helper": "A inclinação move-se para aqui antes do deslocamento (100 = totalmente aberto)",
     "tilt_motor.max_allowed_position": "Posição máxima permitida de inclinação (opcional)",
@@ -236,6 +252,10 @@ const TRANSLATIONS = {
     "entities.open_switch": "Przełącznik otwierania",
     "entities.close_switch": "Przełącznik zamykania",
     "entities.stop_switch": "Przełącznik zatrzymania",
+    "entities.switch_entities_pulse": "Encje przełączników / skryptów",
+    "entities.open_switch_pulse": "Przełącznik lub skrypt otwierania",
+    "entities.close_switch_pulse": "Przełącznik lub skrypt zamykania",
+    "entities.stop_switch_pulse": "Przełącznik lub skrypt zatrzymania",
     "tilt.label": "Nachylenie",
     "tilt.none": "Nieobsługiwane",
     "tilt.sequential_close": "Najpierw zamyka, potem nachyla zamknięte",
@@ -246,6 +266,10 @@ const TRANSLATIONS = {
     "tilt_motor.open_switch": "Przełącznik otwierania nachylenia",
     "tilt_motor.close_switch": "Przełącznik zamykania nachylenia",
     "tilt_motor.stop_switch": "Przełącznik zatrzymania nachylenia",
+    "tilt_motor.label_pulse": "Silnik nachylenia (przełącznik lub skrypt)",
+    "tilt_motor.open_switch_pulse": "Przełącznik lub skrypt otwierania nachylenia",
+    "tilt_motor.close_switch_pulse": "Przełącznik lub skrypt zamykania nachylenia",
+    "tilt_motor.stop_switch_pulse": "Przełącznik lub skrypt zatrzymania nachylenia",
     "tilt_motor.safe_position": "Bezpieczna pozycja nachylenia",
     "tilt_motor.safe_position_helper": "Nachylenie przesuwa się tu przed ruchem (100 = w pełni otwarte)",
     "tilt_motor.max_allowed_position": "Maks. dozwolona pozycja nachylenia (opcjonalna)",
@@ -372,6 +396,10 @@ class CoverTimeBasedCard extends LitElement {
       }
     }
     return str;
+  }
+
+  _switchLabel(baseKey, controlMode) {
+    return this._t(switchLabelKey(baseKey, controlMode));
   }
 
   // --- Lifecycle ---
@@ -1021,13 +1049,13 @@ class CoverTimeBasedCard extends LitElement {
 
     return html`
       <div class="section">
-        <div class="field-label">${this._t("entities.switch_entities")}</div>
+        <div class="field-label">${this._switchLabel("entities.switch_entities", c.control_mode)}</div>
         <div class="entity-grid">
           <ha-entity-picker
             .hass=${this.hass}
             .value=${c.open_switch_entity_id || ""}
             .includeDomains=${switchPickerDomains(c.control_mode)}
-            label=${this._t("entities.open_switch")}
+            label=${this._switchLabel("entities.open_switch", c.control_mode)}
             @value-changed=${(e) =>
               this._onSwitchEntityChange("open_switch_entity_id", e)}
           ></ha-entity-picker>
@@ -1035,7 +1063,7 @@ class CoverTimeBasedCard extends LitElement {
             .hass=${this.hass}
             .value=${c.close_switch_entity_id || ""}
             .includeDomains=${switchPickerDomains(c.control_mode)}
-            label=${this._t("entities.close_switch")}
+            label=${this._switchLabel("entities.close_switch", c.control_mode)}
             @value-changed=${(e) =>
               this._onSwitchEntityChange("close_switch_entity_id", e)}
           ></ha-entity-picker>
@@ -1044,7 +1072,7 @@ class CoverTimeBasedCard extends LitElement {
             .hass=${this.hass}
             .value=${c.stop_switch_entity_id || ""}
             .includeDomains=${switchPickerDomains(c.control_mode)}
-            label=${this._t("entities.stop_switch")}
+            label=${this._switchLabel("entities.stop_switch", c.control_mode)}
             @value-changed=${(e) =>
               this._onSwitchEntityChange("stop_switch_entity_id", e)}
           ></ha-entity-picker>
@@ -1105,14 +1133,14 @@ class CoverTimeBasedCard extends LitElement {
 
     return html`
       <div class="section">
-        <div class="field-label">${this._t("tilt_motor.label")}</div>
+        <div class="field-label">${this._switchLabel("tilt_motor.label", c.control_mode)}</div>
         ${c.control_mode !== "wrapped" ? html`
         <div class="entity-grid">
           <ha-entity-picker
             .hass=${this.hass}
             .value=${c.tilt_open_switch || ""}
             .includeDomains=${switchPickerDomains(c.control_mode)}
-            label=${this._t("tilt_motor.open_switch")}
+            label=${this._switchLabel("tilt_motor.open_switch", c.control_mode)}
             @value-changed=${(e) =>
               this._onSwitchEntityChange("tilt_open_switch", e)}
           ></ha-entity-picker>
@@ -1120,7 +1148,7 @@ class CoverTimeBasedCard extends LitElement {
             .hass=${this.hass}
             .value=${c.tilt_close_switch || ""}
             .includeDomains=${switchPickerDomains(c.control_mode)}
-            label=${this._t("tilt_motor.close_switch")}
+            label=${this._switchLabel("tilt_motor.close_switch", c.control_mode)}
             @value-changed=${(e) =>
               this._onSwitchEntityChange("tilt_close_switch", e)}
           ></ha-entity-picker>
@@ -1129,7 +1157,7 @@ class CoverTimeBasedCard extends LitElement {
             .hass=${this.hass}
             .value=${c.tilt_stop_switch || ""}
             .includeDomains=${switchPickerDomains(c.control_mode)}
-            label=${this._t("tilt_motor.stop_switch")}
+            label=${this._switchLabel("tilt_motor.stop_switch", c.control_mode)}
             @value-changed=${(e) =>
               this._onSwitchEntityChange("tilt_stop_switch", e)}
           ></ha-entity-picker>

--- a/custom_components/cover_time_based/frontend/cover-time-based-card.js
+++ b/custom_components/cover_time_based/frontend/cover-time-based-card.js
@@ -13,7 +13,11 @@ import {
   html,
   css,
 } from "https://unpkg.com/lit-element@2.4.0/lit-element.js?module";
-import { filterEntitiesByValidEntries } from "./entity-filter.js";
+import {
+  filterEntitiesByValidEntries,
+  switchPickerDomains,
+  switchLabelKey,
+} from "./entity-filter.js";
 import { renderTextfield } from "./textfield-render.js";
 
 const DOMAIN = "cover_time_based";
@@ -1022,7 +1026,7 @@ class CoverTimeBasedCard extends LitElement {
           <ha-entity-picker
             .hass=${this.hass}
             .value=${c.open_switch_entity_id || ""}
-            .includeDomains=${["switch"]}
+            .includeDomains=${switchPickerDomains(c.control_mode)}
             label=${this._t("entities.open_switch")}
             @value-changed=${(e) =>
               this._onSwitchEntityChange("open_switch_entity_id", e)}
@@ -1030,7 +1034,7 @@ class CoverTimeBasedCard extends LitElement {
           <ha-entity-picker
             .hass=${this.hass}
             .value=${c.close_switch_entity_id || ""}
-            .includeDomains=${["switch"]}
+            .includeDomains=${switchPickerDomains(c.control_mode)}
             label=${this._t("entities.close_switch")}
             @value-changed=${(e) =>
               this._onSwitchEntityChange("close_switch_entity_id", e)}
@@ -1039,7 +1043,7 @@ class CoverTimeBasedCard extends LitElement {
           <ha-entity-picker
             .hass=${this.hass}
             .value=${c.stop_switch_entity_id || ""}
-            .includeDomains=${["switch"]}
+            .includeDomains=${switchPickerDomains(c.control_mode)}
             label=${this._t("entities.stop_switch")}
             @value-changed=${(e) =>
               this._onSwitchEntityChange("stop_switch_entity_id", e)}
@@ -1107,7 +1111,7 @@ class CoverTimeBasedCard extends LitElement {
           <ha-entity-picker
             .hass=${this.hass}
             .value=${c.tilt_open_switch || ""}
-            .includeDomains=${["switch"]}
+            .includeDomains=${switchPickerDomains(c.control_mode)}
             label=${this._t("tilt_motor.open_switch")}
             @value-changed=${(e) =>
               this._onSwitchEntityChange("tilt_open_switch", e)}
@@ -1115,7 +1119,7 @@ class CoverTimeBasedCard extends LitElement {
           <ha-entity-picker
             .hass=${this.hass}
             .value=${c.tilt_close_switch || ""}
-            .includeDomains=${["switch"]}
+            .includeDomains=${switchPickerDomains(c.control_mode)}
             label=${this._t("tilt_motor.close_switch")}
             @value-changed=${(e) =>
               this._onSwitchEntityChange("tilt_close_switch", e)}
@@ -1124,7 +1128,7 @@ class CoverTimeBasedCard extends LitElement {
           <ha-entity-picker
             .hass=${this.hass}
             .value=${c.tilt_stop_switch || ""}
-            .includeDomains=${["switch"]}
+            .includeDomains=${switchPickerDomains(c.control_mode)}
             label=${this._t("tilt_motor.stop_switch")}
             @value-changed=${(e) =>
               this._onSwitchEntityChange("tilt_stop_switch", e)}

--- a/custom_components/cover_time_based/frontend/cover-time-based-card.js
+++ b/custom_components/cover_time_based/frontend/cover-time-based-card.js
@@ -17,6 +17,7 @@ import {
   filterEntitiesByValidEntries,
   switchPickerDomains,
   switchLabelKey,
+  clearedEntitiesForMode,
 } from "./entity-filter.js";
 import { renderTextfield } from "./textfield-render.js";
 
@@ -631,20 +632,9 @@ class CoverTimeBasedCard extends LitElement {
 
   _onControlModeChange(e) {
     const mode = e.target.value;
-    const updates = { control_mode: mode };
-    // Clear irrelevant entities when switching modes
-    if (mode === "wrapped") {
-      updates.open_switch_entity_id = null;
-      updates.close_switch_entity_id = null;
-      updates.stop_switch_entity_id = null;
-    } else {
-      updates.cover_entity_id = null;
-    }
-    if (mode !== "pulse") {
-      updates.stop_switch_entity_id = null;
-      updates.tilt_stop_switch = null;
-    }
-    this._updateLocal(updates);
+    // Clear entities that don't belong to the new mode so they don't linger
+    // as stale config (see clearedEntitiesForMode).
+    this._updateLocal({ control_mode: mode, ...clearedEntitiesForMode(mode) });
   }
 
   _onPulseTimeChange(e) {

--- a/custom_components/cover_time_based/frontend/entity-filter.js
+++ b/custom_components/cover_time_based/frontend/entity-filter.js
@@ -24,3 +24,15 @@ export function filterEntitiesByValidEntries(
     )
     .map((e) => e.entity_id);
 }
+
+/**
+ * Entity-picker domains for switch-based control modes.
+ *
+ * Pulse mode commands via homeassistant.turn_on/off and ignores the OFF
+ * edge, so `script` entities (e.g. IR-remote open/close/stop scripts) work
+ * there. Switch and toggle modes rely on a latched/held state a script
+ * cannot provide, so they stay switch-only.
+ */
+export function switchPickerDomains(controlMode) {
+  return controlMode === "pulse" ? ["switch", "script"] : ["switch"];
+}

--- a/custom_components/cover_time_based/frontend/entity-filter.js
+++ b/custom_components/cover_time_based/frontend/entity-filter.js
@@ -36,3 +36,14 @@ export function filterEntitiesByValidEntries(
 export function switchPickerDomains(controlMode) {
   return controlMode === "pulse" ? ["switch", "script"] : ["switch"];
 }
+
+/**
+ * Translation-key selector for switch/script picker labels.
+ *
+ * In pulse mode the picker accepts switches OR scripts, so labels use a
+ * "<base>_pulse" variant (e.g. "Open switch or script"). Other modes use
+ * the base key.
+ */
+export function switchLabelKey(baseKey, controlMode) {
+  return controlMode === "pulse" ? `${baseKey}_pulse` : baseKey;
+}

--- a/custom_components/cover_time_based/frontend/entity-filter.js
+++ b/custom_components/cover_time_based/frontend/entity-filter.js
@@ -47,3 +47,32 @@ export function switchPickerDomains(controlMode) {
 export function switchLabelKey(baseKey, controlMode) {
   return controlMode === "pulse" ? `${baseKey}_pulse` : baseKey;
 }
+
+/**
+ * Entity fields to null out when the control mode changes, so entities from
+ * the previous mode don't linger as stale config.
+ *
+ * Wrapped mode uses an inner cover and none of the switch/tilt slots, so all
+ * six are cleared — including tilt_open/tilt_close, which would otherwise
+ * survive and trip the backend script guard. Switch/toggle keep the direction
+ * switches but drop the wrapped cover and the pulse-only stop slots. Pulse
+ * only drops the wrapped cover.
+ */
+export function clearedEntitiesForMode(mode) {
+  const updates = {};
+  if (mode === "wrapped") {
+    updates.open_switch_entity_id = null;
+    updates.close_switch_entity_id = null;
+    updates.stop_switch_entity_id = null;
+    updates.tilt_open_switch = null;
+    updates.tilt_close_switch = null;
+    updates.tilt_stop_switch = null;
+  } else {
+    updates.cover_entity_id = null;
+  }
+  if (mode !== "pulse") {
+    updates.stop_switch_entity_id = null;
+    updates.tilt_stop_switch = null;
+  }
+  return updates;
+}

--- a/custom_components/cover_time_based/manifest.json
+++ b/custom_components/cover_time_based/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/Sese-Schneider/ha-cover-time-based/issues",
   "requirements": [],
-  "version": "4.0.0"
+  "version": "4.1.0"
 }

--- a/custom_components/cover_time_based/websocket_api.py
+++ b/custom_components/cover_time_based/websocket_api.py
@@ -84,15 +84,16 @@ _SWITCH_ENTITY_CONF_KEYS = (
 
 
 def _script_in_non_pulse_mode(control_mode, options):
-    """Return the first script entity_id configured outside pulse/wrapped mode, else None.
+    """Return the first script entity_id configured outside pulse mode, else None.
 
     Scripts are only supported in pulse mode (they auto-return to 'off',
-    which switch/toggle modes misread as a stop). Wrapped mode delegates all
-    movement to an inner cover entity and ignores the switch/tilt slots
-    entirely, so a stale `script.*` value there is harmless. `options` is
-    the merged config that would be persisted.
+    which switch/toggle modes misread as a stop). Every other mode rejects
+    them, keeping the rule simple and unequivocal. Wrapped mode never carries
+    switch-slot entities via the UI — the card clears them when the mode
+    changes (see _onControlModeChange) — so this rejection only fires on raw
+    API/YAML misuse. `options` is the merged config that would be persisted.
     """
-    if control_mode in (CONTROL_MODE_PULSE, CONTROL_MODE_WRAPPED):
+    if control_mode == CONTROL_MODE_PULSE:
         return None
     for key in _SWITCH_ENTITY_CONF_KEYS:
         value = options.get(key)

--- a/custom_components/cover_time_based/websocket_api.py
+++ b/custom_components/cover_time_based/websocket_api.py
@@ -72,6 +72,33 @@ _FIELD_MAP = {
 }
 
 
+# Entity-config fields that may carry a switch- or script-style entity_id.
+_SWITCH_ENTITY_CONF_KEYS = (
+    CONF_OPEN_SWITCH_ENTITY_ID,
+    CONF_CLOSE_SWITCH_ENTITY_ID,
+    CONF_STOP_SWITCH_ENTITY_ID,
+    CONF_TILT_OPEN_SWITCH,
+    CONF_TILT_CLOSE_SWITCH,
+    CONF_TILT_STOP_SWITCH,
+)
+
+
+def _script_in_non_pulse_mode(control_mode, options):
+    """Return the first script entity_id configured outside pulse mode, else None.
+
+    Scripts are only supported in pulse mode (they auto-return to 'off',
+    which switch/toggle modes misread as a stop). `options` is the merged
+    config that would be persisted.
+    """
+    if control_mode == CONTROL_MODE_PULSE:
+        return None
+    for key in _SWITCH_ENTITY_CONF_KEYS:
+        value = options.get(key)
+        if isinstance(value, str) and value.startswith("script."):
+            return value
+    return None
+
+
 def async_register_websocket_api(hass: HomeAssistant) -> None:
     """Register WebSocket API commands."""
     websocket_api.async_register_command(hass, ws_get_config)

--- a/custom_components/cover_time_based/websocket_api.py
+++ b/custom_components/cover_time_based/websocket_api.py
@@ -289,6 +289,21 @@ async def ws_update_config(
                     value = "sequential_close"
                 new_options[conf_key] = value
 
+    # Reject script entities outside pulse mode (they auto-return to 'off',
+    # which switch/toggle modes misread as a stop). Validate the merged result
+    # so switching an existing script-configured cover into switch/toggle is
+    # caught too.
+    offending = _script_in_non_pulse_mode(
+        new_options.get(CONF_CONTROL_MODE), new_options
+    )
+    if offending is not None:
+        connection.send_error(
+            msg["id"],
+            "invalid_entity",
+            "Script entities are only supported in pulse mode",
+        )
+        return
+
     hass.config_entries.async_update_entry(config_entry, options=new_options)
 
     connection.send_result(msg["id"], {"success": True})

--- a/custom_components/cover_time_based/websocket_api.py
+++ b/custom_components/cover_time_based/websocket_api.py
@@ -72,7 +72,7 @@ _FIELD_MAP = {
 }
 
 
-# Entity-config fields that may carry a switch- or script-style entity_id.
+# Entity-id slots that must not hold a `script.` entity outside pulse mode.
 _SWITCH_ENTITY_CONF_KEYS = (
     CONF_OPEN_SWITCH_ENTITY_ID,
     CONF_CLOSE_SWITCH_ENTITY_ID,
@@ -84,13 +84,15 @@ _SWITCH_ENTITY_CONF_KEYS = (
 
 
 def _script_in_non_pulse_mode(control_mode, options):
-    """Return the first script entity_id configured outside pulse mode, else None.
+    """Return the first script entity_id configured outside pulse/wrapped mode, else None.
 
     Scripts are only supported in pulse mode (they auto-return to 'off',
-    which switch/toggle modes misread as a stop). `options` is the merged
-    config that would be persisted.
+    which switch/toggle modes misread as a stop). Wrapped mode delegates all
+    movement to an inner cover entity and ignores the switch/tilt slots
+    entirely, so a stale `script.*` value there is harmless. `options` is
+    the merged config that would be persisted.
     """
-    if control_mode == CONTROL_MODE_PULSE:
+    if control_mode in (CONTROL_MODE_PULSE, CONTROL_MODE_WRAPPED):
         return None
     for key in _SWITCH_ENTITY_CONF_KEYS:
         value = options.get(key)
@@ -300,7 +302,7 @@ async def ws_update_config(
         connection.send_error(
             msg["id"],
             "invalid_entity",
-            "Script entities are only supported in pulse mode",
+            f"Script entities are only supported in pulse mode (got {offending})",
         )
         return
 

--- a/tests/frontend/switch_picker.test.mjs
+++ b/tests/frontend/switch_picker.test.mjs
@@ -6,7 +6,10 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { switchPickerDomains } from "../../custom_components/cover_time_based/frontend/entity-filter.js";
+import {
+  switchPickerDomains,
+  switchLabelKey,
+} from "../../custom_components/cover_time_based/frontend/entity-filter.js";
 
 test("pulse mode allows switch and script domains", () => {
   assert.deepEqual(switchPickerDomains("pulse"), ["switch", "script"]);
@@ -17,4 +20,16 @@ test("non-pulse modes allow only the switch domain", () => {
   assert.deepEqual(switchPickerDomains("toggle"), ["switch"]);
   assert.deepEqual(switchPickerDomains("wrapped"), ["switch"]);
   assert.deepEqual(switchPickerDomains(undefined), ["switch"]);
+});
+
+test("pulse mode maps a label key to its _pulse variant", () => {
+  assert.equal(
+    switchLabelKey("entities.open_switch", "pulse"),
+    "entities.open_switch_pulse"
+  );
+});
+
+test("non-pulse modes use the base label key unchanged", () => {
+  assert.equal(switchLabelKey("entities.open_switch", "switch"), "entities.open_switch");
+  assert.equal(switchLabelKey("entities.open_switch", undefined), "entities.open_switch");
 });

--- a/tests/frontend/switch_picker.test.mjs
+++ b/tests/frontend/switch_picker.test.mjs
@@ -9,6 +9,7 @@ import assert from "node:assert/strict";
 import {
   switchPickerDomains,
   switchLabelKey,
+  clearedEntitiesForMode,
 } from "../../custom_components/cover_time_based/frontend/entity-filter.js";
 
 test("pulse mode allows switch and script domains", () => {
@@ -32,4 +33,34 @@ test("pulse mode maps a label key to its _pulse variant", () => {
 test("non-pulse modes use the base label key unchanged", () => {
   assert.equal(switchLabelKey("entities.open_switch", "switch"), "entities.open_switch");
   assert.equal(switchLabelKey("entities.open_switch", undefined), "entities.open_switch");
+});
+
+test("switching to wrapped clears every switch-based entity slot", () => {
+  const cleared = clearedEntitiesForMode("wrapped");
+  // All six switch/tilt slots nulled — including tilt_open/tilt_close, which
+  // are otherwise stale leftovers that would trip the backend script guard.
+  assert.deepEqual(cleared, {
+    open_switch_entity_id: null,
+    close_switch_entity_id: null,
+    stop_switch_entity_id: null,
+    tilt_open_switch: null,
+    tilt_close_switch: null,
+    tilt_stop_switch: null,
+  });
+});
+
+test("switching to switch/toggle clears the cover and the pulse-only stop slots", () => {
+  for (const mode of ["switch", "toggle"]) {
+    assert.deepEqual(clearedEntitiesForMode(mode), {
+      cover_entity_id: null,
+      stop_switch_entity_id: null,
+      tilt_stop_switch: null,
+    });
+  }
+});
+
+test("switching to pulse only clears the wrapped cover slot", () => {
+  assert.deepEqual(clearedEntitiesForMode("pulse"), {
+    cover_entity_id: null,
+  });
 });

--- a/tests/frontend/switch_picker.test.mjs
+++ b/tests/frontend/switch_picker.test.mjs
@@ -1,0 +1,20 @@
+/**
+ * Tests for switchPickerDomains / switchLabelKey — pulse-mode picker helpers.
+ *
+ * Run: node --test tests/frontend/switch_picker.test.mjs
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { switchPickerDomains } from "../../custom_components/cover_time_based/frontend/entity-filter.js";
+
+test("pulse mode allows switch and script domains", () => {
+  assert.deepEqual(switchPickerDomains("pulse"), ["switch", "script"]);
+});
+
+test("non-pulse modes allow only the switch domain", () => {
+  assert.deepEqual(switchPickerDomains("switch"), ["switch"]);
+  assert.deepEqual(switchPickerDomains("toggle"), ["switch"]);
+  assert.deepEqual(switchPickerDomains("wrapped"), ["switch"]);
+  assert.deepEqual(switchPickerDomains(undefined), ["switch"]);
+});

--- a/tests/test_state_monitoring.py
+++ b/tests/test_state_monitoring.py
@@ -1875,9 +1875,7 @@ class TestPulseModeScriptEntities:
         cover.travel_calc.set_position(0)
 
         with patch.object(cover, "async_write_ha_state"):
-            await cover._handle_external_state_change(
-                "script.open_blind", "off", "on"
-            )
+            await cover._handle_external_state_change("script.open_blind", "off", "on")
 
         assert cover._last_command == SERVICE_OPEN_COVER
 
@@ -1892,9 +1890,7 @@ class TestPulseModeScriptEntities:
         cover.travel_calc.set_position(50)
 
         with patch.object(cover, "async_write_ha_state"):
-            await cover._handle_external_state_change(
-                "script.open_blind", "on", "off"
-            )
+            await cover._handle_external_state_change("script.open_blind", "on", "off")
 
         # OFF edge ignored in pulse mode — no movement, no stop.
         assert not cover.travel_calc.is_traveling()

--- a/tests/test_state_monitoring.py
+++ b/tests/test_state_monitoring.py
@@ -1852,3 +1852,76 @@ class TestRawDirectionChangeEchoFiltering:
                 _make_state_event("switch.open", "on", "off")
             )
             assert not cover.travel_calc.is_traveling()
+
+
+class TestPulseModeScriptEntities:
+    """Pulse mode works with `script` entities (issue #82).
+
+    A script auto-returns to 'off' when it finishes. These tests pin the
+    two behaviors that make scripts safe in pulse mode:
+      - a manual run (off->on) is detected as the external command;
+      - the auto-return (on->off) is ignored, so no spurious stop;
+      - an integration-initiated run + auto-return is fully echo-filtered.
+    """
+
+    @pytest.mark.asyncio
+    async def test_manual_script_run_detected_as_open(self, make_cover):
+        cover = make_cover(
+            control_mode=CONTROL_MODE_PULSE,
+            open_switch="script.open_blind",
+            close_switch="script.close_blind",
+            stop_switch="script.stop_blind",
+        )
+        cover.travel_calc.set_position(0)
+
+        with patch.object(cover, "async_write_ha_state"):
+            await cover._handle_external_state_change(
+                "script.open_blind", "off", "on"
+            )
+
+        assert cover._last_command == SERVICE_OPEN_COVER
+
+    @pytest.mark.asyncio
+    async def test_script_auto_return_to_off_is_ignored(self, make_cover):
+        cover = make_cover(
+            control_mode=CONTROL_MODE_PULSE,
+            open_switch="script.open_blind",
+            close_switch="script.close_blind",
+            stop_switch="script.stop_blind",
+        )
+        cover.travel_calc.set_position(50)
+
+        with patch.object(cover, "async_write_ha_state"):
+            await cover._handle_external_state_change(
+                "script.open_blind", "on", "off"
+            )
+
+        # OFF edge ignored in pulse mode — no movement, no stop.
+        assert not cover.travel_calc.is_traveling()
+
+    @pytest.mark.asyncio
+    async def test_integration_run_and_autoreturn_are_echo_filtered(self, make_cover):
+        cover = make_cover(
+            control_mode=CONTROL_MODE_PULSE,
+            open_switch="script.open_blind",
+            close_switch="script.close_blind",
+            stop_switch="script.stop_blind",
+        )
+        # _send_open marks the open entity pending=2 (expects on + off).
+        cover._pending_switch["script.open_blind"] = 2
+
+        on_event = _make_state_event("script.open_blind", "off", "on")
+        off_event = _make_state_event("script.open_blind", "on", "off")
+
+        with (
+            patch.object(cover, "async_write_ha_state"),
+            patch.object(
+                cover, "_handle_external_state_change", new_callable=AsyncMock
+            ) as handler,
+        ):
+            await cover._async_switch_state_changed(on_event)
+            await cover._async_switch_state_changed(off_event)
+
+        # Both transitions consumed as echoes — external handler never fires.
+        handler.assert_not_awaited()
+        assert "script.open_blind" not in cover._pending_switch

--- a/tests/test_websocket_api.py
+++ b/tests/test_websocket_api.py
@@ -1616,9 +1616,7 @@ class TestScriptGuardHelper:
     def test_rejects_script_when_control_mode_absent(self):
         # No explicit mode → runtime defaults to switch → scripts must be rejected.
         options = {CONF_OPEN_SWITCH_ENTITY_ID: "script.open_blind"}
-        assert (
-            _script_in_non_pulse_mode(None, options) == "script.open_blind"
-        )
+        assert _script_in_non_pulse_mode(None, options) == "script.open_blind"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_websocket_api.py
+++ b/tests/test_websocket_api.py
@@ -1551,3 +1551,65 @@ class TestCloseIncludesTiltFieldRoundTrip:
         connection.send_error.assert_not_called()
         new_opts = hass.config_entries.async_update_entry.call_args[1]["options"]
         assert "close_includes_tilt" not in new_opts
+
+
+# ---------------------------------------------------------------------------
+# _script_in_non_pulse_mode helper
+# ---------------------------------------------------------------------------
+
+
+class TestScriptGuardHelper:
+    """Tests for _script_in_non_pulse_mode (pure validation helper)."""
+
+    def test_allows_scripts_in_pulse_mode(self):
+        from custom_components.cover_time_based.websocket_api import (
+            _script_in_non_pulse_mode,
+        )
+
+        options = {
+            CONF_CONTROL_MODE: CONTROL_MODE_PULSE,
+            CONF_OPEN_SWITCH_ENTITY_ID: "script.open_blind",
+            CONF_CLOSE_SWITCH_ENTITY_ID: "script.close_blind",
+            CONF_STOP_SWITCH_ENTITY_ID: "script.stop_blind",
+        }
+        assert _script_in_non_pulse_mode(CONTROL_MODE_PULSE, options) is None
+
+    def test_rejects_script_in_switch_mode(self):
+        from custom_components.cover_time_based.websocket_api import (
+            _script_in_non_pulse_mode,
+        )
+
+        options = {
+            CONF_CONTROL_MODE: CONTROL_MODE_SWITCH,
+            CONF_OPEN_SWITCH_ENTITY_ID: "script.open_blind",
+            CONF_CLOSE_SWITCH_ENTITY_ID: "switch.close_relay",
+        }
+        assert (
+            _script_in_non_pulse_mode(CONTROL_MODE_SWITCH, options)
+            == "script.open_blind"
+        )
+
+    def test_rejects_script_tilt_entity_in_toggle_mode(self):
+        from custom_components.cover_time_based.websocket_api import (
+            _script_in_non_pulse_mode,
+        )
+
+        options = {
+            CONF_CONTROL_MODE: CONTROL_MODE_TOGGLE,
+            CONF_TILT_OPEN_SWITCH: "script.tilt_open",
+        }
+        assert (
+            _script_in_non_pulse_mode(CONTROL_MODE_TOGGLE, options)
+            == "script.tilt_open"
+        )
+
+    def test_allows_plain_switches_in_switch_mode(self):
+        from custom_components.cover_time_based.websocket_api import (
+            _script_in_non_pulse_mode,
+        )
+
+        options = {
+            CONF_OPEN_SWITCH_ENTITY_ID: "switch.open_relay",
+            CONF_CLOSE_SWITCH_ENTITY_ID: "switch.close_relay",
+        }
+        assert _script_in_non_pulse_mode(CONTROL_MODE_SWITCH, options) is None

--- a/tests/test_websocket_api.py
+++ b/tests/test_websocket_api.py
@@ -29,6 +29,7 @@ from custom_components.cover_time_based.cover import (
 )
 from custom_components.cover_time_based.websocket_api import (
     _resolve_config_entry,
+    _script_in_non_pulse_mode,
     async_register_websocket_api,
     ws_get_config,
     ws_raw_command,
@@ -1562,10 +1563,6 @@ class TestScriptGuardHelper:
     """Tests for _script_in_non_pulse_mode (pure validation helper)."""
 
     def test_allows_scripts_in_pulse_mode(self):
-        from custom_components.cover_time_based.websocket_api import (
-            _script_in_non_pulse_mode,
-        )
-
         options = {
             CONF_CONTROL_MODE: CONTROL_MODE_PULSE,
             CONF_OPEN_SWITCH_ENTITY_ID: "script.open_blind",
@@ -1575,10 +1572,6 @@ class TestScriptGuardHelper:
         assert _script_in_non_pulse_mode(CONTROL_MODE_PULSE, options) is None
 
     def test_rejects_script_in_switch_mode(self):
-        from custom_components.cover_time_based.websocket_api import (
-            _script_in_non_pulse_mode,
-        )
-
         options = {
             CONF_CONTROL_MODE: CONTROL_MODE_SWITCH,
             CONF_OPEN_SWITCH_ENTITY_ID: "script.open_blind",
@@ -1590,10 +1583,6 @@ class TestScriptGuardHelper:
         )
 
     def test_rejects_script_tilt_entity_in_toggle_mode(self):
-        from custom_components.cover_time_based.websocket_api import (
-            _script_in_non_pulse_mode,
-        )
-
         options = {
             CONF_CONTROL_MODE: CONTROL_MODE_TOGGLE,
             CONF_TILT_OPEN_SWITCH: "script.tilt_open",
@@ -1604,15 +1593,25 @@ class TestScriptGuardHelper:
         )
 
     def test_allows_plain_switches_in_switch_mode(self):
-        from custom_components.cover_time_based.websocket_api import (
-            _script_in_non_pulse_mode,
-        )
-
         options = {
             CONF_OPEN_SWITCH_ENTITY_ID: "switch.open_relay",
             CONF_CLOSE_SWITCH_ENTITY_ID: "switch.close_relay",
         }
         assert _script_in_non_pulse_mode(CONTROL_MODE_SWITCH, options) is None
+
+    def test_allows_scripts_in_wrapped_mode(self):
+        options = {
+            CONF_CONTROL_MODE: CONTROL_MODE_WRAPPED,
+            CONF_OPEN_SWITCH_ENTITY_ID: "script.open_blind",
+        }
+        assert _script_in_non_pulse_mode(CONTROL_MODE_WRAPPED, options) is None
+
+    def test_rejects_script_when_control_mode_absent(self):
+        # No explicit mode → runtime defaults to switch → scripts must be rejected.
+        options = {CONF_OPEN_SWITCH_ENTITY_ID: "script.open_blind"}
+        assert (
+            _script_in_non_pulse_mode(None, options) == "script.open_blind"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_websocket_api.py
+++ b/tests/test_websocket_api.py
@@ -1613,3 +1613,87 @@ class TestScriptGuardHelper:
             CONF_CLOSE_SWITCH_ENTITY_ID: "switch.close_relay",
         }
         assert _script_in_non_pulse_mode(CONTROL_MODE_SWITCH, options) is None
+
+
+# ---------------------------------------------------------------------------
+# ws_update_config — script entity guard
+# ---------------------------------------------------------------------------
+
+
+class TestScriptGuardInUpdateConfig:
+    """ws_update_config rejects script entities outside pulse mode."""
+
+    @pytest.mark.asyncio
+    async def test_rejects_setting_script_in_switch_mode(self):
+        config_entry = MagicMock()
+        config_entry.domain = DOMAIN
+        config_entry.options = {CONF_CONTROL_MODE: CONTROL_MODE_SWITCH}
+        hass = MagicMock()
+        conn = _make_connection()
+        msg = {
+            "id": 1,
+            "type": "cover_time_based/update_config",
+            "entity_id": ENTITY_ID,
+            "open_switch_entity_id": "script.open_blind",
+        }
+
+        with patch(
+            "custom_components.cover_time_based.websocket_api._resolve_config_entry",
+            return_value=(config_entry, None),
+        ):
+            await _ws_update_config(hass, conn, msg)
+
+        conn.send_error.assert_called_once()
+        assert conn.send_error.call_args[0][1] == "invalid_entity"
+        hass.config_entries.async_update_entry.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rejects_switching_existing_script_into_switch_mode(self):
+        config_entry = MagicMock()
+        config_entry.domain = DOMAIN
+        config_entry.options = {
+            CONF_CONTROL_MODE: CONTROL_MODE_PULSE,
+            CONF_OPEN_SWITCH_ENTITY_ID: "script.open_blind",
+        }
+        hass = MagicMock()
+        conn = _make_connection()
+        msg = {
+            "id": 1,
+            "type": "cover_time_based/update_config",
+            "entity_id": ENTITY_ID,
+            "control_mode": CONTROL_MODE_SWITCH,
+        }
+
+        with patch(
+            "custom_components.cover_time_based.websocket_api._resolve_config_entry",
+            return_value=(config_entry, None),
+        ):
+            await _ws_update_config(hass, conn, msg)
+
+        conn.send_error.assert_called_once()
+        assert conn.send_error.call_args[0][1] == "invalid_entity"
+        hass.config_entries.async_update_entry.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_allows_script_in_pulse_mode(self):
+        config_entry = MagicMock()
+        config_entry.domain = DOMAIN
+        config_entry.options = {CONF_CONTROL_MODE: CONTROL_MODE_PULSE}
+        hass = MagicMock()
+        conn = _make_connection()
+        msg = {
+            "id": 1,
+            "type": "cover_time_based/update_config",
+            "entity_id": ENTITY_ID,
+            "open_switch_entity_id": "script.open_blind",
+        }
+
+        with patch(
+            "custom_components.cover_time_based.websocket_api._resolve_config_entry",
+            return_value=(config_entry, None),
+        ):
+            await _ws_update_config(hass, conn, msg)
+
+        conn.send_error.assert_not_called()
+        new_opts = hass.config_entries.async_update_entry.call_args[1]["options"]
+        assert new_opts[CONF_OPEN_SWITCH_ENTITY_ID] == "script.open_blind"

--- a/tests/test_websocket_api.py
+++ b/tests/test_websocket_api.py
@@ -1599,12 +1599,19 @@ class TestScriptGuardHelper:
         }
         assert _script_in_non_pulse_mode(CONTROL_MODE_SWITCH, options) is None
 
-    def test_allows_scripts_in_wrapped_mode(self):
+    def test_rejects_script_in_wrapped_mode(self):
+        # Only pulse mode supports scripts. Wrapped never carries switch-slot
+        # scripts via the UI (the card clears them on mode switch), so this
+        # only guards against raw API/YAML misuse — the rule stays simple:
+        # scripts are valid in pulse mode, rejected everywhere else.
         options = {
             CONF_CONTROL_MODE: CONTROL_MODE_WRAPPED,
             CONF_OPEN_SWITCH_ENTITY_ID: "script.open_blind",
         }
-        assert _script_in_non_pulse_mode(CONTROL_MODE_WRAPPED, options) is None
+        assert (
+            _script_in_non_pulse_mode(CONTROL_MODE_WRAPPED, options)
+            == "script.open_blind"
+        )
 
     def test_rejects_script_when_control_mode_absent(self):
         # No explicit mode → runtime defaults to switch → scripts must be rejected.


### PR DESCRIPTION
## Summary

Fixes #82. Before v4.0.0, `script` entities could be used as the open/close/stop targets (e.g. IR-remote-controlled covers, where each script fires an open/close/stop IR command). v4.0.0 restricted the entity pickers to the `switch` domain, removing that ability. This PR re-enables `script` entities — but **only in Pulse mode**, where they work correctly.

### Why pulse mode only

- **Pulse** commands via `homeassistant.turn_on/off` and its external-state handler ignores the OFF edge, so a script's auto-return to `off` is harmless. Pulse already requires a stop target, so open/close/stop are all provided — a perfect fit for the three-script IR case.
- **Switch (latching)** assumes the relay *holds* on for the whole movement and treats OFF as "stop"; a script auto-returns to `off` and would immediately stop the cover. Incompatible.
- **Toggle** is an awkward fit for separate scripts and shares the held-state assumption.
- **Wrapped** drives an inner cover and uses none of these slots.

So the rule is simple and unequivocal: **scripts are valid in pulse mode, rejected everywhere else.**

## Changes

- **Frontend** — the open/close/stop pickers (and dual-motor tilt pickers) offer `switch` + `script` in pulse mode, `switch`-only otherwise. Labels become mode-aware ("Open switch or script" in pulse) across EN/pt/pl. Switching control mode now clears *all* irrelevant entity slots, including the previously-missed `tilt_open_switch`/`tilt_close_switch`.
- **Backend** — `ws_update_config` rejects `script.*` entities when the (merged) control mode isn't pulse, so YAML/API misconfiguration can't slip through; mode-switching an existing cover is validated too.
- **Tests** — pulse-mode script regression tests (manual run detected; auto-return ignored; integration run+auto-return echo-filtered), full guard coverage (`websocket_api.py` at 100%), and frontend helper unit tests.
- **Docs** — README documents script support in pulse mode, including the caveat that scripts running longer than the configured Pulse time get cancelled.
- **Release** — bumps `manifest.json` to **4.1.0** and adds the corresponding `CHANGELOG.md` entry.

## Test Plan

- [x] `pytest tests/` — 863 passed
- [x] `node --test tests/frontend/*.test.mjs` — 17 passed
- [x] `ruff format --check .` and `ruff check .` — clean
- [ ] Manual: in the config card, Pulse mode lists `script.*` entities and labels read "… switch or script"; Switch/Toggle modes hide scripts; Wrapped unchanged.