### PR TITLE
fix: guarantee a real relay edge on rapid toggle re-pulse (motor/entity desync)

### DIFF
--- a/custom_components/cover_time_based/cover_toggle_mode.py
+++ b/custom_components/cover_time_based/cover_toggle_mode.py
@@ -39,11 +39,30 @@ class ToggleModeCover(SwitchCoverTimeBased):
         self._pulse_time = pulse_time
         self._last_external_toggle_time = {}
         self._last_tilt_direction = None
+        # In-flight _complete_pulse tasks, keyed by relay entity_id. Tracked so
+        # a new pulse on the same relay can cancel the stale completion before
+        # it releases the fresh pulse mid-flight (see _pulse_relay).
+        self._pulse_tasks = {}
+        # Serializes _pulse_relay: cover service calls aren't serialized by HA
+        # (no PARALLEL_UPDATES), so concurrent pulses on the same relay could
+        # otherwise interleave between the task pop and the task store, each
+        # missing the other's in-flight pulse.
+        self._pulse_lock = asyncio.Lock()
 
     async def _complete_pulse(self, entity_id):
-        """Complete a relay pulse by turning OFF after pulse_time."""
+        """Complete a relay pulse by turning OFF after pulse_time.
+
+        Only releases the relay if this task is still the one registered for it.
+        A newer pulse replaces the registration (and cancels this task), but
+        asyncio cancellation is cooperative — a task already past the sleep and
+        into the turn_off call could otherwise still fire it and release the
+        fresh pulse. Keying off the registration makes that impossible
+        regardless of cancellation timing.
+        """
         try:
             await sleep(self._pulse_time)
+            if self._pulse_tasks.get(entity_id) is not asyncio.current_task():
+                return
             await self.hass.services.async_call(
                 "homeassistant",
                 "turn_off",
@@ -52,6 +71,59 @@ class ToggleModeCover(SwitchCoverTimeBased):
             )
         except asyncio.CancelledError:
             pass
+
+    async def _pulse_relay(self, entity_id):
+        """Pulse a relay ON with a guaranteed edge, then schedule its release.
+
+        A toggle motor controller acts on the relay's rising edge. The OFF half
+        of a pulse is deferred to a background ``_complete_pulse`` task, so a
+        new command can arrive while the relay is still held ON. A bare
+        ``turn_on`` on an already-on relay produces no edge — the motor misses
+        the pulse while the position tracker keeps advancing, desyncing the
+        entity from the physical cover.
+
+        Cancel any stale completion for this relay (so it can't release the
+        fresh pulse mid-flight) and, if the relay is still held ON, drive it OFF
+        first so the ``turn_on`` is a genuine edge. The release OFF echo is
+        absorbed by the pending count the caller already marked for this relay's
+        own completion turn_off, so no extra echo bookkeeping is needed. Finally
+        schedule (and track) the OFF half so the next pulse can cancel it.
+
+        "Still held ON" is decided by the in-flight pulse *task*, not by
+        ``_switch_is_on``: a real switch confirms its state only after a device
+        round-trip (tens of ms), which is far longer than the gap between rapid
+        presses, so the reported state still reads OFF while our own pulse holds
+        the relay ON. ``_switch_is_on`` is kept as a secondary trigger for the
+        relay being ON for some other reason (e.g. left ON across a restart);
+        that path emits one extra OFF echo over the caller's pending budget, but
+        a stray OFF is harmless — external handlers act only on the rising edge.
+
+        The whole body runs under ``_pulse_lock`` so the pop/cancel/turn_on/
+        store sequence is atomic: HA does not serialize cover service calls, so
+        two concurrent pulses on the same relay would otherwise both pop before
+        either stored, both miss the in-flight pulse, and skip the release.
+        """
+        async with self._pulse_lock:
+            stale = self._pulse_tasks.pop(entity_id, None)
+            pulse_in_flight = stale is not None and not stale.done()
+            if pulse_in_flight:
+                stale.cancel()
+            if pulse_in_flight or self._switch_is_on(entity_id):
+                await self.hass.services.async_call(
+                    "homeassistant",
+                    "turn_off",
+                    {"entity_id": entity_id},
+                    False,
+                )
+            await self.hass.services.async_call(
+                "homeassistant",
+                "turn_on",
+                {"entity_id": entity_id},
+                False,
+            )
+            self._pulse_tasks[entity_id] = self.hass.async_create_task(
+                self._complete_pulse(entity_id)
+            )
 
     async def async_stop_cover(self, **kwargs):
         """Stop the cover, only sending relay command if it was active."""
