### PR TITLE
ci: add bin/bump-dev.sh for the post-release dev-cycle bump

### DIFF
--- a/bin/bump-dev.sh
+++ b/bin/bump-dev.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Opens a PR that rolls main forward to the next minor for development.
+#
+# Usage: bin/bump-dev.sh [--no-push]
+#
+# Run this AFTER a release tag is pushed. release.yml normally pushes the
+# next-minor bump straight to main, but this repo's main is protected (PR-only
+# + required status checks), so that direct push is rejected. This helper does
+# the same bump as a PR instead — run it as yourself so CI triggers and the PR
+# is mergeable.
+#
+# It mirrors bin/release.sh's preflight and the next-minor formula in
+# .github/workflows/release.yml, so the three can't drift. The branch is
+# deliberately version-less: HACS scans every branch and complains about
+# version numbers in branch names.
+
+set -euo pipefail
+
+# Optional --no-push flag for tests.
+NO_PUSH=false
+if [ "${1:-}" = "--no-push" ]; then
+  NO_PUSH=true
+fi
+
+MANIFEST="custom_components/cover_time_based/manifest.json"
+if [ ! -f "$MANIFEST" ]; then
+  echo "error: must be run from the repo root ($MANIFEST not found)" >&2
+  exit 1
+fi
+
+# Must be on main.
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ "$CURRENT_BRANCH" != "main" ]; then
+  echo "error: must be on main (currently on $CURRENT_BRANCH)" >&2
+  exit 1
+fi
+
+# Working tree must be clean.
+if [ -n "$(git status --porcelain)" ]; then
+  echo "error: working tree is not clean; commit or stash first" >&2
+  exit 1
+fi
+
+BRANCH="chore/bump-dev"
+
+# The branch has a fixed name, so a leftover one from an aborted or undeleted
+# prior run would make `git checkout -b` crash mid-run. Catch it up front.
+if git rev-parse -q --verify "refs/heads/$BRANCH" >/dev/null; then
+  echo "error: branch $BRANCH already exists locally; delete it first:" >&2
+  echo "  git branch -D $BRANCH" >&2
+  exit 1
+fi
+if git ls-remote --heads origin "$BRANCH" 2>/dev/null | grep -q "refs/heads/$BRANCH$"; then
+  echo "error: branch $BRANCH already exists on origin; delete it first:" >&2
+  echo "  git push origin --delete $BRANCH" >&2
+  exit 1
+fi
+
+# Local main must be up to date with origin/main (skipped if there's no origin,
+# e.g. in tests).
+if git remote get-url origin >/dev/null 2>&1; then
+  git fetch -q origin main
+  LOCAL=$(git rev-parse main)
+  REMOTE=$(git rev-parse origin/main)
+  if [ "$LOCAL" != "$REMOTE" ]; then
+    echo "error: local main is not up to date with origin/main" >&2
+    echo "  local:  $LOCAL" >&2
+    echo "  origin: $REMOTE" >&2
+    exit 1
+  fi
+fi
+
+# Just-released version carried by the manifest.
+CURRENT=$(python3 -c "import json; print(json.load(open('$MANIFEST'))['version'])")
+
+# Next minor: mj.(mn+1).0 — the same formula release.yml uses. Strip any
+# pre-release suffix first so e.g. 4.3.0-rc.1 still rolls to 4.4.0.
+NEXT=$(python3 -c "import sys; mj, mn, _ = sys.argv[1].split('-')[0].split('.'); print(f'{mj}.{int(mn) + 1}.0')" "$CURRENT")
+
+git checkout -q -b "$BRANCH"
+
+# Bump the manifest version (shared with release.sh and the release workflow so
+# they can't drift).
+"$(dirname "$0")/bump-version.sh" "$NEXT"
+
+git add -A
+git commit -qm "chore: bump version to $NEXT for development"
+
+if [ "$NO_PUSH" = "true" ]; then
+  echo "Branch $BRANCH prepared (manifest $CURRENT -> $NEXT). --no-push given; skipping push and PR creation."
+  exit 0
+fi
+
+# Push the bump branch.
+git push -u origin "$BRANCH"
+
+# Open the PR.
+gh pr create \
+  --title "chore: bump version to $NEXT for development" \
+  --body "Rolls \`main\` forward to the next minor (\`$NEXT\`) for development, so unreleased work no longer carries the just-released \`$CURRENT\`.
+
+This is the post-release dev-cycle bump. \`release.yml\` normally pushes it
+straight to \`main\`, but this repo's \`main\` is protected (PR-only + required
+status checks), so it lands as a PR instead.
+"
+
+echo "Bump branch $BRANCH pushed and PR opened ($CURRENT -> $NEXT)."

--- a/tests/test_bump_dev_script.py
+++ b/tests/test_bump_dev_script.py
@@ -1,0 +1,163 @@
+"""Tests for bin/bump-dev.sh.
+
+Post-release helper that opens a PR rolling main forward to the next minor
+(the dev-cycle bump release.yml can't push directly on a protected main).
+
+Invokes the real bash script inside a throwaway git repo in tmp_path. All GIT_*
+env vars are scrubbed so the subprocess git calls operate on the fixture repo
+and never on the parent repo running the test (e.g. under a pre-push hook).
+"""
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "bin" / "bump-dev.sh"
+MANIFEST_REL = "custom_components/cover_time_based/manifest.json"
+BRANCH = "chore/bump-dev"
+
+
+def _clean_env(extra: dict | None = None) -> dict:
+    env = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+    if extra:
+        env.update(extra)
+    return env
+
+
+def _git(
+    *args: str, cwd: Path, check: bool = True, **kwargs
+) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args], cwd=cwd, check=check, env=_clean_env(), **kwargs
+    )
+
+
+def _run(cwd: Path, *args: str, env: dict | None = None) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(SCRIPT), *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        env=env or _clean_env(),
+    )
+
+
+def _init_repo(
+    tmp_path: Path, *, branch: str = "main", dirty: bool = False, version: str = "4.3.0"
+) -> Path:
+    """Create a tiny git repo with a manifest.json at the just-released version."""
+    _git("init", "-q", "-b", branch, cwd=tmp_path)
+    _git("config", "user.email", "t@test", cwd=tmp_path)
+    _git("config", "user.name", "t", cwd=tmp_path)
+
+    manifest = tmp_path / MANIFEST_REL
+    manifest.parent.mkdir(parents=True)
+    manifest.write_text(
+        json.dumps(
+            {
+                "domain": "cover_time_based",
+                "name": "Cover Time Based",
+                "version": version,
+            },
+            indent=2,
+        )
+        + "\n"
+    )
+    _git("add", ".", cwd=tmp_path)
+    _git("commit", "-qm", "init", cwd=tmp_path)
+
+    if dirty:
+        (tmp_path / "dirt").write_text("x")
+
+    return tmp_path
+
+
+def _manifest_version(repo: Path) -> str:
+    return json.loads((repo / MANIFEST_REL).read_text())["version"]
+
+
+def test_rejects_non_main_branch(tmp_path: Path):
+    _init_repo(tmp_path, branch="feature")
+    result = _run(tmp_path)
+    assert result.returncode != 0
+    assert "main" in (result.stdout + result.stderr).lower()
+
+
+def test_rejects_dirty_tree(tmp_path: Path):
+    _init_repo(tmp_path, dirty=True)
+    result = _run(tmp_path)
+    assert result.returncode != 0
+    combined = (result.stdout + result.stderr).lower()
+    assert "clean" in combined or "dirty" in combined or "uncommitted" in combined
+
+
+def test_rejects_existing_bump_branch(tmp_path: Path):
+    """A leftover version-less chore/bump-dev branch must be detected up front."""
+    _init_repo(tmp_path)
+    _git("branch", BRANCH, cwd=tmp_path)
+    result = _run(tmp_path, "--no-push")
+    assert result.returncode != 0
+    assert BRANCH in (result.stdout + result.stderr)
+
+
+def test_computes_next_minor_and_bumps_manifest(tmp_path: Path):
+    _init_repo(tmp_path, version="4.3.0")
+    result = _run(tmp_path, "--no-push")
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    branches = _git(
+        "branch", "--list", BRANCH, cwd=tmp_path, capture_output=True, text=True
+    ).stdout
+    assert BRANCH in branches
+
+    _git("checkout", "-q", BRANCH, cwd=tmp_path)
+    assert _manifest_version(tmp_path) == "4.4.0"
+
+    last_msg = _git(
+        "log", "-1", "--format=%s", cwd=tmp_path, capture_output=True, text=True
+    ).stdout.strip()
+    assert "4.4.0" in last_msg and "development" in last_msg, (
+        f"unexpected last commit message: {last_msg!r}"
+    )
+
+
+def test_minor_rollover_increments_as_integer(tmp_path: Path):
+    """Next minor must increment numerically (4.9 -> 4.10), not lexically."""
+    _init_repo(tmp_path, version="4.9.0")
+    result = _run(tmp_path, "--no-push")
+    assert result.returncode == 0, result.stdout + result.stderr
+    _git("checkout", "-q", BRANCH, cwd=tmp_path)
+    assert _manifest_version(tmp_path) == "4.10.0"
+
+
+def test_pushes_and_opens_pr(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+
+    # Shim gh and git push into a fake bin dir that records calls.
+    fake_bin = tmp_path / "fake_bin"
+    fake_bin.mkdir()
+    log = tmp_path / "calls.log"
+
+    (fake_bin / "gh").write_text(
+        f'#!/usr/bin/env bash\necho "gh $*" >> "{log}"\necho https://github.com/fake/repo/pull/1\n'
+    )
+    (fake_bin / "gh").chmod(0o755)
+
+    real_git = subprocess.check_output(["which", "git"], text=True).strip()
+    (fake_bin / "git").write_text(
+        f'#!/usr/bin/env bash\nif [ "$1" = "push" ]; then echo "git $*" >> "{log}"; exit 0; fi\nexec {real_git} "$@"\n'
+    )
+    (fake_bin / "git").chmod(0o755)
+
+    env = _clean_env({"PATH": f"{fake_bin}:{os.environ['PATH']}"})
+    result = _run(repo, env=env)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    call_log = log.read_text()
+    assert "git push" in call_log
+    assert "gh pr create" in call_log
+    assert BRANCH in call_log


### PR DESCRIPTION
## Why

`release.yml`'s `bump` job rolls `main` forward to the next minor by pushing **directly to main**. This upstream's `main` is protected (PR-only + required status checks), so that push is rejected (`GH013`) — the **publish** half of a release succeeds while the **bump** half fails on every release (as just happened with v4.3.0).

A fully-automated fix isn't possible from the workflow alone: a PR opened by the workflow's `GITHUB_TOKEN` won't trigger the required CI checks (GitHub's anti-recursion rule), so it'd be unmergeable without an admin-added PAT/App token or a ruleset bypass — neither of which a non-admin contributor can set up.

## What

`bin/bump-dev.sh` does the same bump **as a PR**, run by a real user after the release tag is pushed:

- computes the next minor from the manifest (same `mj.mn+1.0` formula as `release.yml`),
- bumps the manifest via `bin/bump-version.sh` on a version-less `chore/bump-dev` branch,
- opens the PR. Because it runs as you (not `GITHUB_TOKEN`), CI triggers and it's mergeable.

Mirrors `bin/release.sh`'s preflight (on main, clean tree, up to date with origin, no leftover branch).

## Tests

`tests/test_bump_dev_script.py` (TDD, same harness as `test_release_script.py`): next-minor computation incl. the **4.9 → 4.10** integer rollover, the branch/manifest/commit result, push + `gh pr create` via shims, and the main/clean/leftover-branch preflight rejections.

## Note for maintainer

This is a workaround, not the root fix. The cleaner options (admin-only) are: add the `github-actions[bot]` as a **ruleset bypass actor** so `release.yml`'s existing direct push works (zero code), or add a PAT/App token secret so the workflow can open a check-triggering PR itself. Until then, run `bin/bump-dev.sh` after tagging.