### PR TITLE
feat!: don't stop self-stopping motors at their endpoints (#105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## Unreleased
+
+### ⚠ Breaking changes
+
+- **No endpoint stop or run-on for self-stopping motors** ([#105](https://github.com/Sese-Schneider/ha-cover-time-based/issues/105)): in **Pulse**, **Toggle** and **wrapped-cover** modes the integration no longer sends a relay stop — nor applies endpoint run-on — when a cover reaches the 0%/100% endpoints. These motors stop themselves at their internal limit switches, so the stop was redundant; in **Toggle** mode it was actively wrong, re-pulsing the direction relay and restarting the just-stopped motor (the movement-after-every-full-open/close some users saw). The same now applies to a **separate tilt motor** at its tilt endpoints. **Switch** mode is unchanged — its direction relay is latched ON for the whole movement, so it is still switched off (with run-on) at the endpoint.
+
+  **Migration:** no action is required and no settings are lost. The **Endpoint run-on time** option now applies to **Switch mode only**; it is hidden in the config card for the other modes, and any value previously set on a pulse/toggle/wrapped cover is simply ignored. Mid-travel and mid-tilt stops are unaffected. Sequential closes-then-tilts modes still stop at the closed (0%) endpoint, where the motor is deliberately driven past cover-closed to articulate the slats.
+
+### Fixes
+
+- **Separate tilt motor no longer nudges the travel motor** ([#105](https://github.com/Sese-Schneider/ha-cover-time-based/issues/105)): completing a tilt-only move on a separate-tilt-motor cover previously fell through to the travel stop and re-pulsed the *travel* relay (off a stale last-command), while never issuing a proper tilt stop. Tilt completions now settle the tilt motor directly.
+
 ## 4.3.0 (2026-06-17)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ It improves the original integration by adding tilt control, synchronized travel
 - **Wrap an existing cover:** Add time-based position tracking to any cover entity.
 - **Control the tilt of your cover based on time** with four tilt modes: inline, sequential closes-then-tilts-closed, sequential closes-then-tilts-open, or separate tilt motor.
 - **Built-in configuration and calibration:** Calibrate travel times directly from the UI, including finer parameters to compensate for the time it takes the motor to startup.
-- **Resyncs position at endpoints:** The motor can be configured to run-on at the 0%/100% endpoints to resync the position tracker with the physical cover.
+- **Resyncs position at endpoints:** Motors with internal limit switches self-stop at the 0%/100% endpoints, which resyncs the position tracker with the physical cover. For latching (Switch-mode) relays a configurable run-on keeps the relay energized until the motor reaches the endpoint.
 
 ## Install
 
@@ -188,7 +188,7 @@ Select the attribute that you wish to calibrate. The available attributes depend
 | Travel time (close)  | Time in seconds for the cover to fully close                          |         |
 | Travel time (open)   | Time in seconds for the cover to fully open                           |         |
 | Travel startup delay | Motor startup compensation for travel (see below)                     | None    |
-| Endpoint run-on time | Extra relay time at endpoints (0%/100%) to reset position             | 2.0     |
+| Endpoint run-on time | Extra relay time at endpoints to reset position (Switch mode only)    | 2.0     |
 | Min movement time    | Minimum movement duration - blocks shorter movements to prevent drift | None    |
 
 ### Calibration Attributes for Tilt
@@ -216,7 +216,13 @@ Recommended values: 0.05 - 0.15 seconds. Can be configured separately for travel
 
 #### Endpoint Run-on Time
 
-Position tracking is not exact and can drift over time. To reduce drift, the position tracker resyncs itself whenever the cover is sent to the 0% or 100% endpoints. The motor continues running for the number of seconds specified in the **Endpoint Run-on Time** in case the physical cover hasn't quite reached the endpoint. Defaults to 2s.
+Position tracking is not exact and can drift over time, so the tracker resyncs itself whenever the cover is sent fully to the 0% or 100% endpoint.
+
+Most cover motors have internal limit switches and stop themselves at the endpoints. In **Pulse**, **Toggle** and wrapped-cover modes the integration therefore sends **no stop command at an endpoint** — it lets the motor run into its own limit. This avoids an unwanted extra movement (in Toggle mode a stop pulse on an already-stopped motor would restart it) and resyncs the tracker for free, as the motor always reaches its true endpoint.
+
+In **Switch** mode the direction relay is latched ON for the whole movement, so it must be actively switched off at the endpoint. Because tracking is approximate, the relay is held on for an extra **Endpoint Run-on Time** (default 2s) so the motor reaches the physical endpoint before power is cut. **This setting applies only to Switch mode.**
+
+The same self-stop handling applies to a **separate tilt motor** (separate-tilt-motor mode): no stop is sent when tilt reaches its 0%/100% endpoints — the tilt motor self-stops on its own limit — except in **Switch** mode, which de-energizes the latched tilt relay. Mid-tilt positions are always stopped (nothing self-stops there).
 
 Under the **sequential closes-then-tilts-closed** and **sequential closes-then-tilts-open** tilt modes, run-on is skipped at the closed (0%) endpoint, because the motor is already driven past cover-closed for the tilt phase. Run-on still applies at the open (100%) endpoint.
 

--- a/custom_components/cover_time_based/cover_base.py
+++ b/custom_components/cover_time_based/cover_base.py
@@ -126,6 +126,9 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         self._pending_tilt_command: str | None = None
         self._triggered_externally = False
         self._self_initiated_movement = True
+        # True while the active movement drives a dedicated tilt motor (dual
+        # motor), so auto-stop settles the tilt motor instead of travel.
+        self._moving_tilt_motor = False
         self._state = True
         self._pending_switch = {}
         self._pending_switch_timers = {}
@@ -614,7 +617,17 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
             self._cancel_delay_task()
             self._last_command = command
             await self._async_handle_command(command)
-            if self._endpoint_runon_time is not None and self._endpoint_runon_time > 0:
+            if self._self_stops_at_endpoints() and self._at_endpoint(target):
+                # The re-drive above resyncs the cover physically; the motor
+                # self-stops at its limit. A stop here is redundant (and for
+                # toggle re-pulses → restart), so skip it and any run-on.
+                self._log(
+                    "_async_move_to_endpoint :: motor self-stops at endpoint,"
+                    " no relay stop"
+                )
+            elif (
+                self._endpoint_runon_time is not None and self._endpoint_runon_time > 0
+            ):
                 self._delay_task = self.hass.async_create_task(
                     self._delayed_stop(self._endpoint_runon_time)
                 )
@@ -761,6 +774,7 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
 
         self._last_command = command
         if self._tilt_strategy is not None and self._tilt_strategy.uses_tilt_motor:
+            self._moving_tilt_motor = True
             if closing:
                 await self._send_tilt_close()
             else:
@@ -979,6 +993,7 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         self._last_command = command
 
         if self._tilt_strategy is not None and self._tilt_strategy.uses_tilt_motor:
+            self._moving_tilt_motor = True
             if closing:
                 await self._send_tilt_close()
             else:
@@ -1352,6 +1367,7 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
                         self.travel_calc, self.tilt_calc
                     )
                 self._last_command = None
+                self._moving_tilt_motor = False
                 await self._async_persist_position()
                 return
 
@@ -1359,7 +1375,7 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
                 self._log("auto_stop_if_necessary :: tilt restore complete")
                 self._tilt_restore_active = False
                 if self._has_tilt_motor():
-                    await self._send_tilt_stop()
+                    await self._tilt_settle()
                 else:
                     await self._async_handle_command(SERVICE_STOP_COVER)
                 if self._tilt_strategy is not None:
@@ -1367,6 +1383,7 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
                         self.travel_calc, self.tilt_calc
                     )
                 self._last_command = None
+                self._moving_tilt_motor = False
                 await self._async_persist_position()
                 return
 
@@ -1400,15 +1417,27 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
                 # off the exact target (a freeze re-commands the calculated, not
                 # requested, position). Just settle the tracker.
                 self._log("auto_stop_if_necessary :: device self-stops, no relay stop")
-            elif (
-                self._endpoint_runon_time is not None
-                and self._endpoint_runon_time > 0
-                and current_travel is not None
-                and current_travel in (0, 100)
-                and (
-                    self._tilt_strategy is None
-                    or self._tilt_strategy.allows_endpoint_runon(current_travel)
+            elif self._has_tilt_motor() and self._moving_tilt_motor:
+                # The completed movement drove the dedicated tilt motor — settle
+                # that motor (skipping the stop at the tilt endpoints), not
+                # travel. Without this a tilt move would fall through to the
+                # travel stop below and re-pulse the travel relay off a stale
+                # _last_command.
+                await self._tilt_settle()
+            elif self._at_endpoint(current_travel) and self._self_stops_at_endpoints():
+                # The motor self-stops at its physical limit switch. Sending a
+                # stop here is redundant (and for toggle re-pulses → restart),
+                # so skip the relay stop and any run-on; just settle the
+                # tracker. Run-on (below) is therefore switch-mode only.
+                self._log(
+                    "auto_stop_if_necessary :: motor self-stops at endpoint"
+                    " (position=%d), no relay stop",
+                    current_travel,
                 )
+            elif (
+                self._at_endpoint(current_travel)
+                and self._endpoint_runon_time is not None
+                and self._endpoint_runon_time > 0
             ):
                 self._log(
                     "auto_stop_if_necessary :: at endpoint (position=%d),"
@@ -1422,6 +1451,7 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
             else:
                 await self._async_handle_command(SERVICE_STOP_COVER)
             self._last_command = None
+            self._moving_tilt_motor = False
             await self._async_persist_position()
 
     def _motor_stops_itself(self) -> bool:
@@ -1434,6 +1464,61 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         relay stop.
         """
         return False
+
+    def _self_stops_at_endpoints(self) -> bool:
+        """Return True if the motor self-stops at the physical endpoints.
+
+        Roller-shutter motors have internal limit switches that halt the motor
+        at fully-open/closed on their own. For modes whose relays are momentary
+        or delegated (toggle, pulse, wrapped), the stop we would otherwise send
+        at 0%/100% is therefore redundant — and for toggle actively harmful, as
+        re-pulsing the direction relay restarts the already-stopped motor. Such
+        modes return True so auto-stop skips the relay stop (and run-on) at an
+        endpoint while still stopping mid-travel, where nothing self-stops.
+
+        Switch mode overrides this to False: its direction relay is latched ON
+        for the whole travel, so reaching an endpoint must still de-energize it.
+        """
+        return True
+
+    def _at_endpoint(self, position) -> bool:
+        """Return True at a travel endpoint (0/100) where endpoint handling
+        (self-stop skip or run-on) applies.
+
+        Sequential tilt drives the motor past cover-closed to articulate the
+        slats, so it disallows endpoint handling at 0 (``allows_endpoint_runon``).
+        """
+        return (
+            position is not None
+            and position in (0, 100)
+            and (
+                self._tilt_strategy is None
+                or self._tilt_strategy.allows_endpoint_runon(position)
+            )
+        )
+
+    async def _tilt_settle(self) -> None:
+        """Stop the dedicated tilt motor at the end of a tilt-motor movement.
+
+        Mirrors the travel endpoint logic: at the tilt endpoints (0%/100%) the
+        tilt motor self-stops on its own limit, so the stop is skipped (and for
+        toggle a re-pulse would restart it) — except in switch mode, whose
+        latched tilt relay must still be de-energized. Mid-tilt always stops.
+        """
+        current_tilt = (
+            self.tilt_calc.current_position() if self._has_tilt_support() else None
+        )
+        if (
+            current_tilt is not None
+            and current_tilt in (0, 100)
+            and self._self_stops_at_endpoints()
+        ):
+            self._log(
+                "_tilt_settle :: tilt motor self-stops at endpoint (%d), no relay stop",
+                current_tilt,
+            )
+        else:
+            await self._send_tilt_stop()
 
     async def _delayed_stop(self, delay):
         """Stop the relay after a delay."""
@@ -1470,6 +1555,9 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         self._pending_travel_command = None
         self._pending_tilt_target = None
         self._pending_tilt_command = None
+        # Each movement entry point funnels through here; default to a travel
+        # move and let the tilt-motor paths below opt in.
+        self._moving_tilt_motor = False
 
         if not was_restoring and not was_pre_stepping:
             return
@@ -1576,6 +1664,7 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
             command,
         )
 
+        self._moving_tilt_motor = False
         if not self._triggered_externally:
             # Stop tilt motor and send travel command.
             await self._send_tilt_stop()
@@ -1643,6 +1732,7 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         await self._async_handle_command(SERVICE_STOP_COVER)
 
         # Send tilt command and start tracking
+        self._moving_tilt_motor = True
         closing_tilt = command == SERVICE_CLOSE_COVER
         if closing_tilt:
             await self._send_tilt_close()

--- a/custom_components/cover_time_based/cover_switch_mode.py
+++ b/custom_components/cover_time_based/cover_switch_mode.py
@@ -14,6 +14,15 @@ class SwitchModeCover(SwitchCoverTimeBased):
     of the movement. _send_stop turns both direction switches OFF.
     """
 
+    def _self_stops_at_endpoints(self) -> bool:
+        """Switch mode latches the direction relay ON for the whole travel.
+
+        Unlike the momentary modes, reaching an endpoint must still de-energize
+        that relay, so the endpoint stop (and run-on) are kept rather than
+        skipped.
+        """
+        return False
+
     async def _handle_external_state_change(self, entity_id, old_val, new_val):
         """Handle external state change in switch (latching) mode.
 

--- a/custom_components/cover_time_based/frontend/cover-time-based-card.js
+++ b/custom_components/cover_time_based/frontend/cover-time-based-card.js
@@ -1364,8 +1364,17 @@ class CoverTimeBasedCard extends LitElement {
       ["timing.travel_time_open", "travel_time_open", c.travel_time_open, 0.1],
       ["timing.travel_startup_delay", "travel_startup_delay", c.travel_startup_delay],
       ["timing.min_movement_time", "min_movement_time", c.min_movement_time],
-      ["timing.endpoint_runon_time", "endpoint_runon_time", c.endpoint_runon_time],
     ];
+    // Endpoint run-on only applies to switch mode (its latched relay must be
+    // de-energized at the endpoint). Pulse/toggle/wrapped covers self-stop at
+    // their limit switches, so the setting has no effect there.
+    if ((c.control_mode || "switch") === "switch") {
+      travelRows.push([
+        "timing.endpoint_runon_time",
+        "endpoint_runon_time",
+        c.endpoint_runon_time,
+      ]);
+    }
 
     const tiltRows = [
       ["timing.tilt_time_close", "tilt_time_close", c.tilt_time_close, 0.1],

--- a/tests/test_endpoint_self_stop.py
+++ b/tests/test_endpoint_self_stop.py
@@ -1,0 +1,365 @@
+"""Endpoint self-stop behaviour.
+
+Motors with internal limit switches self-stop at the physical endpoints
+(0% / 100%). For every relay mode whose relays are momentary or delegated
+(toggle, pulse, wrapped) the integration must therefore NOT send a stop at
+an endpoint — the motor has already stopped, and a stop there is at best
+redundant and at worst (toggle) re-pulses the relay and restarts the motor.
+
+Switch mode is the exception: its direction relay is latched ON for the
+whole travel, so reaching an endpoint must still de-energize it. Switch
+mode therefore keeps both the endpoint stop and endpoint run-on.
+
+Mid-travel stops (position 1..99) are unaffected in every mode — nothing
+self-stops there, so the timed stop is essential.
+"""
+
+import asyncio
+
+import pytest
+from unittest.mock import patch
+
+from homeassistant.const import SERVICE_CLOSE_COVER
+
+from custom_components.cover_time_based.cover import (
+    CONTROL_MODE_PULSE,
+    CONTROL_MODE_SWITCH,
+    CONTROL_MODE_TOGGLE,
+)
+
+
+async def _cancel_tasks(cover):
+    tasks = getattr(cover.hass, "_test_tasks", [])
+    for task in tasks:
+        if not task.done():
+            task.cancel()
+    if tasks:
+        await asyncio.gather(*tasks, return_exceptions=True)
+        tasks.clear()
+
+
+def _ha_calls(cover):
+    """Relay (homeassistant.turn_on/turn_off) service calls."""
+    return [
+        c
+        for c in cover.hass.services.async_call.call_args_list
+        if c.args[0] == "homeassistant"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_toggle_reaching_endpoint_sends_no_relay_stop(make_cover):
+    """Toggle at an endpoint must not re-pulse the relay (issue #105).
+
+    With the default run-on (2.0s) the stop is currently deferred to a
+    background ``_delayed_stop`` task, so assert the stop is neither issued
+    now nor scheduled.
+    """
+    cover = make_cover(control_mode=CONTROL_MODE_TOGGLE)
+    cover._self_initiated_movement = True
+    cover._last_command = SERVICE_CLOSE_COVER
+    cover.travel_calc.set_position(0)
+
+    cover.hass.services.async_call.reset_mock()
+    with patch.object(cover, "async_write_ha_state"):
+        await cover.auto_stop_if_necessary()
+
+    assert _ha_calls(cover) == []
+    assert cover._delay_task is None
+    await _cancel_tasks(cover)
+
+
+@pytest.mark.asyncio
+async def test_switch_reaching_endpoint_still_de_energizes(make_cover):
+    """Switch mode latches the direction relay ON, so an endpoint must still
+    turn it OFF. Run-on disabled here so the stop is immediate."""
+    cover = make_cover(control_mode=CONTROL_MODE_SWITCH, endpoint_runon_time=0)
+    cover._self_initiated_movement = True
+    cover._last_command = SERVICE_CLOSE_COVER
+    cover.travel_calc.set_position(0)
+
+    cover.hass.services.async_call.reset_mock()
+    with patch.object(cover, "async_write_ha_state"):
+        await cover.auto_stop_if_necessary()
+
+    off_calls = [c for c in _ha_calls(cover) if c.args[1] == "turn_off"]
+    assert off_calls, "switch mode must de-energize its relays at an endpoint"
+    await _cancel_tasks(cover)
+
+
+@pytest.mark.asyncio
+async def test_switch_keeps_endpoint_runon(make_cover):
+    """Switch mode keeps run-on: an endpoint schedules the delayed stop."""
+    cover = make_cover(control_mode=CONTROL_MODE_SWITCH, endpoint_runon_time=2.0)
+    cover._self_initiated_movement = True
+    cover._last_command = SERVICE_CLOSE_COVER
+    cover.travel_calc.set_position(0)
+
+    with patch.object(cover, "async_write_ha_state"):
+        await cover.auto_stop_if_necessary()
+
+    assert cover._delay_task is not None
+    await _cancel_tasks(cover)
+
+
+@pytest.mark.asyncio
+async def test_pulse_reaching_endpoint_sends_no_relay_stop(make_cover):
+    """Pulse mode at an endpoint sends no stop pulse and schedules no run-on."""
+    cover = make_cover(control_mode=CONTROL_MODE_PULSE, stop_switch="switch.stop")
+    cover._self_initiated_movement = True
+    cover._last_command = SERVICE_CLOSE_COVER
+    cover.travel_calc.set_position(0)
+
+    cover.hass.services.async_call.reset_mock()
+    with patch.object(cover, "async_write_ha_state"):
+        await cover.auto_stop_if_necessary()
+
+    assert _ha_calls(cover) == []
+    assert cover._delay_task is None
+    await _cancel_tasks(cover)
+
+
+@pytest.mark.asyncio
+async def test_wrapped_non_native_reaching_endpoint_sends_no_stop(make_cover):
+    """A wrapped cover with no native position support self-stops at endpoints
+    (real cover + reports its settled state), so no stop_cover is sent."""
+    cover = make_cover(cover_entity_id="cover.inner")
+    assert not cover._motor_stops_itself()  # mock entity advertises no features
+    cover._self_initiated_movement = True
+    cover._last_command = SERVICE_CLOSE_COVER
+    cover.travel_calc.set_position(0)
+
+    cover.hass.services.async_call.reset_mock()
+    with patch.object(cover, "async_write_ha_state"):
+        await cover.auto_stop_if_necessary()
+
+    assert cover.hass.services.async_call.call_args_list == []
+    assert cover._delay_task is None
+    await _cancel_tasks(cover)
+
+
+@pytest.mark.asyncio
+async def test_toggle_mid_travel_still_stops(make_cover):
+    """Mid-travel (not an endpoint) still issues the timed stop in every mode —
+    nothing self-stops between the endpoints."""
+    cover = make_cover(control_mode=CONTROL_MODE_TOGGLE)
+    cover._self_initiated_movement = True
+    cover._last_command = SERVICE_CLOSE_COVER
+    cover.travel_calc.set_position(50)
+
+    cover.hass.services.async_call.reset_mock()
+    with patch.object(cover, "async_write_ha_state"):
+        await cover.auto_stop_if_necessary()
+
+    on_calls = [c for c in _ha_calls(cover) if c.args[1] == "turn_on"]
+    assert on_calls, "mid-travel stop must still re-pulse the relay"
+    await _cancel_tasks(cover)
+
+
+@pytest.mark.asyncio
+async def test_toggle_resync_at_endpoint_schedules_no_stop(make_cover):
+    """Commanding to the endpoint we already sit at (resync) re-drives the
+    motor but must not schedule a stop for a self-stopping mode (issue #105).
+
+    This is the _async_move_to_endpoint resync path (open-at-100), distinct
+    from the auto-stop path.
+    """
+    cover = make_cover(control_mode=CONTROL_MODE_TOGGLE, endpoint_runon_time=2.0)
+    cover.travel_calc.set_position(100)
+
+    cover.hass.services.async_call.reset_mock()
+    with patch.object(cover, "async_write_ha_state"):
+        await cover.async_open_cover()
+
+    # Resync re-pulses the open relay to drive physically to the limit...
+    on_calls = [
+        c
+        for c in _ha_calls(cover)
+        if c.args[1] == "turn_on" and c.args[2].get("entity_id") == "switch.open"
+    ]
+    assert on_calls, "resync should re-pulse the direction relay"
+    # ...but must not schedule a run-on/stop that would re-pulse (restart) it.
+    assert cover._delay_task is None
+    await _cancel_tasks(cover)
+
+
+@pytest.mark.asyncio
+async def test_sequential_close_still_stops_at_closed_without_runon(make_cover):
+    """Sequential close-then-tilt-closed drives the motor PAST cover-closed to
+    articulate the slats, so travel=0 is not a hard limit — the slats-closed
+    position is timed and the motor must be stopped there. A stop is therefore
+    sent (toggle re-pulse), but with no run-on (it would overdrive the tilt).
+    """
+    cover = make_cover(
+        control_mode=CONTROL_MODE_TOGGLE,
+        tilt_time_close=2.0,
+        tilt_time_open=2.0,
+        tilt_mode="sequential_close",
+        endpoint_runon_time=2.0,
+    )
+    cover._self_initiated_movement = True
+    cover._last_command = SERVICE_CLOSE_COVER
+    cover.travel_calc.set_position(0)
+    cover.tilt_calc.set_position(0)
+
+    cover.hass.services.async_call.reset_mock()
+    with patch.object(cover, "async_write_ha_state"):
+        await cover.auto_stop_if_necessary()
+
+    on_calls = [c for c in _ha_calls(cover) if c.args[1] == "turn_on"]
+    assert on_calls, "sequential close must still stop the motor at the tilt end"
+    assert cover._delay_task is None, "but without run-on (would overdrive tilt)"
+    await _cancel_tasks(cover)
+
+
+@pytest.mark.asyncio
+async def test_mid_tilt_at_travel_endpoint_still_stops_tilt(make_cover):
+    """At a travel endpoint, a mid-tilt move must still stop the tilt motor.
+
+    The tilt-motor settle takes priority over the travel-endpoint self-stop
+    skip: if the travel-endpoint skip ran first (cover at travel=100), the tilt
+    motor would never be stopped, and a stale travel _last_command could
+    re-pulse the travel relay. A mid-tilt target isolates the tilt branch — the
+    travel-endpoint skip alone would leave the tilt motor running.
+    """
+    cover = make_cover(
+        control_mode=CONTROL_MODE_TOGGLE,
+        tilt_time_close=2.0,
+        tilt_time_open=2.0,
+        tilt_mode="dual_motor",
+        tilt_open_switch="switch.tilt_open",
+        tilt_close_switch="switch.tilt_close",
+    )
+    cover.travel_calc.set_position(100)  # cover at a travel endpoint
+    cover.tilt_calc.set_position(0)
+
+    with (
+        patch.object(cover, "async_write_ha_state"),
+        patch("custom_components.cover_time_based.cover_toggle_mode.sleep"),
+    ):
+        await cover.set_tilt_position(50)  # mid-tilt
+        cover.hass.services.async_call.reset_mock()
+        cover.tilt_calc.set_position(50)  # tilt reaches its mid target
+        await cover.auto_stop_if_necessary()
+
+    tilt_calls = [
+        c
+        for c in _ha_calls(cover)
+        if c.args[2].get("entity_id") in ("switch.tilt_open", "switch.tilt_close")
+    ]
+    travel_calls = [
+        c
+        for c in _ha_calls(cover)
+        if c.args[2].get("entity_id") in ("switch.open", "switch.close")
+    ]
+    assert tilt_calls, "mid-tilt at a travel endpoint must still stop the tilt motor"
+    assert travel_calls == [], "tilt completion must not drive the travel motor"
+    await _cancel_tasks(cover)
+
+
+@pytest.mark.parametrize(
+    "kwargs,expected",
+    [
+        ({"control_mode": CONTROL_MODE_TOGGLE}, True),
+        ({"control_mode": CONTROL_MODE_PULSE, "stop_switch": "switch.stop"}, True),
+        ({"cover_entity_id": "cover.inner"}, True),
+        ({"control_mode": CONTROL_MODE_SWITCH}, False),
+    ],
+)
+def test_self_stops_at_endpoints_per_mode(make_cover, kwargs, expected):
+    """Only switch mode (latched relay) must stop at endpoints."""
+    cover = make_cover(**kwargs)
+    assert cover._self_stops_at_endpoints() is expected
+
+
+# ===================================================================
+# Tilt endpoints (dual-motor: separate tilt motor with its own limits)
+# ===================================================================
+
+
+def _travel_calls(cover):
+    return [
+        c
+        for c in _ha_calls(cover)
+        if c.args[2].get("entity_id") in ("switch.open", "switch.close")
+    ]
+
+
+def _tilt_calls(cover):
+    return [
+        c
+        for c in _ha_calls(cover)
+        if c.args[2].get("entity_id") in ("switch.tilt_open", "switch.tilt_close")
+    ]
+
+
+def _make_dual_motor(make_cover, control_mode=CONTROL_MODE_TOGGLE):
+    return make_cover(
+        control_mode=control_mode,
+        tilt_time_close=2.0,
+        tilt_time_open=2.0,
+        tilt_mode="dual_motor",
+        tilt_open_switch="switch.tilt_open",
+        tilt_close_switch="switch.tilt_close",
+    )
+
+
+async def _run_tilt_move(cover, target):
+    """Drive a real dual-motor tilt move to `target` and complete it."""
+    with (
+        patch.object(cover, "async_write_ha_state"),
+        patch("custom_components.cover_time_based.cover_toggle_mode.sleep"),
+    ):
+        await cover.set_tilt_position(target)
+        cover.hass.services.async_call.reset_mock()
+        cover.tilt_calc.set_position(target)
+        await cover.auto_stop_if_necessary()
+
+
+@pytest.mark.asyncio
+async def test_dual_motor_tilt_to_endpoint_sends_no_stop(make_cover):
+    """A dual-motor tilt reaching a tilt endpoint must not stop the tilt motor
+    (it self-stops at its limit) and must never drive the travel motor."""
+    cover = _make_dual_motor(make_cover)
+    cover.travel_calc.set_position(50)  # mid-travel: isolate tilt behaviour
+    cover.tilt_calc.set_position(0)
+
+    await _run_tilt_move(cover, 100)  # tilt to its open endpoint
+
+    assert _tilt_calls(cover) == [], "tilt motor self-stops at its endpoint"
+    assert _travel_calls(cover) == [], "tilt move must not drive the travel motor"
+    await _cancel_tasks(cover)
+
+
+@pytest.mark.asyncio
+async def test_dual_motor_tilt_to_mid_still_stops_tilt(make_cover):
+    """A dual-motor tilt reaching a mid position must stop the tilt motor
+    (nothing self-stops there) and must not drive the travel motor."""
+    cover = _make_dual_motor(make_cover)
+    cover.travel_calc.set_position(50)
+    cover.tilt_calc.set_position(0)
+
+    await _run_tilt_move(cover, 50)  # mid tilt
+
+    assert _tilt_calls(cover), "mid-tilt must stop the tilt motor"
+    assert _travel_calls(cover) == [], "tilt move must not drive the travel motor"
+    await _cancel_tasks(cover)
+
+
+@pytest.mark.asyncio
+async def test_switch_dual_motor_tilt_to_endpoint_de_energizes(make_cover):
+    """Switch mode latches the tilt relay ON, so a tilt endpoint must still turn
+    it off."""
+    cover = _make_dual_motor(make_cover, control_mode=CONTROL_MODE_SWITCH)
+    cover.travel_calc.set_position(50)
+    cover.tilt_calc.set_position(0)
+
+    with patch.object(cover, "async_write_ha_state"):
+        await cover.set_tilt_position(100)
+        cover.hass.services.async_call.reset_mock()
+        cover.tilt_calc.set_position(100)
+        await cover.auto_stop_if_necessary()
+
+    off = [c for c in _tilt_calls(cover) if c.args[1] == "turn_off"]
+    assert off, "switch mode must de-energize the tilt relay at a tilt endpoint"
+    await _cancel_tasks(cover)


### PR DESCRIPTION
## Summary

Closes #105.

Roller-shutter motors self-stop at their internal limit switches, so the relay stop the integration sent at the 0%/100% endpoints was redundant — and in **toggle** mode actively wrong: it re-pulsed the direction relay and restarted the just-stopped motor (the unwanted movement after every full open/close that #105 reports).

This PR stops sending an endpoint stop (and run-on) for the modes whose motors self-stop:

- **Pulse / Toggle / wrapped-cover:** no relay stop and no run-on at travel 0%/100% — the motor runs into its own limit. Mid-travel stops are unchanged.
- **Separate tilt motor:** same treatment at the tilt endpoints (0%/100%); mid-tilt still stops.
- **Switch mode:** unchanged — its direction relay is latched ON for the whole movement, so it is still de-energized (with run-on) at the endpoint.
- **Sequential closes-then-tilts:** still stops at the closed (0%) endpoint, where the motor is deliberately driven past cover-closed to articulate the slats.

It also fixes a pre-existing **separate-tilt-motor bug**: a completed tilt-only move fell through to the travel stop and re-pulsed the *travel* relay (off a stale `_last_command`), and never issued a proper tilt stop. Tilt completions now settle the tilt motor directly.

## ⚠ Breaking change

`endpoint_runon_time` now applies to **switch mode only** (and is hidden in the config card for other modes). Pulse/toggle/wrapped covers no longer send a stop or run-on at the endpoints. **No config migration is needed** — the option stays valid and stored; it is simply ignored for non-switch modes. Details in CHANGELOG.

## Implementation

- `_self_stops_at_endpoints()` hook (True; `SwitchModeCover` overrides to False).
- `_at_endpoint(position)` predicate dedups the endpoint condition across the auto-stop and resync paths.
- `_tilt_settle()` + a `_moving_tilt_motor` flag route a tilt-move completion to the tilt motor instead of the travel stop.
- Frontend: the run-on field is shown only for switch mode.

Note: the resync path (`open` while already at 100%) now also skips the post-command stop for **wrapped-native** covers — intentional and consistent with the existing `_motor_stops_itself` handling (avoids nudging a native cover off its exact target).

## Testing

- New `tests/test_endpoint_self_stop.py` (16 cases: each mode × endpoint/mid × travel/tilt), every new test confirmed RED before its fix.
- Full suite: **1005 passing**; ruff + translations + frontend builds green via the pre-push hook.

## Follow-ups (separate PRs)

- Remove `pulse_time` for toggle mode (unnecessary for self-releasing toggle relays; would also retire most of #100's rapid-re-pulse machinery) — from the #105 discussion.
- Optional up/down software interlock for switch mode — #99.