@@ -208,14 +280,8 @@ class ToggleModeCover(SwitchCoverTimeBased):
             {"entity_id": self._close_switch_entity_id},
             False,
         )
-        await self.hass.services.async_call(
-            "homeassistant",
-            "turn_on",
-            {"entity_id": self._open_switch_entity_id},
-            False,
-        )
         # Motor controller acts on ON edge; complete pulse in background
-        self.hass.async_create_task(self._complete_pulse(self._open_switch_entity_id))
+        await self._pulse_relay(self._open_switch_entity_id)
 
     async def _send_close(self) -> None:
         if self._switch_is_on(self._open_switch_entity_id):
@@ -227,40 +293,18 @@ class ToggleModeCover(SwitchCoverTimeBased):
             {"entity_id": self._open_switch_entity_id},
             False,
         )
-        await self.hass.services.async_call(
-            "homeassistant",
-            "turn_on",
-            {"entity_id": self._close_switch_entity_id},
-            False,
-        )
         # Motor controller acts on ON edge; complete pulse in background
-        self.hass.async_create_task(self._complete_pulse(self._close_switch_entity_id))
+        await self._pulse_relay(self._close_switch_entity_id)
 
     async def _send_stop(self) -> None:
         if self._last_command == SERVICE_CLOSE_COVER:
             self._mark_switch_pending(self._close_switch_entity_id, 2)
-            await self.hass.services.async_call(
-                "homeassistant",
-                "turn_on",
-                {"entity_id": self._close_switch_entity_id},
-                False,
-            )
             # Motor toggles on ON edge; complete pulse in background
-            self.hass.async_create_task(
-                self._complete_pulse(self._close_switch_entity_id)
-            )
+            await self._pulse_relay(self._close_switch_entity_id)
         elif self._last_command == SERVICE_OPEN_COVER:
             self._mark_switch_pending(self._open_switch_entity_id, 2)
-            await self.hass.services.async_call(
-                "homeassistant",
-                "turn_on",
-                {"entity_id": self._open_switch_entity_id},
-                False,
-            )
             # Motor toggles on ON edge; complete pulse in background
-            self.hass.async_create_task(
-                self._complete_pulse(self._open_switch_entity_id)
-            )
+            await self._pulse_relay(self._open_switch_entity_id)
         else:
             self._log("_send_stop :: toggle mode with no last command, skipping")
 
@@ -276,13 +320,7 @@ class ToggleModeCover(SwitchCoverTimeBased):
             {"entity_id": self._tilt_close_switch_id},
             False,
         )
-        await self.hass.services.async_call(
-            "homeassistant",
-            "turn_on",
-            {"entity_id": self._tilt_open_switch_id},
-            False,
-        )
-        self.hass.async_create_task(self._complete_pulse(self._tilt_open_switch_id))
+        await self._pulse_relay(self._tilt_open_switch_id)
         self._last_tilt_direction = "open"
 
     async def _send_tilt_close(self) -> None:
@@ -295,36 +333,16 @@ class ToggleModeCover(SwitchCoverTimeBased):
             {"entity_id": self._tilt_open_switch_id},
             False,
         )
-        await self.hass.services.async_call(
-            "homeassistant",
-            "turn_on",
-            {"entity_id": self._tilt_close_switch_id},
-            False,
-        )
-        self.hass.async_create_task(self._complete_pulse(self._tilt_close_switch_id))
+        await self._pulse_relay(self._tilt_close_switch_id)
         self._last_tilt_direction = "close"
 
     async def _send_tilt_stop(self) -> None:
         if self._last_tilt_direction == "close":
             self._mark_switch_pending(self._tilt_close_switch_id, 2)
-            await self.hass.services.async_call(
-                "homeassistant",
-                "turn_on",
-                {"entity_id": self._tilt_close_switch_id},
-                False,
-            )
-            self.hass.async_create_task(
-                self._complete_pulse(self._tilt_close_switch_id)
-            )
+            await self._pulse_relay(self._tilt_close_switch_id)
         elif self._last_tilt_direction == "open":
             self._mark_switch_pending(self._tilt_open_switch_id, 2)
