### PR TITLE
fix: register card as Lovelace resource so it survives a cold load

### DIFF
--- a/custom_components/cover_time_based/__init__.py
+++ b/custom_components/cover_time_based/__init__.py
@@ -4,13 +4,16 @@ import hashlib
 import logging
 from pathlib import Path
 
-from homeassistant.components import frontend
 from homeassistant.components.http import StaticPathConfig
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.typing import ConfigType
 
+from .card_resources import (
+    async_register_card_resource,
+    async_unregister_card_resource,
+)
 from .const import DOMAIN
 from .position_storage import async_get_position_store
 from .websocket_api import async_register_websocket_api
@@ -33,6 +36,9 @@ def _compute_frontend_hash(files: list[Path]) -> str:
 # entity-filter.js) on every file change, since the relative imports resolve
 # under the same hashed prefix.
 _FRONTEND_HASH = _compute_frontend_hash(list(_FRONTEND_DIR.glob("*.js")))
+# Hash-independent prefix used to recognise (and cache-bust in place) a card
+# resource left over from a previous version.
+_CARD_BASE_URL = f"/{DOMAIN}_panel/"
 _PANEL_URL = f"/{DOMAIN}_panel/{_FRONTEND_HASH}"
 _CARD_JS_URL = f"{_PANEL_URL}/cover-time-based-card.js"
 
@@ -49,12 +55,16 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             )
         ]
     )
-    frontend.add_extra_js_url(hass, _CARD_JS_URL)
+    await async_register_card_resource(hass, _CARD_BASE_URL, _CARD_JS_URL)
     return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Cover Time Based from a config entry."""
+    # Idempotent: re-establishes the card resource whenever an entry is added,
+    # including re-adding a cover after the last one was removed (which
+    # unregisters the resource) — async_setup only runs once per session.
+    await async_register_card_resource(hass, _CARD_BASE_URL, _CARD_JS_URL)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(async_update_options))
 
@@ -82,9 +92,21 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Remove a config entry — drop its saved position."""
+    """Remove a config entry — drop its saved position.
+
+    When the last entry is removed (full uninstall) also clean up the card's
+    Lovelace resource so it doesn't linger in Settings → Dashboards → Resources.
+    """
     store = await async_get_position_store(hass)
     await store.async_remove(entry.entry_id)
+
+    remaining = [
+        e
+        for e in hass.config_entries.async_entries(DOMAIN)
+        if e.entry_id != entry.entry_id
+    ]
+    if not remaining:
+        await async_unregister_card_resource(hass, _CARD_JS_URL)
 
 
 async def async_update_options(hass: HomeAssistant, entry: ConfigEntry) -> None:

