### PR TITLE
chore: bump version to 4.4.0 for development

### DIFF
--- a/custom_components/cover_time_based/manifest.json
+++ b/custom_components/cover_time_based/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/Sese-Schneider/ha-cover-time-based/issues",
   "requirements": [],
-  "version": "4.3.0"
+  "version": "4.4.0"
 }


### PR DESCRIPTION
Rolls `main` forward to the next minor (`4.4.0`) so unreleased work no longer carries the just-released `4.3.0`.

This is the post-release dev-cycle bump that `release.yml`'s `bump` job normally pushes automatically — but that direct push to `main` is **rejected by this repo's ruleset** ("Changes must be made through a pull request" + required status checks), so it has to land as a PR instead. See the note below.

> ⚠️ **Follow-up:** `release.yml` assumes `main` is unprotected and pushes the next-minor bump directly (`git push origin HEAD:main`). On this protected upstream that job will fail on **every** release. Options: change the `bump` job to open a PR (or use a PAT/app token that can bypass the rule), or exempt the Actions bot in the ruleset. The v4.3.0 release itself published fine; only the auto-bump failed.