-            await self.hass.services.async_call(
-                "homeassistant",
-                "turn_on",
-                {"entity_id": self._tilt_open_switch_id},
-                False,
-            )
-            self.hass.async_create_task(self._complete_pulse(self._tilt_open_switch_id))
+            await self._pulse_relay(self._tilt_open_switch_id)
         else:
             self._log(
                 "_send_tilt_stop :: toggle mode with no last tilt direction, skipping"

--- a/tests/test_cover_toggle_mode.py
+++ b/tests/test_cover_toggle_mode.py
@@ -11,6 +11,7 @@ await those tasks to verify the full call sequence.
 """
 
 import asyncio
+from types import SimpleNamespace
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock, call, patch
@@ -101,6 +102,28 @@ def _calls(mock: AsyncMock):
 
 def _ha(service, entity_id):
     return call("homeassistant", service, {"entity_id": entity_id}, False)
+
+
+def _hold_relay_on(cover, entity_id):
+    """Make hass report ``entity_id`` as currently ON, every other relay OFF.
+
+    Simulates a relay still held ON by a previous pulse whose background
+    ``_complete_pulse`` (turn_off) has not fired yet.
+    """
+    on = SimpleNamespace(state="on")
+    off = SimpleNamespace(state="off")
+    cover.hass.states.get = MagicMock(
+        side_effect=lambda eid: on if eid == entity_id else off
+    )
+
+
+def _calls_for(cover, entity_id):
+    """Recorded service calls whose target is ``entity_id``, in order."""
+    return [
+        c
+        for c in _calls(cover.hass.services.async_call)
+        if c.args[2].get("entity_id") == entity_id
+    ]
 
 
 # ===================================================================
@@ -1086,4 +1109,203 @@ class TestToggleExternalTravelWhileTraveling:
 
         assert cover.travel_calc.is_traveling()
         assert cover.travel_calc._travel_to_position == 100
+        await _cancel_tasks(cover)
+
+
+# ===================================================================
+# Rising-edge guarantee: re-pulsing a still-held relay
+# ===================================================================
+
+
+class TestToggleEdgeGuaranteeOnHeldRelay:
+    """A fresh pulse on a relay still held ON must produce a real rising edge.
+
+    Toggle motor controllers act on the relay's OFF→ON edge. The OFF half of
+    a pulse is deferred to a background ``_complete_pulse`` task, so a second
+    command can land while the relay is still held ON. A bare ``turn_on`` on
+    an already-on relay produces no edge — the motor misses the pulse while
+    the position tracker advances, desyncing the entity from the physical
+    cover. The send methods must release the relay (turn_off) first so the
+    motor sees a genuine edge.
+    """
+
+    @pytest.mark.asyncio
+    async def test_close_while_close_relay_held_releases_first(self):
+        cover = _make_toggle_cover()
+        _hold_relay_on(cover, "switch.close")
+
+        with patch(
+            "custom_components.cover_time_based.cover_toggle_mode.sleep",
+            new_callable=AsyncMock,
+        ):
+            await cover._send_close()
+            await _drain_tasks(cover)
+
+        close_calls = _calls_for(cover, "switch.close")
+        assert close_calls[0] == _ha("turn_off", "switch.close")
+        assert close_calls[1] == _ha("turn_on", "switch.close")
+
+    @pytest.mark.asyncio
+    async def test_open_while_open_relay_held_releases_first(self):
+        cover = _make_toggle_cover()
+        _hold_relay_on(cover, "switch.open")
+
+        with patch(
+            "custom_components.cover_time_based.cover_toggle_mode.sleep",
+            new_callable=AsyncMock,
+        ):
+            await cover._send_open()
+            await _drain_tasks(cover)
+
+        open_calls = _calls_for(cover, "switch.open")
+        assert open_calls[0] == _ha("turn_off", "switch.open")
+        assert open_calls[1] == _ha("turn_on", "switch.open")
+
+    @pytest.mark.asyncio
+    async def test_stop_while_relay_held_releases_first(self):
+        cover = _make_toggle_cover()
+        cover._last_command = SERVICE_CLOSE_COVER
+        _hold_relay_on(cover, "switch.close")
+
+        with patch(
+            "custom_components.cover_time_based.cover_toggle_mode.sleep",
+            new_callable=AsyncMock,
+        ):
+            await cover._send_stop()
+            await _drain_tasks(cover)
+
+        close_calls = _calls_for(cover, "switch.close")
+        assert close_calls[0] == _ha("turn_off", "switch.close")
+        assert close_calls[1] == _ha("turn_on", "switch.close")
+
+    @pytest.mark.asyncio
+    async def test_idle_relay_pulse_unchanged(self):
+        """When the relay is OFF, no redundant release is issued."""
+        cover = _make_toggle_cover()
+        _hold_relay_on(cover, "switch.nothing")  # close + open both report OFF
+
+        with patch(
+            "custom_components.cover_time_based.cover_toggle_mode.sleep",
+            new_callable=AsyncMock,
+        ):
+            await cover._send_close()
+            await _drain_tasks(cover)
+
+        assert _calls(cover.hass.services.async_call) == [
+            _ha("turn_off", "switch.open"),
+            _ha("turn_on", "switch.close"),
+            _ha("turn_off", "switch.close"),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_repulse_within_pulse_releases_despite_state_lag(self):
+        """The reported desync: a second pulse arrives within pulse_time, before
+        HA's switch state reflects the first turn_on (a real switch confirms
+        state only after a device round-trip — ~76 ms in the field log, vs the
+        2 ms between presses). The in-flight pulse *task*, not the laggy reported
+        switch state, must trigger the release so the motor gets a real edge.
+        """
+        cover = _make_toggle_cover()
+        # hass keeps reporting every relay OFF for the whole test — simulating
+        # switch-state commit lag (the turn_on hasn't been confirmed yet).
+        cover.hass.states.get = MagicMock(
+            side_effect=lambda eid: SimpleNamespace(state="off")
+        )
+
+        # First pulse: schedules a live completion (relay is commanded on).
+        await cover._send_close()
+        assert not cover._pulse_tasks["switch.close"].done()
+
+        # Second pulse lands while the first is still in flight.
+        with patch(
+            "custom_components.cover_time_based.cover_toggle_mode.sleep",
+            new_callable=AsyncMock,
+        ):
+            await cover._send_close()
+
+        close_calls = _calls_for(cover, "switch.close")
+        # pulse 1 -> turn_on; pulse 2 must release (turn_off) then re-pulse,
+        # despite the reported relay state still being "off".
+        assert close_calls[0] == _ha("turn_on", "switch.close")
+        assert close_calls[1] == _ha("turn_off", "switch.close")
+        assert close_calls[2] == _ha("turn_on", "switch.close")
+        await _cancel_tasks(cover)
+
+    @pytest.mark.asyncio
+    async def test_superseded_completion_does_not_release_relay(self):
+        """A completion whose registration was replaced by a newer pulse must
+        not issue turn_off, even if cancellation didn't stop it in time.
+
+        asyncio cancellation is cooperative: a _complete_pulse already past its
+        sleep and into the turn_off call can finish. Keying the release on the
+        registered task (not on cancellation) makes "a stale completion can't
+        release a fresh pulse" deterministic.
+        """
+        cover = _make_toggle_cover()
+        with patch(
+            "custom_components.cover_time_based.cover_toggle_mode.sleep",
+            new_callable=AsyncMock,
+        ):
+            task = cover.hass.async_create_task(cover._complete_pulse("switch.close"))
+            # A newer pulse has since claimed the relay (different registration).
+            cover._pulse_tasks["switch.close"] = object()
+            await task
+
+        assert _ha("turn_off", "switch.close") not in _calls(
+            cover.hass.services.async_call
+        )
+        await _cancel_tasks(cover)
+
+    @pytest.mark.asyncio
+    async def test_concurrent_same_relay_pulses_serialize_and_release(self):
+        """Two _send_close calls that interleave at their awaits must each get a
+        real edge. Cover service calls aren't serialized (no PARALLEL_UPDATES),
+        so without a lock both could pop the pulse task before either stores it,
+        both see no in-flight pulse, neither releases, and the second turn_on is
+        a no-op — the original desync, under true concurrency. _pulse_relay must
+        serialize so the second pulse sees the first's in-flight pulse.
+        """
+        cover = _make_toggle_cover()
+        # Relays report OFF (state lag) and each service call yields control,
+        # forcing the two pulses to interleave under asyncio.gather.
+        cover.hass.states.get = MagicMock(
+            side_effect=lambda eid: SimpleNamespace(state="off")
+        )
+
+        async def _yielding_call(*args, **kwargs):
+            await asyncio.sleep(0)
+
+        cover.hass.services.async_call = AsyncMock(side_effect=_yielding_call)
+
+        # Do NOT patch sleep: the first pulse's completion stays in flight, so
+        # the second must detect it and release the relay.
+        await asyncio.gather(cover._send_close(), cover._send_close())
+
+        close_calls = _calls_for(cover, "switch.close")
+        # One turn_on per pulse, plus a release turn_off for the second.
+        assert close_calls.count(_ha("turn_on", "switch.close")) == 2
+        assert _ha("turn_off", "switch.close") in close_calls
+        first_on = close_calls.index(_ha("turn_on", "switch.close"))
+        release = close_calls.index(_ha("turn_off", "switch.close"))
+        assert release > first_on  # a release, not a leading opposite turn_off
+        await _cancel_tasks(cover)
+
+    @pytest.mark.asyncio
+    async def test_new_pulse_cancels_stale_completion(self):
+        """A new pulse cancels the previous pulse's pending completion so it
+        cannot release the new pulse's relay mid-flight."""
+        cover = _make_toggle_cover()
+
+        # First pulse: completion task scheduled, relay left ON until it fires.
+        await cover._send_close()
+        stale = cover._pulse_tasks["switch.close"]
+        assert not stale.done()
+
+        # Second pulse arrives while the relay is still held ON.
+        _hold_relay_on(cover, "switch.close")
+        await cover._send_close()
+        await asyncio.sleep(0)  # let the cancellation propagate
+
+        assert stale.cancelled()
+        assert cover._pulse_tasks["switch.close"] is not stale
         await _cancel_tasks(cover)