--- a/custom_components/cover_time_based/card_resources.py
+++ b/custom_components/cover_time_based/card_resources.py
@@ -54,7 +54,10 @@ async def async_register_card_resource(
             for item in resources.async_items():
                 url = item.get("url", "")
                 if url == card_url:
-                    return  # Already the current version.
+                    # Already current — record the id (hass.data is empty after
+                    # a restart) so a later full uninstall can delete it.
+                    hass.data.setdefault(DOMAIN, {})[_RESOURCE_ID_KEY] = item["id"]
+                    return
                 if url.startswith(base_url):
                     # Old version → cache-bust in place.
                     await resources.async_update_item(item["id"], {"url": card_url})

--- a/custom_components/cover_time_based/card_resources.py
+++ b/custom_components/cover_time_based/card_resources.py
@@ -1,0 +1,106 @@
+"""Lovelace card resource registration for the Cover Time Based card.
+
+The card JS must be registered as a Lovelace *resource* rather than loaded via
+``frontend.add_extra_js_url``. ``add_extra_js_url`` injects the module into the
+index page's ``<script type="module">``, which runs at page load — *before* HA
+lazily installs ``@webcomponents/scoped-custom-element-registry`` on first
+Lovelace render. Installing that polyfill swaps ``window.customElements`` for a
+fresh registry, silently dropping any element defined beforehand, so HA then
+reports "custom element doesn't exist" until the user refreshes. Lovelace
+resources are loaded during Lovelace init (after the swap), so the card
+survives a cold load.
+
+Falls back to ``add_extra_js_url`` when the Lovelace resource store is
+unavailable (e.g. YAML-mode dashboards), where the timing issue doesn't apply.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components import frontend
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+# Key under hass.data[DOMAIN] holding the registered resource's id.
+_RESOURCE_ID_KEY = "card_resource_id"
+
+
+def _get_lovelace_resources(hass: HomeAssistant):
+    """The Lovelace resource collection, or None if unavailable (YAML mode)."""
+    return getattr(hass.data.get("lovelace"), "resources", None)
+
+
+async def async_register_card_resource(
+    hass: HomeAssistant,
+    base_url: str,
+    card_url: str,
+) -> None:
+    """Register the card JS as a Lovelace resource (preferred).
+
+    ``base_url`` is the stable, hash-independent prefix used to recognise a
+    resource left over from a previous version so it can be cache-busted in
+    place; ``card_url`` is the current, content-hashed URL. Falls back to
+    ``add_extra_js_url`` if the Lovelace resource store isn't available.
+    """
+    try:
+        resources = _get_lovelace_resources(hass)
+        if resources is not None and hasattr(resources, "async_create_item"):
+            if not resources.loaded:
+                await resources.async_load()
+                resources.loaded = True
+            for item in resources.async_items():
+                url = item.get("url", "")
+                if url == card_url:
+                    return  # Already the current version.
+                if url.startswith(base_url):
+                    # Old version → cache-bust in place.
+                    await resources.async_update_item(item["id"], {"url": card_url})
+                    hass.data.setdefault(DOMAIN, {})[_RESOURCE_ID_KEY] = item["id"]
+                    return
+            item = await resources.async_create_item(
+                {"res_type": "module", "url": card_url}
+            )
+            hass.data.setdefault(DOMAIN, {})[_RESOURCE_ID_KEY] = item["id"]
+            return
+    except Exception:  # pylint: disable=broad-exception-caught
+        _LOGGER.debug(
+            "Could not register card as a Lovelace resource; "
+            "falling back to add_extra_js_url",
+            exc_info=True,
+        )
+
+    frontend.add_extra_js_url(hass, card_url)
+
+
+async def async_unregister_card_resource(
+    hass: HomeAssistant,
+    card_url: str,
+) -> None:
+    """Remove the card's Lovelace resource (on full uninstall).
+
+    Mirrors :func:`async_register_card_resource`: deletes the resource by the id
+    stored at registration time, or — if the card was added via the
+    ``add_extra_js_url`` fallback (no stored id) — removes that instead.
+    """
+    resource_id = hass.data.get(DOMAIN, {}).get(_RESOURCE_ID_KEY)
+    if resource_id is None:
+        try:
+            frontend.remove_extra_js_url(hass, card_url)
+        except Exception:  # pylint: disable=broad-exception-caught
+            _LOGGER.debug(
+                "Could not remove card via remove_extra_js_url", exc_info=True
+            )
+        return
+
+    try:
+        resources = _get_lovelace_resources(hass)
+        if resources is not None and hasattr(resources, "async_delete_item"):
+            await resources.async_delete_item(resource_id)
+            hass.data.get(DOMAIN, {}).pop(_RESOURCE_ID_KEY, None)
+    except Exception:  # pylint: disable=broad-exception-caught
+        _LOGGER.debug(
+            "Could not remove Lovelace resource %s", resource_id, exc_info=True
+        )

--- a/custom_components/cover_time_based/frontend/cover-time-based-card.js
+++ b/custom_components/cover_time_based/frontend/cover-time-based-card.js
@@ -1948,11 +1948,14 @@ if (!customElements.get("cover-time-based-card")) {
   customElements.define("cover-time-based-card", CoverTimeBasedCard);
 }
 
-// Register with Lovelace card picker
+// Register with Lovelace card picker, guarded against double-evaluation so the
+// picker doesn't list the card twice.
 window.customCards = window.customCards || [];
-window.customCards.push({
-  type: "cover-time-based-card",
-  name: "Cover Time Based Configuration",
-  description:
-    "Configure device type, input entities, timing, and run calibration tests for cover_time_based entities.",
-});
+if (!window.customCards.some((c) => c.type === "cover-time-based-card")) {
+  window.customCards.push({
+    type: "cover-time-based-card",
+    name: "Cover Time Based Configuration",
+    description:
+      "Configure device type, input entities, timing, and run calibration tests for cover_time_based entities.",
+  });
+}

--- a/custom_components/cover_time_based/frontend/cover-time-based-card.js
+++ b/custom_components/cover_time_based/frontend/cover-time-based-card.js
@@ -1941,7 +1941,12 @@ class CoverTimeBasedCard extends LitElement {
   }
 }
 
-customElements.define("cover-time-based-card", CoverTimeBasedCard);
+// Guard the define: now that the card loads via a Lovelace resource (after HA
+// swaps in the scoped-custom-element-registry polyfill) a double-evaluation
+// would otherwise throw "already defined".
+if (!customElements.get("cover-time-based-card")) {
+  customElements.define("cover-time-based-card", CoverTimeBasedCard);
+}
 
 // Register with Lovelace card picker
 window.customCards = window.customCards || [];

--- a/custom_components/cover_time_based/manifest.json
+++ b/custom_components/cover_time_based/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "cover_time_based",
   "name": "Cover Time Based",
+  "after_dependencies": ["lovelace"],
   "codeowners": ["@Sese-Schneider", "@clintongormley"],
   "config_flow": true,
   "dependencies": ["http"],

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -16,6 +16,7 @@ from custom_components.cover_time_based import (
     async_unload_entry,
     async_update_options,
 )
+from custom_components.cover_time_based.card_resources import _RESOURCE_ID_KEY
 from custom_components.cover_time_based.const import DOMAIN
 
 
@@ -196,6 +197,21 @@ class TestCardResourceRegistration:
         mock_add_js.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_setup_records_id_when_resource_already_current(self):
+        """After a restart hass.data is empty but the resource is already
+        current; setup must still record its id so a later uninstall can
+        delete it (rather than leaving it orphaned in Dashboards → Resources)."""
+        resources = FakeResources(
+            items=[{"id": "abc", "url": _CARD_JS_URL}], loaded=True
+        )
+        hass = _make_setup_hass(resources)
+
+        with patch("homeassistant.components.frontend.add_extra_js_url"):
+            await async_setup(hass, {})
+
+        assert hass.data[DOMAIN][_RESOURCE_ID_KEY] == "abc"
+
+    @pytest.mark.asyncio
     async def test_setup_updates_existing_resource_on_version_change(self):
         stale_url = f"{_CARD_BASE_URL}deadbeef/cover-time-based-card.js"
         resources = FakeResources(items=[{"id": "old", "url": stale_url}], loaded=True)
@@ -359,6 +375,30 @@ class TestCardResourceUnregistration:
             await async_remove_entry(hass, entry)
 
         assert resources.deleted == ["new-id"]
+
+    @pytest.mark.asyncio
+    async def test_uninstall_deletes_already_current_resource(self):
+        """Regression: after a restart the resource is already current and
+        hass.data is empty; setup records the id so full uninstall deletes the
+        resource instead of falling back to the no-op remove_extra_js_url."""
+        resources = FakeResources(
+            items=[{"id": "abc", "url": _CARD_JS_URL}], loaded=True
+        )
+        hass = _make_setup_hass(resources)
+
+        with patch("homeassistant.components.frontend.add_extra_js_url"):
+            await async_setup(hass, {})
+
+        entry = MagicMock()
+        entry.entry_id = "e1"
+        hass.config_entries.async_entries = MagicMock(return_value=[])
+        with patch(
+            "custom_components.cover_time_based.async_get_position_store"
+        ) as mock_store:
+            mock_store.return_value.async_remove = AsyncMock()
+            await async_remove_entry(hass, entry)
+
+        assert resources.deleted == ["abc"]
 
     @pytest.mark.asyncio
     async def test_remove_entry_keeps_resource_when_others_remain(self):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -6,14 +6,60 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from custom_components.cover_time_based import (
+    _CARD_BASE_URL,
     _CARD_JS_URL,
     _PANEL_URL,
     _compute_frontend_hash,
+    async_remove_entry,
     async_setup,
     async_setup_entry,
     async_unload_entry,
     async_update_options,
 )
+from custom_components.cover_time_based.const import DOMAIN
+
+
+class FakeResources:
+    """Minimal stand-in for HA's Lovelace resource collection."""
+
+    def __init__(self, items=None, loaded=False):
+        self._items = list(items or [])
+        self.loaded = loaded
+        self.created = []
+        self.updated = []
+        self.deleted = []
+
+    def async_items(self):
+        return list(self._items)
+
+    async def async_load(self):
+        self.loaded = True
+
+    async def async_create_item(self, data):
+        item = {"id": "new-id", **data}
+        self.created.append(data)
+        self._items.append(item)
+        return item
+
+    async def async_update_item(self, item_id, data):
+        self.updated.append((item_id, data))
+
+    async def async_delete_item(self, item_id):
+        self.deleted.append(item_id)
+        self._items = [i for i in self._items if i.get("id") != item_id]
+
+
+def _make_setup_hass(resources):
+    """A hass whose Lovelace resource collection is `resources` (or None)."""
+    hass = MagicMock()
+    hass.http.async_register_static_paths = AsyncMock()
+    if resources is None:
+        hass.data = {}
+    else:
+        lovelace = MagicMock()
+        lovelace.resources = resources
+        hass.data = {"lovelace": lovelace}
+    return hass
 
 
 class TestIntegrationSetup:
@@ -34,26 +80,67 @@ class TestIntegrationSetup:
         entry.async_on_unload.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_setup_entry_does_not_register_frontend(self):
-        """Frontend is registered by async_setup, not per-entry."""
-        hass = MagicMock()
+    async def test_setup_entry_does_not_register_static_path_or_websocket(self):
+        """Static paths and the websocket API are global (async_setup), not per-entry."""
+        resources = FakeResources()
+        hass = _make_setup_hass(resources)
         hass.config_entries.async_forward_entry_setups = AsyncMock()
-        hass.http.async_register_static_paths = AsyncMock()
         entry = MagicMock()
         entry.async_on_unload = MagicMock()
         entry.add_update_listener = MagicMock()
 
-        with (
-            patch("homeassistant.components.frontend.add_extra_js_url") as mock_add_js,
-            patch(
-                "custom_components.cover_time_based.async_register_websocket_api"
-            ) as mock_reg_ws,
-        ):
+        with patch(
+            "custom_components.cover_time_based.async_register_websocket_api"
+        ) as mock_reg_ws:
             await async_setup_entry(hass, entry)
 
-        mock_add_js.assert_not_called()
         mock_reg_ws.assert_not_called()
         hass.http.async_register_static_paths.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_setup_entry_registers_card_resource(self):
+        """Each entry (re)registers the card resource, so re-adding a cover
+        after the last one was removed restores the card without an HA restart."""
+        resources = FakeResources()
+        hass = _make_setup_hass(resources)
+        hass.config_entries.async_forward_entry_setups = AsyncMock()
+        entry = MagicMock()
+        entry.async_on_unload = MagicMock()
+        entry.add_update_listener = MagicMock()
+
+        await async_setup_entry(hass, entry)
+
+        assert len(resources.created) == 1
+        assert resources.created[0]["url"] == _CARD_JS_URL
+
+    @pytest.mark.asyncio
+    async def test_re_add_after_full_removal_reregisters_card(self):
+        """Regression: removing the last entry unregisters the resource; adding
+        a new entry in the same session must register it again."""
+        resources = FakeResources()
+        hass = _make_setup_hass(resources)
+        hass.config_entries.async_forward_entry_setups = AsyncMock()
+
+        # Initial install registers the resource.
+        await async_setup(hass, {})
+        assert len(resources.created) == 1
+        assert resources.async_items()  # resource present
+
+        # Remove the last (only) entry → resource is unregistered.
+        entry = MagicMock()
+        entry.entry_id = "e1"
+        hass.config_entries.async_entries = MagicMock(return_value=[])
+        with patch(
+            "custom_components.cover_time_based.async_get_position_store"
+        ) as mock_store:
+            mock_store.return_value.async_remove = AsyncMock()
+            await async_remove_entry(hass, entry)
+        assert resources.async_items() == []  # resource gone
+
+        # Re-add an entry in the same session → resource restored.
+        await async_setup_entry(hass, entry)
+        assert resources.async_items()
+        assert resources.async_items()[0]["url"] == _CARD_JS_URL
 
 
 class TestGlobalSetup:
@@ -76,18 +163,93 @@ class TestGlobalSetup:
         mock_reg_ws.assert_called_once_with(hass)
 
     @pytest.mark.asyncio
-    async def test_setup_registers_static_path_and_card_js(self):
-        hass = MagicMock()
-        hass.http.async_register_static_paths = AsyncMock()
+    async def test_setup_registers_static_path(self):
+        resources = FakeResources()
+        hass = _make_setup_hass(resources)
 
-        with patch("homeassistant.components.frontend.add_extra_js_url") as mock_add_js:
+        with patch("homeassistant.components.frontend.add_extra_js_url"):
             result = await async_setup(hass, {})
 
         assert result is True
         hass.http.async_register_static_paths.assert_awaited_once()
+
+
+class TestCardResourceRegistration:
+    """The card must be registered as a Lovelace *resource* (loaded during
+    Lovelace init, after HA swaps in the scoped-custom-element-registry
+    polyfill) rather than via add_extra_js_url (injected at page load, before
+    the swap — which drops the element and yields a 'custom element doesn't
+    exist' configuration error until a refresh)."""
+
+    @pytest.mark.asyncio
+    async def test_setup_registers_card_as_lovelace_resource(self):
+        resources = FakeResources()
+        hass = _make_setup_hass(resources)
+
+        with patch("homeassistant.components.frontend.add_extra_js_url") as mock_add_js:
+            await async_setup(hass, {})
+
+        assert resources.loaded is True
+        assert len(resources.created) == 1
+        assert resources.created[0]["res_type"] == "module"
+        assert resources.created[0]["url"] == _CARD_JS_URL
+        mock_add_js.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_setup_updates_existing_resource_on_version_change(self):
+        stale_url = f"{_CARD_BASE_URL}deadbeef/cover-time-based-card.js"
+        resources = FakeResources(items=[{"id": "old", "url": stale_url}], loaded=True)
+        hass = _make_setup_hass(resources)
+
+        with patch("homeassistant.components.frontend.add_extra_js_url"):
+            await async_setup(hass, {})
+
+        assert resources.updated == [("old", {"url": _CARD_JS_URL})]
+        assert resources.created == []
+
+    @pytest.mark.asyncio
+    async def test_setup_skips_when_resource_already_current(self):
+        resources = FakeResources(items=[{"id": "x", "url": _CARD_JS_URL}], loaded=True)
+        hass = _make_setup_hass(resources)
+
+        with patch("homeassistant.components.frontend.add_extra_js_url"):
+            await async_setup(hass, {})
+
+        assert resources.created == []
+        assert resources.updated == []
+
+    @pytest.mark.asyncio
+    async def test_setup_falls_back_to_add_extra_js_url_without_resources(self):
+        hass = _make_setup_hass(None)
+
+        with patch("homeassistant.components.frontend.add_extra_js_url") as mock_add_js:
+            await async_setup(hass, {})
+
         mock_add_js.assert_called_once()
         _, js_url = mock_add_js.call_args.args
-        assert js_url.endswith("/cover-time-based-card.js")
+        assert js_url == _CARD_JS_URL
+
+
+class TestManifest:
+    """Manifest invariants the frontend fix depends on."""
+
+    def test_orders_after_lovelace(self):
+        # `after_dependencies: ["lovelace"]` guarantees Lovelace (and its
+        # resource store) is set up before us, so async_setup registers the
+        # card as a resource instead of silently falling back to the
+        # add_extra_js_url path that drops the element on cold load.
+        import json
+        from pathlib import Path
+
+        manifest = json.loads(
+            (
+                Path(__file__).parent.parent
+                / "custom_components"
+                / "cover_time_based"
+                / "manifest.json"
+            ).read_text()
+        )
+        assert "lovelace" in manifest.get("after_dependencies", [])
 
 
 class TestFrontendCacheBuster:
@@ -162,3 +324,98 @@ class TestIntegrationTeardown:
         await async_update_options(hass, entry)
 
         hass.config_entries.async_reload.assert_awaited_once_with("test_entry_id")
+
+
+class TestCardResourceUnregistration:
+    """On full uninstall (removal of the last config entry) the Lovelace
+    resource should be cleaned up; removing one of several entries must leave
+    it in place."""
+
+    def _make_remove_hass(self, resources, remaining, stored_id="new-id"):
+        hass = MagicMock()
+        lovelace = MagicMock()
+        lovelace.resources = resources
+        data = {"lovelace": lovelace}
+        if stored_id is not None:
+            data[DOMAIN] = {"card_resource_id": stored_id}
+        hass.data = data
+        hass.config_entries.async_entries = MagicMock(return_value=remaining)
+        return hass
+
+    @pytest.mark.asyncio
+    async def test_remove_last_entry_unregisters_card_resource(self):
+        resources = FakeResources(
+            items=[{"id": "new-id", "url": _CARD_JS_URL}], loaded=True
+        )
+        entry = MagicMock()
+        entry.entry_id = "e1"
+        # Only this entry exists; HA has already dropped it from the registry.
+        hass = self._make_remove_hass(resources, remaining=[])
+
+        with patch(
+            "custom_components.cover_time_based.async_get_position_store"
+        ) as mock_store:
+            mock_store.return_value.async_remove = AsyncMock()
+            await async_remove_entry(hass, entry)
+
+        assert resources.deleted == ["new-id"]
+
+    @pytest.mark.asyncio
+    async def test_remove_entry_keeps_resource_when_others_remain(self):
+        resources = FakeResources(
+            items=[{"id": "new-id", "url": _CARD_JS_URL}], loaded=True
+        )
+        entry = MagicMock()
+        entry.entry_id = "e1"
+        other = MagicMock()
+        other.entry_id = "e2"
+        hass = self._make_remove_hass(resources, remaining=[other])
+
+        with patch(
+            "custom_components.cover_time_based.async_get_position_store"
+        ) as mock_store:
+            mock_store.return_value.async_remove = AsyncMock()
+            await async_remove_entry(hass, entry)
+
+        assert resources.deleted == []
+
+    @pytest.mark.asyncio
+    async def test_remove_entry_excludes_self_from_remaining(self):
+        # HA may still list the entry being removed; it must not count as a
+        # surviving consumer of the resource.
+        resources = FakeResources(
+            items=[{"id": "new-id", "url": _CARD_JS_URL}], loaded=True
+        )
+        entry = MagicMock()
+        entry.entry_id = "e1"
+        hass = self._make_remove_hass(resources, remaining=[entry])
+
+        with patch(
+            "custom_components.cover_time_based.async_get_position_store"
+        ) as mock_store:
+            mock_store.return_value.async_remove = AsyncMock()
+            await async_remove_entry(hass, entry)
+
+        assert resources.deleted == ["new-id"]
+
+    @pytest.mark.asyncio
+    async def test_remove_last_entry_falls_back_to_remove_extra_js_url(self):
+        # Registered via the add_extra_js_url fallback → no stored resource id.
+        entry = MagicMock()
+        entry.entry_id = "e1"
+        hass = self._make_remove_hass(None, remaining=[], stored_id=None)
+
+        with (
+            patch(
+                "custom_components.cover_time_based.async_get_position_store"
+            ) as mock_store,
+            patch(
+                "homeassistant.components.frontend.remove_extra_js_url"
+            ) as mock_remove_js,
+        ):
+            mock_store.return_value.async_remove = AsyncMock()
+            await async_remove_entry(hass, entry)
+
+        mock_remove_js.assert_called_once()
+        _, js_url = mock_remove_js.call_args.args
+        assert js_url == _CARD_JS_URL


### PR DESCRIPTION
## Problem

The configuration panel/card sometimes fails to load on a cold start, showing **"Configuration error: custom element doesn't exist"** and only working after a manual refresh.

### Root cause

The card JS is loaded via `frontend.add_extra_js_url`, which injects the module into the index page's `<script type="module">` — it runs at **page load**, before HA lazily installs `@webcomponents/scoped-custom-element-registry` on the first Lovelace render. Installing that polyfill **swaps `window.customElements` for a fresh registry**, silently dropping the element defined beforehand. HA then resolves the card against the swapped registry → the configuration error. A refresh works because the polyfill is already installed before the module re-runs.

## Fix

Register the card as a **Lovelace resource** instead — HA loads those during Lovelace init, *after* the registry swap, so the card survives a cold load. Falls back to `add_extra_js_url` only when the resource store is unavailable (YAML-resource mode, where the timing issue doesn't apply).

- **Register in `async_setup_entry`** (idempotent) as well as `async_setup`, so re-adding a cover after the last one was removed re-establishes the resource without an HA restart.
- **Remove the resource on full uninstall** (when the last config entry is removed), so it doesn't linger in Settings → Dashboards → Resources.
- **`after_dependencies: ["lovelace"]`** guarantees the resource store is set up before this integration, so registration doesn't fall back to the buggy `add_extra_js_url` path due to startup ordering.
- **Guard `customElements.define`** against double-evaluation.

## Tests

New unit tests in `tests/test_init.py` cover resource create/update-in-place/skip-when-current/fallback, removal on last-entry uninstall (and keeping it when other entries remain), the re-add-after-removal regression, and the `after_dependencies` manifest invariant. Full suite: **874 passing**; `ruff` clean.