### PR TITLE
Mark cover unavailable and reject movement when target entities are unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - **Tilt support for wrapped covers without native tilt** ([#85](https://github.com/Sese-Schneider/ha-cover-time-based/issues/85)): the **Inline** and **Sequential** tilt modes are now available when wrapping an existing cover, even if that cover only exposes open/close/stop. These modes drive the wrapped cover's normal open/close commands, so they work on any cover — previously the tilt options were hidden unless the wrapped cover reported native tilt support. The **Separate tilt motor** mode still requires native tilt support (it delegates the tilt commands to the wrapped entity), so it remains hidden until the selected cover advertises it.
 - **Ignore reported position (wrapped covers)**: a new option to track position purely by time and ignore the `current_position` the wrapped cover reports. Enable it for covers that report an unreliable position (the fully-closed endpoint is still trusted).
+- **Detect unavailable relays / targets** ([#89](https://github.com/Sese-Schneider/ha-cover-time-based/issues/89)): the cover now reports as **unavailable** whenever any of its underlying target entities (the switches, buttons, scripts, or wrapped cover that drive it) is unavailable — for example an MQTT relay going offline. Commands that would *start* movement in a direction whose target is unavailable are rejected instead of silently running the time-based simulation and drifting the reported position. Stopping is always allowed, so a cover can still be halted even while a target is offline.
 
 ### Fixes
 

--- a/custom_components/cover_time_based/cover_base.py
+++ b/custom_components/cover_time_based/cover_base.py
@@ -649,15 +649,13 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         current_tilt = (
             self.tilt_calc.current_position() if self._tilt_strategy else None
         )
-        # A tilt pre-step started here returns before the gate below — see
-        # _require_movement_target_available.
+        self._require_movement_target_available(self._movement_target(closing))
         tilt_target, pre_step_delay, started = await self._plan_tilt_for_travel(
             target, command, current, current_tilt
         )
         if started:
             return
 
-        self._require_movement_target_available(self._movement_target(closing))
         await self._async_handle_command(command)
         coupled_calc = self.tilt_calc if tilt_target is not None else None
         self._begin_movement(
@@ -1502,11 +1500,16 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
             travel_target,
             travel_command,
         )
+        closing_tilt = tilt_target < current_tilt
+        self._require_movement_target_available(
+            self._tilt_movement_target(
+                SERVICE_CLOSE_COVER if closing_tilt else SERVICE_OPEN_COVER
+            )
+        )
         self._pending_travel_target = travel_target
         self._pending_travel_command = travel_command
         self._tilt_restore_target = restore_target
 
-        closing_tilt = tilt_target < current_tilt
         if not self._triggered_externally:
             if closing_tilt:
                 await self._send_tilt_close()
@@ -1565,11 +1568,11 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
             tilt_target,
             tilt_command,
         )
-        self._pending_tilt_target = tilt_target
-        self._pending_tilt_command = tilt_command
-
         closing = travel_target < current_pos
         command = SERVICE_CLOSE_COVER if closing else SERVICE_OPEN_COVER
+        self._require_movement_target_available(self._movement_target(closing))
+        self._pending_tilt_target = tilt_target
+        self._pending_tilt_command = tilt_command
         self._last_command = command
         await self._async_handle_command(command)
 

--- a/custom_components/cover_time_based/cover_base.py
+++ b/custom_components/cover_time_based/cover_base.py
@@ -1178,9 +1178,11 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         so the cover can always be halted regardless of target availability.
 
         Movement that runs via a pre-step (dual-motor / sequential) returns from
-        the funnel before reaching this per-direction gate; that drive is covered
-        instead by the all-targets `available` flag (the cover reports
-        unavailable whenever any target is down).
+        the funnel before reaching the funnel's own per-direction gate, so each
+        pre-step phase calls this directly for its target (in
+        `_start_tilt_pre_step` / `_start_travel_pre_step`). The all-targets
+        `available` flag (the cover reports unavailable whenever any target is
+        down) is the backstop covering both paths.
         """
         if not self._self_initiated_movement or self.hass is None:
             return

--- a/custom_components/cover_time_based/cover_base.py
+++ b/custom_components/cover_time_based/cover_base.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
     SERVICE_CLOSE_COVER,
     SERVICE_OPEN_COVER,
     SERVICE_STOP_COVER,
+    STATE_UNAVAILABLE,
 )
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
@@ -183,6 +184,17 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
     # Lifecycle
     # -----------------------------------------------------------------------
 
+    # Single source of truth for the switch-target attribute names. Used both
+    # to register state-change listeners and to enumerate configured targets.
+    _SWITCH_TARGET_ATTRS = (
+        "_open_switch_entity_id",
+        "_close_switch_entity_id",
+        "_stop_switch_entity_id",
+        "_tilt_open_switch_id",
+        "_tilt_close_switch_id",
+        "_tilt_stop_switch_id",
+    )
+
     async def async_added_to_hass(self):
         """Only cover's position and tilt matters."""
         pos, tilt_pos = await self._async_load_restored_positions()
@@ -192,14 +204,7 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
                 self.tilt_calc.set_position(int(tilt_pos))
 
         # Register state change listeners for switch entities
-        for attr in (
-            "_open_switch_entity_id",
-            "_close_switch_entity_id",
-            "_stop_switch_entity_id",
-            "_tilt_open_switch_id",
-            "_tilt_close_switch_id",
-            "_tilt_stop_switch_id",
-        ):
+        for attr in self._SWITCH_TARGET_ATTRS:
             entity_id = getattr(self, attr, None)
             if entity_id:
                 self._state_listener_unsubs.append(
@@ -253,8 +258,10 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
 
     @property
     def available(self) -> bool:
-        """Return True if the cover is properly configured and available."""
-        return len(self._get_missing_configuration()) == 0
+        """Return True if the cover is configured and its targets are available."""
+        return (
+            not self._get_missing_configuration() and not self._any_target_unavailable()
+        )
 
     @property
     def assumed_state(self):
@@ -642,12 +649,15 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         current_tilt = (
             self.tilt_calc.current_position() if self._tilt_strategy else None
         )
+        # A tilt pre-step started here returns before the gate below — see
+        # _require_movement_target_available.
         tilt_target, pre_step_delay, started = await self._plan_tilt_for_travel(
             target, command, current, current_tilt
         )
         if started:
             return
 
+        self._require_movement_target_available(self._movement_target(closing))
         await self._async_handle_command(command)
         coupled_calc = self.tilt_calc if tilt_target is not None else None
         self._begin_movement(
@@ -736,6 +746,9 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
             needs_travel_pre_step,
         )
 
+        self._require_movement_target_available(self._tilt_movement_target(command))
+        # The travel pre-step below isn't covered by the tilt gate above — see
+        # _require_movement_target_available.
         if needs_travel_pre_step and travel_target is not None:
             await self._start_travel_pre_step(travel_target, target, command)
             return
@@ -828,6 +841,8 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         current_tilt = (
             self.tilt_calc.current_position() if self._tilt_strategy else None
         )
+        # A tilt pre-step started here returns before the gate below — see
+        # _require_movement_target_available.
         tilt_target, pre_step_delay, started = await self._plan_tilt_for_travel(
             target, command, current, current_tilt
         )
@@ -851,6 +866,7 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
             )
             return
 
+        self._require_movement_target_available(self._movement_target(closing))
         await self._async_handle_command(command)
         self._begin_movement(
             target,
@@ -939,6 +955,9 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         ):
             return
 
+        self._require_movement_target_available(self._tilt_movement_target(command))
+        # The travel pre-step below isn't covered by the tilt gate above — see
+        # _require_movement_target_available.
         if needs_travel_pre_step and travel_target is not None:
             await self._start_travel_pre_step(travel_target, target, command)
             return
@@ -1102,6 +1121,75 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         if self._travel_time_close is None and self._travel_time_open is None:
             missing.append("travel times")
         return missing
+
+    def _target_entity_ids(self) -> list[str]:
+        """Return the configured target entity IDs this cover drives.
+
+        These are the switch/button/script entities that actually move the
+        device. Subclasses (e.g. wrapped mode) extend this with their own
+        targets.
+        """
+        return [
+            entity_id
+            for attr in self._SWITCH_TARGET_ATTRS
+            if (entity_id := getattr(self, attr, None))
+        ]
+
+    @staticmethod
+    def _entity_unavailable(state) -> bool:
+        """Return True if a target entity is unavailable.
+
+        Unavailable means the entity is missing (state is None) or its state is
+        STATE_UNAVAILABLE. STATE_UNKNOWN is treated as available (a connected
+        entity whose value isn't known yet, e.g. a button after a restart).
+        """
+        return state is None or state.state == STATE_UNAVAILABLE
+
+    def _any_target_unavailable(self) -> bool:
+        """Short-circuiting check used by the hot-path `available` property."""
+        if self.hass is None:
+            return False
+        return any(
+            self._entity_unavailable(self.hass.states.get(entity_id))
+            for entity_id in self._target_entity_ids()
+        )
+
+    def _movement_target(self, closing: bool) -> str | None:
+        """Entity driven to move the cover in the given travel direction."""
+        return self._close_switch_entity_id if closing else self._open_switch_entity_id
+
+    def _tilt_movement_target(self, command: str) -> str | None:
+        """Entity driven for a resolved tilt command.
+
+        ``command`` is what the funnel already computed via ``tilt_command_for``
+        (which some strategies, e.g. sequential_open, invert). Dual-motor tilt
+        uses dedicated tilt switches; shared-motor tilt drives the main travel
+        switch.
+        """
+        closing = command == SERVICE_CLOSE_COVER
+        if self._tilt_strategy is not None and self._tilt_strategy.uses_tilt_motor:
+            return self._tilt_close_switch_id if closing else self._tilt_open_switch_id
+        return self._movement_target(closing)
+
+    def _require_movement_target_available(self, target: str | None) -> None:
+        """Reject a fresh, self-initiated movement whose target is unavailable.
+
+        Only fresh user/automation movement is gated (`_self_initiated_movement`).
+        Stops, reverses, external reactions, retargets, and internal
+        continuations never reach here (or have `_self_initiated_movement` False),
+        so the cover can always be halted regardless of target availability.
+
+        Movement that runs via a pre-step (dual-motor / sequential) returns from
+        the funnel before reaching this per-direction gate; that drive is covered
+        instead by the all-targets `available` flag (the cover reports
+        unavailable whenever any target is down).
+        """
+        if not self._self_initiated_movement or self.hass is None:
+            return
+        if target and self._entity_unavailable(self.hass.states.get(target)):
+            raise HomeAssistantError(
+                f"Cover target '{target}' is unavailable; cannot start movement."
+            )
 
     def _has_tilt_support(self):
         """Return if cover has tilt support."""
@@ -1766,6 +1854,15 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         entity_id = event.data.get("entity_id")
         new_state = event.data.get("new_state")
         old_state = event.data.get("old_state")
+
+        # Availability transition: push a state write so `available` updates
+        # live in the UI. Done before the None-guard below so entity
+        # removal/re-appearance is also reflected. An "unavailable" transition
+        # drives no movement (it matches no opening/closing/stopped branch).
+        was_unavailable = self._entity_unavailable(old_state)
+        now_unavailable = self._entity_unavailable(new_state)
+        if was_unavailable != now_unavailable:
+            self.async_write_ha_state()
 
         if new_state is None or old_state is None:
             return

--- a/custom_components/cover_time_based/cover_wrapped.py
+++ b/custom_components/cover_time_based/cover_wrapped.py
@@ -62,6 +62,21 @@ class WrappedCoverTimeBased(CoverTimeBased):
         """Return True if the wrapped cover entity is configured."""
         return bool(self._cover_entity_id)
 
+    def _target_entity_ids(self) -> list[str]:
+        """Wrapped mode drives the wrapped cover entity."""
+        ids = super()._target_entity_ids()
+        if self._cover_entity_id:
+            ids.append(self._cover_entity_id)
+        return ids
+
+    def _movement_target(self, closing: bool) -> str | None:
+        """Wrapped mode drives the wrapped cover entity for all travel."""
+        return self._cover_entity_id
+
+    def _tilt_movement_target(self, command: str) -> str | None:
+        """Wrapped mode drives the wrapped cover entity for all tilt."""
+        return self._cover_entity_id
+
     def _start_bounce_grace_window(self) -> None:
         self._last_self_command_time = time.monotonic()
 

--- a/tests/test_unavailable_targets.py
+++ b/tests/test_unavailable_targets.py
@@ -1,0 +1,375 @@
+"""Tests for rejecting commands / marking unavailable when targets are unavailable."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.exceptions import HomeAssistantError
+
+from custom_components.cover_time_based.cover import (
+    CONTROL_MODE_SWITCH,
+)
+
+
+def _set_target_states(cover, mapping):
+    """Make cover.hass.states.get return per-entity states.
+
+    mapping: {entity_id: state_string or None}. None => entity missing.
+    Any entity not in mapping returns a default 'on' state (available).
+    """
+
+    def _get(entity_id):
+        if entity_id in mapping:
+            value = mapping[entity_id]
+            if value is None:
+                return None
+            st = MagicMock()
+            st.state = value
+            return st
+        st = MagicMock()
+        st.state = "on"
+        return st
+
+    cover.hass.states.get = MagicMock(side_effect=_get)
+
+
+def _make_state_event(entity_id, old_state, new_state):
+    """Build a HA-style state-change event (old/new states may be None)."""
+    old = None
+    if old_state is not None:
+        old = MagicMock()
+        old.state = old_state
+        old.attributes = {}
+    new = None
+    if new_state is not None:
+        new = MagicMock()
+        new.state = new_state
+        new.attributes = {}
+    event = MagicMock()
+    event.data = {"entity_id": entity_id, "old_state": old, "new_state": new}
+    return event
+
+
+class TestEntityUnavailableHelper:
+    def test_none_state_is_unavailable(self, make_cover):
+        cover = make_cover(open_switch="switch.open", close_switch="switch.close")
+        assert cover._entity_unavailable(None) is True
+
+    def test_unavailable_state_is_unavailable(self, make_cover):
+        cover = make_cover(open_switch="switch.open", close_switch="switch.close")
+        st = MagicMock()
+        st.state = STATE_UNAVAILABLE
+        assert cover._entity_unavailable(st) is True
+
+    def test_unknown_state_is_available(self, make_cover):
+        cover = make_cover(open_switch="switch.open", close_switch="switch.close")
+        st = MagicMock()
+        st.state = STATE_UNKNOWN
+        assert cover._entity_unavailable(st) is False
+
+    def test_on_state_is_available(self, make_cover):
+        cover = make_cover(open_switch="switch.open", close_switch="switch.close")
+        st = MagicMock()
+        st.state = "on"
+        assert cover._entity_unavailable(st) is False
+
+
+class TestUnavailableTargetHelpers:
+    def test_target_entity_ids_lists_configured_switches(self, make_cover):
+        cover = make_cover(
+            control_mode=CONTROL_MODE_SWITCH,
+            open_switch="switch.open",
+            close_switch="switch.close",
+            stop_switch="switch.stop",
+        )
+        assert set(cover._target_entity_ids()) == {
+            "switch.open",
+            "switch.close",
+            "switch.stop",
+        }
+
+    def test_target_entity_ids_for_wrapped_includes_cover(self, make_cover):
+        cover = make_cover(cover_entity_id="cover.real")
+        assert cover._target_entity_ids() == ["cover.real"]
+
+    def test_any_target_unavailable_flags_unavailable_state(self, make_cover):
+        cover = make_cover(open_switch="switch.open", close_switch="switch.close")
+        _set_target_states(cover, {"switch.open": STATE_UNAVAILABLE})
+        assert cover._any_target_unavailable() is True
+
+    def test_any_target_unavailable_flags_missing_entity(self, make_cover):
+        cover = make_cover(open_switch="switch.open", close_switch="switch.close")
+        _set_target_states(cover, {"switch.close": None})
+        assert cover._any_target_unavailable() is True
+
+    def test_any_target_unavailable_ignores_unknown(self, make_cover):
+        cover = make_cover(open_switch="switch.open", close_switch="switch.close")
+        _set_target_states(cover, {"switch.open": STATE_UNKNOWN})
+        assert cover._any_target_unavailable() is False
+
+    def test_any_target_unavailable_false_when_all_available(self, make_cover):
+        cover = make_cover(open_switch="switch.open", close_switch="switch.close")
+        _set_target_states(cover, {})
+        assert cover._any_target_unavailable() is False
+
+
+class TestAvailableProperty:
+    def test_available_true_when_targets_present(self, make_cover):
+        cover = make_cover(open_switch="switch.open", close_switch="switch.close")
+        _set_target_states(cover, {})
+        assert cover.available is True
+
+    def test_available_false_when_target_unavailable(self, make_cover):
+        cover = make_cover(open_switch="switch.open", close_switch="switch.close")
+        _set_target_states(cover, {"switch.open": STATE_UNAVAILABLE})
+        assert cover.available is False
+
+    def test_available_false_when_target_missing(self, make_cover):
+        cover = make_cover(open_switch="switch.open", close_switch="switch.close")
+        _set_target_states(cover, {"switch.open": None})
+        assert cover.available is False
+
+    def test_available_true_when_target_unknown(self, make_cover):
+        cover = make_cover(open_switch="switch.open", close_switch="switch.close")
+        _set_target_states(cover, {"switch.open": STATE_UNKNOWN})
+        assert cover.available is True
+
+    def test_available_false_for_wrapped_when_cover_unavailable(self, make_cover):
+        cover = make_cover(cover_entity_id="cover.real")
+        _set_target_states(cover, {"cover.real": STATE_UNAVAILABLE})
+        assert cover.available is False
+
+
+class TestExternalTriggerNotGatedByUnavailableTarget:
+    """Event-driven re-entry (physical switch reactions) must NOT be blocked by
+    the unavailable-target gate — only direct service calls are rejected.
+    Otherwise a legitimate stop/track is aborted and the tracker desyncs."""
+
+    @pytest.mark.asyncio
+    async def test_external_stop_not_blocked_when_other_target_unavailable(
+        self, make_cover
+    ):
+        cover = make_cover(
+            control_mode=CONTROL_MODE_SWITCH,
+            open_switch="switch.open",
+            close_switch="switch.close",
+        )
+        # close switch is dead, but the open relay is physically operating
+        _set_target_states(cover, {"switch.close": STATE_UNAVAILABLE})
+        cover.travel_calc.set_position(50)
+        cover.travel_calc.start_travel_down()
+        # open relay releasing (on->off) = physical stop in latching mode
+        event = _make_state_event("switch.open", "on", "off")
+        with patch.object(cover, "async_write_ha_state"):
+            await cover._async_switch_state_changed(event)  # must NOT raise
+        assert not cover.travel_calc.is_traveling()
+
+    @pytest.mark.asyncio
+    async def test_external_open_not_blocked_when_other_target_unavailable(
+        self, make_cover
+    ):
+        cover = make_cover(
+            control_mode=CONTROL_MODE_SWITCH,
+            open_switch="switch.open",
+            close_switch="switch.close",
+        )
+        _set_target_states(cover, {"switch.close": STATE_UNAVAILABLE})
+        cover.travel_calc.set_position(0)
+        # open relay engaging (off->on) = physical open in latching mode
+        event = _make_state_event("switch.open", "off", "on")
+        with patch.object(cover, "async_write_ha_state"):
+            await cover._async_switch_state_changed(event)  # must NOT raise
+        assert cover.travel_calc.is_traveling()
+
+
+class TestAvailabilityPush:
+    @pytest.mark.asyncio
+    async def test_write_state_when_target_becomes_unavailable(self, make_cover):
+        cover = make_cover(open_switch="switch.open", close_switch="switch.close")
+        event = _make_state_event("switch.open", "off", STATE_UNAVAILABLE)
+        with patch.object(cover, "async_write_ha_state") as write:
+            await cover._async_switch_state_changed(event)
+        write.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_write_state_when_target_recovers(self, make_cover):
+        cover = make_cover(open_switch="switch.open", close_switch="switch.close")
+        event = _make_state_event("switch.open", STATE_UNAVAILABLE, "off")
+        with patch.object(cover, "async_write_ha_state") as write:
+            await cover._async_switch_state_changed(event)
+        write.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_write_state_when_target_removed(self, make_cover):
+        cover = make_cover(open_switch="switch.open", close_switch="switch.close")
+        event = _make_state_event("switch.open", "off", None)
+        with patch.object(cover, "async_write_ha_state") as write:
+            await cover._async_switch_state_changed(event)
+        write.assert_called()
+
+
+class TestMovementStartGating:
+    @pytest.mark.asyncio
+    async def test_open_raises_when_open_target_unavailable(self, make_cover):
+        cover = make_cover(open_switch="switch.open", close_switch="switch.close")
+        _set_target_states(cover, {"switch.open": STATE_UNAVAILABLE})
+        cover.travel_calc.set_position(0)
+        with patch.object(cover, "async_write_ha_state"):
+            with pytest.raises(HomeAssistantError):
+                await cover.async_open_cover()
+        assert not cover.travel_calc.is_traveling()
+
+    @pytest.mark.asyncio
+    async def test_open_allowed_when_only_close_target_unavailable(self, make_cover):
+        cover = make_cover(open_switch="switch.open", close_switch="switch.close")
+        _set_target_states(cover, {"switch.close": STATE_UNAVAILABLE})
+        cover.travel_calc.set_position(0)
+        with patch.object(cover, "async_write_ha_state"):
+            await cover.async_open_cover()  # open target fine → must NOT raise
+        assert cover.travel_calc.is_traveling()
+
+    @pytest.mark.asyncio
+    async def test_close_raises_when_close_target_unavailable(self, make_cover):
+        cover = make_cover(open_switch="switch.open", close_switch="switch.close")
+        _set_target_states(cover, {"switch.close": STATE_UNAVAILABLE})
+        cover.travel_calc.set_position(100)
+        with patch.object(cover, "async_write_ha_state"):
+            with pytest.raises(HomeAssistantError):
+                await cover.async_close_cover()
+        assert not cover.travel_calc.is_traveling()
+
+    @pytest.mark.asyncio
+    async def test_stop_never_gated(self, make_cover):
+        cover = make_cover(open_switch="switch.open", close_switch="switch.close")
+        _set_target_states(
+            cover,
+            {"switch.open": STATE_UNAVAILABLE, "switch.close": STATE_UNAVAILABLE},
+        )
+        cover.travel_calc.set_position(50)
+        cover.travel_calc.start_travel(100)  # opening
+        with patch.object(cover, "async_write_ha_state"):
+            await cover.async_stop_cover()  # must NOT raise
+        assert not cover.travel_calc.is_traveling()
+
+    @pytest.mark.asyncio
+    async def test_in_motion_open_resolves_to_stop_even_if_open_target_unavailable(
+        self, make_cover
+    ):
+        cover = make_cover(open_switch="switch.open", close_switch="switch.close")
+        _set_target_states(cover, {"switch.open": STATE_UNAVAILABLE})
+        cover.travel_calc.set_position(50)
+        cover.travel_calc.start_travel(100)  # opening
+        assert cover.is_opening
+        with patch.object(cover, "async_write_ha_state"):
+            await cover.async_open_cover()  # in-motion open == stop; must NOT raise
+        assert not cover.travel_calc.is_traveling()
+
+    @pytest.mark.asyncio
+    async def test_external_open_not_gated(self, make_cover):
+        cover = make_cover(
+            control_mode=CONTROL_MODE_SWITCH,
+            open_switch="switch.open",
+            close_switch="switch.close",
+        )
+        _set_target_states(cover, {"switch.open": STATE_UNAVAILABLE})
+        cover.travel_calc.set_position(0)
+        cover._triggered_externally = True
+        try:
+            with patch.object(cover, "async_write_ha_state"):
+                await cover._async_move_to_endpoint(target=100)  # external → not gated
+        finally:
+            cover._triggered_externally = False
+        assert cover.travel_calc.is_traveling()
+
+    @pytest.mark.asyncio
+    async def test_wrapped_open_raises_when_cover_unavailable(self, make_cover):
+        cover = make_cover(cover_entity_id="cover.real")
+        _set_target_states(cover, {"cover.real": STATE_UNAVAILABLE})
+        cover.travel_calc.set_position(0)
+        with patch.object(cover, "async_write_ha_state"):
+            with pytest.raises(HomeAssistantError):
+                await cover.async_open_cover()
+        assert not cover.travel_calc.is_traveling()
+
+    @pytest.mark.asyncio
+    async def test_wrapped_stop_not_gated(self, make_cover):
+        cover = make_cover(cover_entity_id="cover.real")
+        _set_target_states(cover, {"cover.real": STATE_UNAVAILABLE})
+        cover.travel_calc.set_position(50)
+        cover.travel_calc.start_travel(100)
+        with patch.object(cover, "async_write_ha_state"):
+            await cover.async_stop_cover()  # must NOT raise
+        assert not cover.travel_calc.is_traveling()
+
+    @pytest.mark.asyncio
+    async def test_tilt_open_raises_when_tilt_open_target_unavailable(self, make_cover):
+        cover = make_cover(
+            open_switch="switch.open",
+            close_switch="switch.close",
+            tilt_open_switch="switch.tilt_open",
+            tilt_close_switch="switch.tilt_close",
+            tilt_mode="dual_motor",
+            tilt_time_open=5,
+            tilt_time_close=5,
+        )
+        _set_target_states(cover, {"switch.tilt_open": STATE_UNAVAILABLE})
+        cover.tilt_calc.set_position(0)
+        with patch.object(cover, "async_write_ha_state"):
+            with pytest.raises(HomeAssistantError):
+                await cover.async_open_cover_tilt()
+        assert not cover.tilt_calc.is_traveling()
+
+    @pytest.mark.asyncio
+    async def test_tilt_open_allowed_when_only_tilt_close_unavailable(self, make_cover):
+        cover = make_cover(
+            open_switch="switch.open",
+            close_switch="switch.close",
+            tilt_open_switch="switch.tilt_open",
+            tilt_close_switch="switch.tilt_close",
+            tilt_mode="dual_motor",
+            tilt_time_open=5,
+            tilt_time_close=5,
+        )
+        _set_target_states(cover, {"switch.tilt_close": STATE_UNAVAILABLE})
+        cover.tilt_calc.set_position(0)
+        with patch.object(cover, "async_write_ha_state"):
+            await cover.async_open_cover_tilt()  # tilt_open fine → must NOT raise
+        assert cover.tilt_calc.is_traveling()
+
+
+class TestSequentialOpenTiltGating:
+    """sequential_open inverts tilt_command_for: closing the tilt drives the
+    OPEN travel switch. The gate must key off the actual command, not `closing`.
+    """
+
+    def _make(self, make_cover):
+        return make_cover(
+            open_switch="switch.open",
+            close_switch="switch.close",
+            tilt_mode="sequential_open",
+            tilt_time_open=5,
+            tilt_time_close=5,
+        )
+
+    @pytest.mark.asyncio
+    async def test_tilt_close_raises_when_open_switch_unavailable(self, make_cover):
+        # tilt-close fires OPEN (inverted) → gate must check switch.open
+        cover = self._make(make_cover)
+        _set_target_states(cover, {"switch.open": STATE_UNAVAILABLE})
+        cover.tilt_calc.set_position(100)
+        with patch.object(cover, "async_write_ha_state"):
+            with pytest.raises(HomeAssistantError):
+                await cover.async_close_cover_tilt()
+        assert not cover.tilt_calc.is_traveling()
+
+    @pytest.mark.asyncio
+    async def test_tilt_close_allowed_when_only_close_switch_unavailable(
+        self, make_cover
+    ):
+        # tilt-close fires OPEN; the CLOSE switch being dead must NOT block it
+        cover = self._make(make_cover)
+        _set_target_states(cover, {"switch.close": STATE_UNAVAILABLE})
+        cover.tilt_calc.set_position(100)
+        with patch.object(cover, "async_write_ha_state"):
+            await cover.async_close_cover_tilt()  # must NOT raise
+        assert cover.tilt_calc.is_traveling()

--- a/tests/test_unavailable_targets.py
+++ b/tests/test_unavailable_targets.py
@@ -373,3 +373,106 @@ class TestSequentialOpenTiltGating:
         with patch.object(cover, "async_write_ha_state"):
             await cover.async_close_cover_tilt()  # must NOT raise
         assert cover.tilt_calc.is_traveling()
+
+
+class TestPreStepGating:
+    """Dual-motor pre-step paths must honour the movement-target gate.
+
+    These exercise the two cases the per-direction gate could be bypassed by
+    a pre-step that starts a relay before the gate is reached.
+    """
+
+    # GAP 1: dual-motor travel that needs a tilt pre-step must check the tilt target
+    @pytest.mark.asyncio
+    async def test_travel_with_tilt_prestep_raises_when_tilt_target_unavailable(
+        self, make_cover
+    ):
+        cover = make_cover(
+            open_switch="switch.open",
+            close_switch="switch.close",
+            tilt_open_switch="switch.tilt_open",
+            tilt_close_switch="switch.tilt_close",
+            tilt_mode="dual_motor",
+            tilt_time_open=5,
+            tilt_time_close=5,
+        )
+        # safe_tilt_position defaults to 100. Tilt at 30 (not safe) + a real
+        # travel move (50 -> 100) forces the dual-motor tilt-to-safe pre-step:
+        # _plan_tilt_for_travel appends TiltTo(100) and starts _start_tilt_pre_step.
+        cover.travel_calc.set_position(50)
+        cover.tilt_calc.set_position(30)
+        # Tilt opens 30 -> 100, so the gated tilt target is switch.tilt_open;
+        # kill both tilt switches. Travel targets stay available.
+        _set_target_states(
+            cover,
+            {
+                "switch.tilt_open": STATE_UNAVAILABLE,
+                "switch.tilt_close": STATE_UNAVAILABLE,
+            },
+        )
+        with patch.object(cover, "async_write_ha_state"):
+            with pytest.raises(HomeAssistantError):
+                await cover.async_open_cover()
+        assert not cover.tilt_calc.is_traveling()
+        assert not cover.travel_calc.is_traveling()
+
+    # GAP 1b: same path must also check the travel target up front
+    @pytest.mark.asyncio
+    async def test_travel_with_tilt_prestep_raises_when_travel_target_unavailable(
+        self, make_cover
+    ):
+        cover = make_cover(
+            open_switch="switch.open",
+            close_switch="switch.close",
+            tilt_open_switch="switch.tilt_open",
+            tilt_close_switch="switch.tilt_close",
+            tilt_mode="dual_motor",
+            tilt_time_open=5,
+            tilt_time_close=5,
+        )
+        # Same tilt pre-step trigger as above (tilt 30 -> safe 100, travel 50 -> 100).
+        cover.travel_calc.set_position(50)
+        cover.tilt_calc.set_position(30)
+        # Tilt targets fine; the OPEN travel relay (fired after the pre-step) is dead.
+        _set_target_states(cover, {"switch.open": STATE_UNAVAILABLE})
+        with patch.object(cover, "async_write_ha_state"):
+            with pytest.raises(HomeAssistantError):
+                await cover.async_open_cover()
+        assert not cover.tilt_calc.is_traveling()
+        assert not cover.travel_calc.is_traveling()
+
+    # GAP 2: dual-motor tilt that needs a travel pre-step must check the travel target
+    @pytest.mark.asyncio
+    async def test_tilt_with_travel_prestep_raises_when_travel_target_unavailable(
+        self, make_cover
+    ):
+        cover = make_cover(
+            open_switch="switch.open",
+            close_switch="switch.close",
+            tilt_open_switch="switch.tilt_open",
+            tilt_close_switch="switch.tilt_close",
+            tilt_stop_switch="switch.tilt_stop",
+            tilt_mode="dual_motor",
+            tilt_time_open=5,
+            tilt_time_close=5,
+            safe_tilt_position=100,
+            max_tilt_allowed_position=0,
+        )
+        # Travel at 50 (above max_tilt_allowed_position=0) forces the travel
+        # pre-step: plan_move_tilt appends TravelTo(0) before TiltTo, and
+        # _start_travel_pre_step closes the cover to 0 first.
+        cover.travel_calc.set_position(50)
+        cover.tilt_calc.set_position(100)
+        # Tilt targets fine; both travel relays dead (travel pre-step closes -> switch.close).
+        _set_target_states(
+            cover,
+            {
+                "switch.open": STATE_UNAVAILABLE,
+                "switch.close": STATE_UNAVAILABLE,
+            },
+        )
+        with patch.object(cover, "async_write_ha_state"):
+            with pytest.raises(HomeAssistantError):
+                await cover.async_set_cover_tilt_position(tilt_position=50)
+        assert not cover.travel_calc.is_traveling()
+        assert not cover.tilt_calc.is_traveling()


### PR DESCRIPTION
Closes #89.

## Problem

When a cover's underlying target entities (the switches/buttons/scripts that drive it, or the wrapped cover entity) become **unavailable** in Home Assistant — for example an MQTT relay going offline via its last-will, as described in #89 — the integration kept accepting commands and ran its simulated time-based movement anyway. The cover looked usable and the reported position drifted away from physical reality, with no feedback to the user that nothing actually moved.

## What this does

- **Marks the cover `available: false`** whenever any configured target entity is unavailable (missing or `STATE_UNAVAILABLE`). `STATE_UNKNOWN` is treated as available — a `button` entity's state is `unknown` until first pressed, so gating on `unknown` would deadlock button/pulse-mode covers after every restart.
- **Rejects the start of new directional movement** (raises `HomeAssistantError`) when *that direction's* target is unavailable. Gating is per-direction: a dead tilt relay doesn't block travel, and a dead close relay doesn't block opening.
- **Always allows stops.** Explicit `stop_cover`, reversing, and in-motion presses that the integration resolves to a stop (e.g. pressing "open" again while opening in toggle mode) are never gated — the cover can always be halted, even while a target is offline. The stop also halts the internal position tracker so it doesn't keep drifting.
- **Pushes a state update** when a target crosses the availability boundary, so the cover's availability reflects in the UI live.

Works across switch/latching, pulse, toggle and wrapped modes, and for both travel and tilt (inline, sequential, dual-motor — including the inverted `sequential_open` tilt command).

## Implementation notes

- `available` is all-targets (unavailable if *any* target is down); command gating is per-direction (only the target the command actually drives).
- The gate lives at the four movement-start funnels, just before the relay fires and the tracker starts, discriminated by `_self_initiated_movement` so external/physical-switch reactions and internal continuations are never gated.

## Test plan

- Added `tests/test_unavailable_targets.py` covering: `available` reflecting unavailable/missing/unknown targets; per-direction gating (open blocked when open target down, allowed when only close is down; and vice-versa); stop never gated even with all targets down; in-motion open resolving to a stop; external triggers not gated; wrapped-mode gating on the cover entity; dual-motor and inverted `sequential_open` tilt gating; live availability push on transitions.
- Full suite green: `python -m pytest -q` → 895 passed. `ruff check` / `ruff format --check` clean.