### PR DESCRIPTION
## Problem

Reported from the field: pressing the cover tile buttons rapidly left a toggle-mode cover desynced — the **physical cover sat still while the entity kept closing** (position tracker ran 95 → 25 with the motor stationary).

## Root cause

In toggle mode every motor pulse is `turn_on` on a direction relay; the OFF half is deferred to a background `_complete_pulse` task (`pulse_time`, default 1.0s). The motor controller toggles on the relay's **rising edge**.

When a second command landed before the previous pulse released the relay (e.g. *close-while-closing* stops via a close pulse, then a 2 ms-later close press re-pulses), the new `turn_on` hit an **already-on relay → no rising edge → motor missed the pulse**, yet the entity started tracking movement. `set_position`'s `already_moving_same_dir` retarget (which deliberately sends no new pulse) then compounded the drift.

Reconstructed from a user log, millisecond-precise:

| Time | Event | Relay | Motor | Entity |
|------|-------|-------|-------|--------|
| 19:50:06.969 | close-while-closing → stop pulse | ON-edge | **stops** ~95 | stops ~95 ✓ |
| 19:50:06.971 | close press 2 ms later → `_send_close` | already ON → **no edge** | **stays stopped** | **starts closing** ✗ |
| 19:50:15 | slider → 25 → `already_moving_same_dir` retarget | — | still stopped | keeps closing ✗ |

