### PR TITLE
docs: fix README release/license/commit badges (deprecated shields.io endpoints)

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,10 +340,10 @@ cover:
 
 </details>
 
-[commits-shield]: https://img.shields.io/github/commit-activity/y/Sese-Schneider/ha-cover-time-based.svg?style=for-the-badge
+[commits-shield]: https://img.shields.io/github/commit-activity/y/Sese-Schneider/ha-cover-time-based?style=for-the-badge
 [commits]: https://github.com/Sese-Schneider/ha-cover-time-based/commits/main
 [installations-shield]: https://img.shields.io/badge/dynamic/json?url=https://analytics.home-assistant.io/custom_integrations.json&query=$.cover_time_based.total&label=Active%20installations&color=41BDF5&style=for-the-badge
-[license-shield]: https://img.shields.io/github/license/Sese-Schneider/ha-cover-time-based.svg?style=for-the-badge
+[license-shield]: https://img.shields.io/github/license/Sese-Schneider/ha-cover-time-based?style=for-the-badge
 [maintenance-shield]: https://img.shields.io/maintenance/yes/2026.svg?style=for-the-badge
-[releases-shield]: https://img.shields.io/github/release/Sese-Schneider/ha-cover-time-based.svg?style=for-the-badge
+[releases-shield]: https://img.shields.io/github/v/release/Sese-Schneider/ha-cover-time-based?style=for-the-badge
 [releases]: https://github.com/Sese-Schneider/ha-cover-time-based/releases


### PR DESCRIPTION
## Summary

The README's **release** and **license** badges currently render shields.io error text — "unable to select next github token from pool" and (on GitHub's cached image proxy) "invalid" — even though the repo's license is correctly detected as MIT and v4.1.0 is published.

The cause is the **deprecated `.svg` GitHub badge endpoints**, which are flaky on shields.io's side. This switches the three GitHub-API-backed badges to the current endpoint forms, which resolve correctly (verified live):

| Badge | Before | After | Renders |
|---|---|---|---|
| Release | `github/release/…**.svg**` | `github/**v/release**/…` | `v4.1.0` |
| License | `github/license/…**.svg**` | `github/license/…` | `MIT` |
| Commits | `github/commit-activity/y/…**.svg**` | `github/commit-activity/y/…` | `25/year` |

No content/license change — the `LICENSE` file is valid and GitHub already reports `spdx_id: MIT`. The other badges (HACS, maintenance, the dynamic install-count) don't hit the GitHub API and are unaffected.

## Test Plan

- [x] Fetched each new endpoint and confirmed it renders the expected value instead of an error.