### PR TITLE
Add release tooling: bin/release.sh + tag-driven publish + post-release next-minor bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,99 @@
+name: Release
+
+# Publishes a GitHub Release when a v* tag is pushed (HACS reads GitHub
+# releases), then — for final releases only — rolls main forward to the next
+# minor so unreleased work no longer carries the just-released version.
+#
+# Release flow:
+#   1. bin/release.sh <version>  -> opens the chore/release PR (bumps manifest)
+#   2. merge the PR
+#   3. git tag v<version> && git push origin v<version>  -> triggers this workflow
+#
+# No secret or repo setup is required: main is unprotected, so the next-minor
+# bump is pushed directly to main using the default GITHUB_TOKEN.
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    name: Publish GitHub Release
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      prerelease: ${{ steps.version.outputs.prerelease }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract and validate version from tag
+        id: version
+        env:
+          REF: ${{ github.ref }}
+        run: |
+          VERSION="${REF#refs/tags/v}"
+          # Reject off-spec tags (the same semver contract bin/release.sh
+          # enforces), so a hand-pushed bad tag can't slip through.
+          bin/bump-version.sh --validate "$VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          # Any semver pre-release (a hyphen) is a pre-release; the regex only
+          # permits -alpha/-beta/-rc.
+          if [[ "$VERSION" == *-* ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Validate manifest version matches tag
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          MANIFEST_VER=$(python3 -c "import json; print(json.load(open('custom_components/cover_time_based/manifest.json'))['version'])")
+          if [ "$VERSION" != "$MANIFEST_VER" ]; then
+            echo "::error::Tag v$VERSION does not match manifest.json version $MANIFEST_VER"
+            exit 1
+          fi
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v3
+        with:
+          generate_release_notes: true
+          # Pre-releases (alpha/beta/rc) stay off "latest" until promoted via:
+          #   gh release edit v<version> --prerelease=false --latest=true
+          prerelease: ${{ steps.version.outputs.prerelease }}
+          make_latest: ${{ steps.version.outputs.prerelease == 'true' && 'false' || 'true' }}
+
+  bump:
+    needs: publish
+    # Only final releases roll main forward; pre-releases leave the version alone.
+    if: needs.publish.outputs.prerelease == 'false'
+    runs-on: ubuntu-latest
+    name: Bump main to next minor
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Compute next minor and bump version files
+        id: bump
+        env:
+          VERSION: ${{ needs.publish.outputs.version }}
+        run: |
+          NEXT=$(python3 -c "import os; mj, mn, _ = os.environ['VERSION'].split('-')[0].split('.'); print(f'{mj}.{int(mn)+1}.0')")
+          echo "next=$NEXT" >> "$GITHUB_OUTPUT"
+          # Same verified bump bin/release.sh uses, so the two can't drift.
+          bin/bump-version.sh "$NEXT"
+
+      - name: Commit and push the bump directly to main
+        env:
+          NEXT: ${{ steps.bump.outputs.next }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "chore: bump version to $NEXT for development"
+          # main is unprotected, so the default GITHUB_TOKEN can push directly.
+          git push origin HEAD:main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,13 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
+          # No-op guard: if the manifest is already at $NEXT (e.g. a re-run, or
+          # main was hand-bumped), there's nothing to commit — exit cleanly
+          # rather than letting `git commit` fail the job under `set -e`.
+          if git diff --cached --quiet; then
+            echo "manifest already at $NEXT — nothing to bump; skipping commit/push."
+            exit 0
+          fi
           git commit -m "chore: bump version to $NEXT for development"
           # main is unprotected, so the default GITHUB_TOKEN can push directly.
           git push origin HEAD:main

--- a/bin/bump-version.sh
+++ b/bin/bump-version.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Bumps the integration version in the manifest, verified.
+#
+# Single source of truth for the version bump, shared by bin/release.sh (local
+# release prep) and .github/workflows/release.yml (post-release next-minor
+# bump), so the two can never drift.
+#
+# Usage: bin/bump-version.sh <version>             bump manifest to <version>
+#        bin/bump-version.sh --validate <version>  semver-check only, no writes
+#
+# Operates on the current working directory's repo (relative path), so callers
+# must invoke it from the repo root.
+#
+# File bumped:
+#   - custom_components/cover_time_based/manifest.json  (the HA/HACS version of record)
+#
+# This is a pure-Python integration: the manifest is the ONLY version-carrying
+# file (the bundled frontend ships as static ESM with no package.json version).
+#
+# The single write is verified; an edit that fails to land is a hard error
+# rather than a silently stale version.
+
+set -euo pipefail
+
+SEMVER_RE='^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$'
+
+validate() {
+  local v="${1:-}"
+  if ! [[ "$v" =~ $SEMVER_RE ]]; then
+    echo "error: not a valid semver version: $v" >&2
+    echo "expected format: MAJOR.MINOR.PATCH or MAJOR.MINOR.PATCH-(alpha|beta|rc).N" >&2
+    exit 1
+  fi
+}
+
+require_file() {
+  if [ ! -f "$1" ]; then
+    echo "error: expected version file not found: $1" >&2
+    exit 1
+  fi
+}
+
+if [ "${1:-}" = "--validate" ]; then
+  validate "${2:-}"
+  exit 0
+fi
+
+if [ $# -lt 1 ]; then
+  echo "usage: $0 <version> | --validate <version>" >&2
+  exit 2
+fi
+
+VERSION="$1"
+validate "$VERSION"
+
+MANIFEST="custom_components/cover_time_based/manifest.json"
+require_file "$MANIFEST"
+
+# manifest.json carries the version exactly once. Use sed (not a JSON
+# reserialiser) so the manifest's key order is preserved.
+sed -i.bak "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" "$MANIFEST"
+rm -f "$MANIFEST.bak"
+grep -q "\"version\": \"$VERSION\"" "$MANIFEST" \
+  || { echo "error: failed to bump version in $MANIFEST" >&2; exit 1; }

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Prepares a release PR for the Cover Time Based integration.
+#
+# Usage: bin/release.sh <version> [--no-push]
+#
+# Example: bin/release.sh 4.3.0
+#          bin/release.sh 4.3.0-rc.1
+#
+# This is a pure-Python HA integration: the only version-carrying file is the
+# manifest (no frontend build, no npm package). The bundled card ships as static
+# ESM, so there is nothing to rebuild here.
+#
+# What it does:
+#   1. Pre-flight: valid semver, on main, clean tree, tag not taken (locally or
+#      on origin), local main up to date with origin/main, no leftover
+#      chore/release branch.
+#   2. Creates the version-less `chore/release` branch, bumps the manifest
+#      version (via bin/bump-version.sh), commits a `chore: release` marker,
+#      pushes, and opens a PR.
+#
+# After the PR merges, push the v<version> tag to publish the GitHub Release:
+#   git tag v<version> && git push origin v<version>
+# The release workflow then publishes the release and, for final releases,
+# pushes a follow-up commit bumping main to the next minor (main is unprotected).
+#
+# The release branch is deliberately version-less: HACS scans every branch and
+# complains about version numbers in branch names.
+
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+  echo "usage: $0 <version> [--no-push]" >&2
+  exit 2
+fi
+
+VERSION="$1"
+
+SEMVER_RE='^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$'
+if ! [[ "$VERSION" =~ $SEMVER_RE ]]; then
+  echo "error: not a valid semver version: $VERSION" >&2
+  echo "expected format: MAJOR.MINOR.PATCH or MAJOR.MINOR.PATCH-(alpha|beta|rc).N" >&2
+  exit 1
+fi
+
+# Must be on main.
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ "$CURRENT_BRANCH" != "main" ]; then
+  echo "error: must be on main (currently on $CURRENT_BRANCH)" >&2
+  exit 1
+fi
+
+# Working tree must be clean.
+if [ -n "$(git status --porcelain)" ]; then
+  echo "error: working tree is not clean; commit or stash first" >&2
+  exit 1
+fi
+
+# Tag must not exist locally or on origin.
+TAG="v$VERSION"
+if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+  echo "error: tag $TAG already exists locally" >&2
+  exit 1
+fi
+if git ls-remote --tags origin 2>/dev/null | grep -q "refs/tags/$TAG$"; then
+  echo "error: tag $TAG already exists on origin" >&2
+  exit 1
+fi
+
+# Local main must be up to date with origin/main.
+if git remote get-url origin >/dev/null 2>&1; then
+  git fetch -q origin main
+  LOCAL=$(git rev-parse main)
+  REMOTE=$(git rev-parse origin/main)
+  if [ "$LOCAL" != "$REMOTE" ]; then
+    echo "error: local main is not up to date with origin/main" >&2
+    echo "  local:  $LOCAL" >&2
+    echo "  origin: $REMOTE" >&2
+    exit 1
+  fi
+fi
+
+BRANCH="chore/release"
+
+# The release branch has a fixed name, so a leftover one from an aborted or
+# undeleted prior release would make `git checkout -b` crash mid-run. Catch it
+# here, before any work, with a clear message.
+if git rev-parse -q --verify "refs/heads/$BRANCH" >/dev/null; then
+  echo "error: branch $BRANCH already exists locally; delete it first:" >&2
+  echo "  git branch -D $BRANCH" >&2
+  exit 1
+fi
+if git ls-remote --heads origin "$BRANCH" 2>/dev/null | grep -q "refs/heads/$BRANCH$"; then
+  echo "error: branch $BRANCH already exists on origin; delete it first:" >&2
+  echo "  git push origin --delete $BRANCH" >&2
+  exit 1
+fi
+
+# Optional --no-push flag for tests.
+NO_PUSH=false
+if [ "${2:-}" = "--no-push" ]; then
+  NO_PUSH=true
+fi
+
+git checkout -q -b "$BRANCH"
+
+# Bump the manifest version (shared with the release workflow's next-minor bump
+# so they can't drift).
+"$(dirname "$0")/bump-version.sh" "$VERSION"
+
+git add -A
+# --allow-empty supports the "version already bumped in an earlier feature
+# commit" workflow: the release branch still gets a clear `chore: release`
+# marker commit for the tag to point at.
+git commit --allow-empty -qm "chore: release $TAG"
+
+if [ "$NO_PUSH" = "true" ]; then
+  echo "Branch $BRANCH prepared. --no-push given; skipping push and PR creation."
+  exit 0
+fi
+
+# Push the release branch.
+git push -u origin "$BRANCH"
+
+# Open the PR.
+gh pr create \
+  --title "chore: release $TAG" \
+  --body "Release \`$TAG\`: bumps the manifest version to \`$VERSION\`.
+
+After merge, push the tag to publish the GitHub Release:
+
+\`\`\`
+git tag $TAG
+git push origin $TAG
+\`\`\`
+
+The release workflow publishes the GitHub Release and, for final releases,
+rolls \`main\` forward to the next minor.
+"
+
+echo "Release $TAG branch pushed and PR opened."

--- a/tests/test_bump_version.py
+++ b/tests/test_bump_version.py
@@ -1,0 +1,108 @@
+"""Tests for bin/bump-version.sh."""
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "bin" / "bump-version.sh"
+MANIFEST_REL = "custom_components/cover_time_based/manifest.json"
+
+
+def _clean_env(extra: dict | None = None) -> dict:
+    """Return os.environ with all GIT_* vars stripped, plus any extras."""
+    env = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+    if extra:
+        env.update(extra)
+    return env
+
+
+def _run(cwd: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(SCRIPT), *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        env=_clean_env(),
+    )
+
+
+def _make_tmp_repo(tmp_path: Path, version: str = "4.2.0") -> Path:
+    """Create a minimal tree with a manifest.json carrying the given version."""
+    manifest = tmp_path / MANIFEST_REL
+    manifest.parent.mkdir(parents=True)
+    manifest.write_text(
+        json.dumps(
+            {
+                "domain": "cover_time_based",
+                "name": "Cover Time Based",
+                "version": version,
+            },
+            indent=2,
+        )
+        + "\n"
+    )
+    return tmp_path
+
+
+def test_validate_rejects_bad_semver(tmp_path: Path):
+    _make_tmp_repo(tmp_path)
+    before = (tmp_path / MANIFEST_REL).read_text()
+    result = _run(tmp_path, "--validate", "not-a-version")
+    assert result.returncode != 0
+    assert "semver" in (result.stdout + result.stderr).lower()
+    # --validate must not write anything.
+    assert (tmp_path / MANIFEST_REL).read_text() == before
+
+
+def test_validate_accepts_good_semver(tmp_path: Path):
+    _make_tmp_repo(tmp_path)
+    before = (tmp_path / MANIFEST_REL).read_text()
+    for v in ("4.3.0", "5.0.0", "4.3.0-alpha.1", "4.3.0-beta.2", "4.3.0-rc.1"):
+        result = _run(tmp_path, "--validate", v)
+        assert result.returncode == 0, f"{v}: {result.stdout + result.stderr}"
+    # --validate must not write anything.
+    assert (tmp_path / MANIFEST_REL).read_text() == before
+
+
+def test_bump_rewrites_manifest(tmp_path: Path):
+    _make_tmp_repo(tmp_path, version="4.2.0")
+    result = _run(tmp_path, "4.3.0")
+    assert result.returncode == 0, result.stdout + result.stderr
+    data = json.loads((tmp_path / MANIFEST_REL).read_text())
+    assert data["version"] == "4.3.0"
+    # Other keys preserved.
+    assert data["domain"] == "cover_time_based"
+
+
+def test_bump_rejects_bad_semver(tmp_path: Path):
+    _make_tmp_repo(tmp_path)
+    before = (tmp_path / MANIFEST_REL).read_text()
+    result = _run(tmp_path, "not-a-version")
+    assert result.returncode != 0
+    assert "semver" in (result.stdout + result.stderr).lower()
+    assert (tmp_path / MANIFEST_REL).read_text() == before
+
+
+def test_bump_fails_when_manifest_missing(tmp_path: Path):
+    result = _run(tmp_path, "4.3.0")
+    assert result.returncode != 0
+    assert "not found" in (result.stdout + result.stderr).lower()
+
+
+def test_bump_on_copy_of_real_manifest(tmp_path: Path):
+    """Bumping a copy of the real repo manifest works and preserves key order."""
+    src = REPO_ROOT / MANIFEST_REL
+    dst = tmp_path / MANIFEST_REL
+    dst.parent.mkdir(parents=True)
+    shutil.copy(src, dst)
+    keys_before = list(json.loads(dst.read_text()).keys())
+
+    result = _run(tmp_path, "9.9.9")
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    data = json.loads(dst.read_text())
+    assert data["version"] == "9.9.9"
+    assert list(data.keys()) == keys_before, "manifest key order must be preserved"

--- a/tests/test_release_script.py
+++ b/tests/test_release_script.py
@@ -1,0 +1,250 @@
+"""Tests for bin/release.sh.
+
+Invokes the real bash script inside a throwaway git repo in tmp_path. All GIT_*
+env vars are scrubbed so the subprocess git calls operate on the fixture repo
+and never on the parent repo running the test (e.g. under a pre-push hook).
+"""
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "bin" / "release.sh"
+MANIFEST_REL = "custom_components/cover_time_based/manifest.json"
+
+
+def _clean_env(extra: dict | None = None) -> dict:
+    """Return os.environ with all GIT_* vars stripped, plus any extras.
+
+    Without this, subprocess git calls in tests inherit GIT_DIR / GIT_WORK_TREE /
+    GIT_INDEX_FILE from a parent context (e.g. a pre-push hook) and operate on
+    the wrong repo.
+    """
+    env = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+    if extra:
+        env.update(extra)
+    return env
+
+
+def _git(
+    *args: str, cwd: Path, check: bool = True, **kwargs
+) -> subprocess.CompletedProcess:
+    """Run a git command with GIT_* env scrubbed."""
+    return subprocess.run(
+        ["git", *args], cwd=cwd, check=check, env=_clean_env(), **kwargs
+    )
+
+
+def _run(cwd: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(SCRIPT), *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        env=_clean_env(),
+    )
+
+
+def test_rejects_invalid_semver(tmp_path: Path):
+    result = _run(tmp_path, "not-a-version")
+    assert result.returncode != 0
+    assert "semver" in (result.stdout + result.stderr).lower()
+
+
+def test_accepts_alpha_suffix(tmp_path: Path):
+    """Pre-flight should accept alpha pre-release suffix at the semver check.
+    Other pre-flights (clean tree, on main, etc.) will still fail in tmp_path,
+    so we only check that the error is NOT a semver error."""
+    result = _run(tmp_path, "4.3.0-alpha.1")
+    combined = (result.stdout + result.stderr).lower()
+    assert "semver" not in combined
+
+
+def test_accepts_beta_suffix(tmp_path: Path):
+    result = _run(tmp_path, "4.3.0-beta.2")
+    combined = (result.stdout + result.stderr).lower()
+    assert "semver" not in combined
+
+
+def test_accepts_rc_suffix(tmp_path: Path):
+    result = _run(tmp_path, "4.3.0-rc.1")
+    combined = (result.stdout + result.stderr).lower()
+    assert "semver" not in combined
+
+
+def _init_repo(
+    tmp_path: Path, *, branch: str = "main", dirty: bool = False, version: str = "4.2.0"
+) -> Path:
+    """Create a tiny git repo with a manifest.json on the named branch."""
+    _git("init", "-q", "-b", branch, cwd=tmp_path)
+    _git("config", "user.email", "t@test", cwd=tmp_path)
+    _git("config", "user.name", "t", cwd=tmp_path)
+
+    manifest = tmp_path / MANIFEST_REL
+    manifest.parent.mkdir(parents=True)
+    manifest.write_text(
+        json.dumps(
+            {
+                "domain": "cover_time_based",
+                "name": "Cover Time Based",
+                "version": version,
+            },
+            indent=2,
+        )
+        + "\n"
+    )
+    _git("add", ".", cwd=tmp_path)
+    _git("commit", "-qm", "init", cwd=tmp_path)
+    _git("tag", f"v{version}", cwd=tmp_path)
+
+    if dirty:
+        (tmp_path / "dirt").write_text("x")
+
+    return tmp_path
+
+
+def test_rejects_non_main_branch(tmp_path: Path):
+    _init_repo(tmp_path, branch="feature")
+    result = _run(tmp_path, "4.3.0")
+    assert result.returncode != 0
+    assert "main" in (result.stdout + result.stderr).lower()
+
+
+def test_rejects_dirty_tree(tmp_path: Path):
+    _init_repo(tmp_path, dirty=True)
+    result = _run(tmp_path, "4.3.0")
+    assert result.returncode != 0
+    combined = (result.stdout + result.stderr).lower()
+    assert "clean" in combined or "dirty" in combined or "uncommitted" in combined
+
+
+def test_rejects_existing_tag(tmp_path: Path):
+    _init_repo(tmp_path)
+    result = _run(tmp_path, "4.2.0")  # tag v4.2.0 already exists
+    assert result.returncode != 0
+    assert "tag" in (result.stdout + result.stderr).lower()
+
+
+def test_rejects_main_behind_origin(tmp_path: Path):
+    """If local main has fewer commits than origin/main, fail."""
+    origin = tmp_path / "origin.git"
+    _git("init", "-q", "--bare", "-b", "main", str(origin), cwd=tmp_path)
+
+    local = tmp_path / "local"
+    local.mkdir()
+    _init_repo(local)
+    _git("remote", "add", "origin", str(origin), cwd=local)
+    _git("push", "-q", "origin", "main", "--tags", cwd=local)
+
+    # Add a commit on origin that local doesn't have.
+    other = tmp_path / "other"
+    _git("clone", "-q", str(origin), str(other), cwd=tmp_path)
+    _git("config", "user.email", "t@test", cwd=other)
+    _git("config", "user.name", "t", cwd=other)
+    (other / "new.txt").write_text("x")
+    _git("add", ".", cwd=other)
+    _git("commit", "-qm", "new", cwd=other)
+    _git("push", "-q", "origin", "main", cwd=other)
+
+    result = _run(local, "4.3.0")
+    assert result.returncode != 0
+    combined = (result.stdout + result.stderr).lower()
+    assert "up to date" in combined or "behind" in combined
+
+
+def test_rejects_existing_release_branch(tmp_path: Path):
+    """A leftover version-less chore/release branch must be detected up front."""
+    _init_repo(tmp_path)
+    _git("branch", "chore/release", cwd=tmp_path)
+    result = _run(tmp_path, "4.3.0")
+    assert result.returncode != 0
+    assert "chore/release" in (result.stdout + result.stderr)
+
+
+def test_integration_release_bumps_manifest(tmp_path: Path):
+    _init_repo(tmp_path)
+    result = _run(tmp_path, "4.3.0", "--no-push")
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    # Version-less release branch exists.
+    branches = _git(
+        "branch",
+        "--list",
+        "chore/release",
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    ).stdout
+    assert "chore/release" in branches
+
+    # Switch to it and inspect the manifest.
+    _git("checkout", "-q", "chore/release", cwd=tmp_path)
+    data = json.loads((tmp_path / MANIFEST_REL).read_text())
+    assert data["version"] == "4.3.0"
+
+    # A chore: release marker commit sits on top.
+    last_msg = _git(
+        "log", "-1", "--format=%s", cwd=tmp_path, capture_output=True, text=True
+    ).stdout.strip()
+    assert "release v4.3.0" in last_msg, f"unexpected last commit message: {last_msg!r}"
+
+
+def test_pushes_and_opens_pr(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+
+    # Shim gh and git push into a fake bin dir that records calls.
+    fake_bin = tmp_path / "fake_bin"
+    fake_bin.mkdir()
+    log = tmp_path / "calls.log"
+
+    (fake_bin / "gh").write_text(
+        f'#!/usr/bin/env bash\necho "gh $*" >> "{log}"\necho https://github.com/fake/repo/pull/1\n'
+    )
+    (fake_bin / "gh").chmod(0o755)
+
+    real_git = subprocess.check_output(["which", "git"], text=True).strip()
+    (fake_bin / "git").write_text(
+        f'#!/usr/bin/env bash\nif [ "$1" = "push" ]; then echo "git $*" >> "{log}"; exit 0; fi\nexec {real_git} "$@"\n'
+    )
+    (fake_bin / "git").chmod(0o755)
+
+    env = _clean_env({"PATH": f"{fake_bin}:{os.environ['PATH']}"})
+    result = subprocess.run(
+        ["bash", str(SCRIPT), "4.3.0"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    call_log = log.read_text()
+    assert "git push" in call_log
+    assert "gh pr create" in call_log
+    assert "chore/release" in call_log
+
+
+def test_does_not_leak_to_parent_git_dir_via_env(tmp_path: Path, monkeypatch):
+    """If GIT_DIR is set in the env (e.g. by a hook), tests must not write to
+    that repo. Regression for the bug where fixture git config leaked into the
+    main repo's config during a pre-push hook run."""
+    parent = tmp_path / "parent_repo"
+    parent.mkdir()
+    subprocess.run(["git", "init", "-q", "-b", "main", str(parent)], check=True)
+    parent_git = parent / ".git"
+    config_before = (parent_git / "config").read_text()
+
+    monkeypatch.setenv("GIT_DIR", str(parent_git))
+
+    fixture = tmp_path / "fixture"
+    fixture.mkdir()
+    _init_repo(fixture)
+
+    config_after = (parent_git / "config").read_text()
+    assert config_before == config_after, (
+        f"_init_repo leaked into GIT_DIR config:\n--- before ---\n{config_before}\n--- after ---\n{config_after}"
+    )

--- a/tests/test_release_script.py
+++ b/tests/test_release_script.py
@@ -234,7 +234,10 @@ def test_does_not_leak_to_parent_git_dir_via_env(tmp_path: Path, monkeypatch):
     main repo's config during a pre-push hook run."""
     parent = tmp_path / "parent_repo"
     parent.mkdir()
-    subprocess.run(["git", "init", "-q", "-b", "main", str(parent)], check=True)
+    # Scrub GIT_* from this init too: if the runner already has GIT_DIR set
+    # (the very leakage this test guards against), an unscrubbed init could
+    # itself be redirected. Keeps the test self-consistent.
+    subprocess.run(["git", "init", "-q", "-b", "main", str(parent)], check=True, env=_clean_env())
     parent_git = parent / ".git"
     config_before = (parent_git / "config").read_text()
 

--- a/tests/test_release_script.py
+++ b/tests/test_release_script.py
@@ -237,7 +237,9 @@ def test_does_not_leak_to_parent_git_dir_via_env(tmp_path: Path, monkeypatch):
     # Scrub GIT_* from this init too: if the runner already has GIT_DIR set
     # (the very leakage this test guards against), an unscrubbed init could
     # itself be redirected. Keeps the test self-consistent.
-    subprocess.run(["git", "init", "-q", "-b", "main", str(parent)], check=True, env=_clean_env())
+    subprocess.run(
+        ["git", "init", "-q", "-b", "main", str(parent)], check=True, env=_clean_env()
+    )
     parent_git = parent / ".git"
     config_before = (parent_git / "config").read_text()
 


### PR DESCRIPTION
Adds optional release tooling. The repo currently has no release workflow; this wires up a reproducible release + a "roll `main` forward to the next minor after each final release" step so unreleased work never carries a shipped version.

### What's included
- **`bin/bump-version.sh`** — verified, single-source version bump of `custom_components/cover_time_based/manifest.json` (the only version-carrying file). `--validate` mode for CI.
- **`bin/release.sh`** — opens a `chore/release` PR: pre-flights (semver, on main, clean tree, tag-free, up-to-date), bumps the manifest, pushes a version-less branch (HACS rejects version numbers in branch names), opens the PR. `--no-push` for tests.
- **`.github/workflows/release.yml`** — on a `v*` tag: validate tag==manifest, publish a GitHub Release (`prerelease` iff the version has a `-alpha/-beta/-rc` suffix); then, **for final releases only**, compute the next minor and push the bump directly to `main` (works because `main` is unprotected — no secret/PAT needed).
- **Tests** (`tests/test_release_script.py`, `tests/test_bump_version.py`) — the scripts are exercised in a temp git repo; written test-first.

### Notes for the maintainer
- It's composable — if you only want the publish half, or only the bump, the two are cleanly separable.
- No new secrets or repo settings required.
- All existing CI (HACS validate, tests, lint) passes on this branch.