## Fix

Route every toggle relay pulse (`_send_open`/`_send_close`/`_send_stop` and the three tilt equivalents) through a single `_pulse_relay(entity_id)`, which:

1. **cancels the stale `_complete_pulse`** for that relay (tracked in `_pulse_tasks`) so it can't release the fresh pulse mid-flight,
2. **drives the relay OFF first when a pulse is still in flight**, so the `turn_on` is a genuine OFF→ON edge the motor acts on, and
3. **schedules + tracks** the new completion.

Two subtleties that the review process surfaced and that the implementation handles:

- **"Held ON" is decided by the in-flight pulse *task*, not the relay's reported state.** A real switch confirms its state only after a device round-trip (~76 ms in the field log) — far longer than the gap between rapid presses (2 ms) — so `_switch_is_on` still reads OFF while our own pulse holds the relay ON. Gating the release on the deterministic in-flight task is what makes the fix work on the exact hardware that reported the bug. `_switch_is_on` is kept only as a secondary trigger (relay left ON across a restart, etc.).
- **`_pulse_relay` runs under a per-instance lock.** HA does not serialize cover service calls (no `PARALLEL_UPDATES`), so two concurrent pulses on the same relay could otherwise both pop the task before either stored it, both miss the in-flight pulse, and skip the release — reintroducing the bug under true concurrency, with an orphaned completion task as a side effect.

The release OFF echo is absorbed by the pending count the caller already marked for the (cancelled) completion `turn_off`, so the echo ledger stays balanced. The idle (relay-off) path is unchanged.

## Tests

New `TestToggleEdgeGuaranteeOnHeldRelay` (TDD — every test confirmed RED before its fix):
- held-relay close/open/stop each release before re-pulsing,
- the idle path is unchanged,
- a new pulse cancels the stale completion,
- **state-lag scenario**: the release is driven by the in-flight task even when reported state lags (this is the actual field bug),
- **concurrent same-relay pulses** serialize via the lock and each still gets a real edge.

Full suite: **957 passed**. `ruff check .` + `ruff format --check .` clean.

Verified by the test suite; not yet exercised on physical hardware.
