### PR TITLE
feat: software up/down interlock for switch mode (#99)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
   **Migration:** no action is required and no settings are lost. The **Endpoint run-on time** option now applies to **Switch mode only**; it is hidden in the config card for the other modes, and any value previously set on a pulse/toggle/wrapped cover is simply ignored. Mid-travel and mid-tilt stops are unaffected. Sequential closes-then-tilts modes still stop at the closed (0%) endpoint, where the motor is deliberately driven past cover-closed to articulate the slats.
 
+### Features
+
+- **Up/down interlock for switch mode** ([#99](https://github.com/Sese-Schneider/ha-cover-time-based/issues/99)): in switch (latching relay) mode, when the integration observes one direction relay turn ON from outside Home Assistant — for example a decoupled wall switch, or the physical switch wired straight to the relays — it now turns the opposite direction relay OFF. This covers both the travel (up/down) relays and, on dual-motor covers, the tilt relays, so two opposing relays are never energized at once even on motors with no hardware interlock. The integration already did this when *it* drove the relays; this extends the same protection to externally-triggered changes. Pulse and toggle modes are unaffected, since they don't hold a direction relay on.
+
 ### Fixes
 
 - **Separate tilt motor no longer nudges the travel motor** ([#105](https://github.com/Sese-Schneider/ha-cover-time-based/issues/105)): completing a tilt-only move on a separate-tilt-motor cover previously fell through to the travel stop and re-pulsed the *travel* relay (off a stale last-command), while never issuing a proper tilt stop. Tilt completions now settle the tilt motor directly.

--- a/custom_components/cover_time_based/cover_switch_mode.py
+++ b/custom_components/cover_time_based/cover_switch_mode.py
@@ -28,10 +28,18 @@ class SwitchModeCover(SwitchCoverTimeBased):
 
         ON = relay is driving the motor → start tracking.
         OFF = relay released → stop tracking.
+
+        Software up/down interlock: when we observe one direction relay turn ON
+        externally (e.g. a decoupled wall switch, or the switch wired straight
+        to the relays), turn the opposite relay OFF so both directions are never
+        energized at once — mirroring the interlock the driver path already does
+        in _send_open / _send_close. Switch mode is the only mode that latches a
+        direction relay, so it is the only mode that needs this.
         """
         if entity_id == self._open_switch_entity_id:
             if new_val == "on":
                 _LOGGER.debug("_handle_external_state_change :: external open detected")
+                await self._interlock_off(self._close_switch_entity_id)
                 await self.async_open_cover()
             elif new_val == "off":
                 _LOGGER.debug(
@@ -43,6 +51,7 @@ class SwitchModeCover(SwitchCoverTimeBased):
                 _LOGGER.debug(
                     "_handle_external_state_change :: external close detected"
                 )
+                await self._interlock_off(self._open_switch_entity_id)
                 await self.async_close_cover()
             elif new_val == "off":
                 _LOGGER.debug(
@@ -50,17 +59,43 @@ class SwitchModeCover(SwitchCoverTimeBased):
                 )
                 await self.async_stop_cover()
 
+    async def _interlock_off(self, entity_id) -> None:
+        """Turn the opposite direction relay OFF (software interlock).
+
+        Only writes when the relay is actually ON — there is nothing to
+        interlock otherwise, and the passive observe path should not produce
+        needless relay writes. Marks the resulting state-change event as a
+        pending echo so _async_switch_state_changed does not misread our own
+        turn_off as the user releasing that switch (which would call
+        async_stop_cover and cancel the move we just started).
+        """
+        if self._switch_is_on(entity_id):
+            _LOGGER.debug("_interlock_off :: turning off %s", entity_id)
+            self._mark_switch_pending(entity_id, 1)
+            await self.hass.services.async_call(
+                "homeassistant",
+                "turn_off",
+                {"entity_id": entity_id},
+                False,
+            )
+
     async def _handle_external_tilt_state_change(self, entity_id, old_val, new_val):
         """Handle external tilt state change in switch (latching) mode.
 
         ON = tilt relay is driving the motor → start tilt tracking.
         OFF = tilt relay released → stop tilt tracking.
+
+        Dual-motor tilt relays latch the same way the travel relays do, so the
+        same up/down interlock applies: observing one tilt direction turn ON
+        externally turns the opposite tilt relay OFF (mirroring _send_tilt_open
+        / _send_tilt_close on the driver path). See _interlock_off.
         """
         if entity_id == self._tilt_open_switch_id:
             if new_val == "on":
                 _LOGGER.debug(
                     "_handle_external_tilt_state_change :: external tilt open detected"
                 )
+                await self._interlock_off(self._tilt_close_switch_id)
                 await self.async_open_cover_tilt()
             elif new_val == "off":
                 _LOGGER.debug(
@@ -72,6 +107,7 @@ class SwitchModeCover(SwitchCoverTimeBased):
                 _LOGGER.debug(
                     "_handle_external_tilt_state_change :: external tilt close detected"
                 )
+                await self._interlock_off(self._tilt_open_switch_id)
                 await self.async_close_cover_tilt()
             elif new_val == "off":
                 _LOGGER.debug(

--- a/tests/test_cover_switch_mode.py
+++ b/tests/test_cover_switch_mode.py
@@ -7,8 +7,12 @@ service calls for the latching relay (switch) mode.
 import asyncio
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock, call
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
+from custom_components.cover_time_based.cover import (
+    CONTROL_MODE_PULSE,
+    CONTROL_MODE_TOGGLE,
+)
 from custom_components.cover_time_based.cover_switch_mode import SwitchModeCover
 
 
@@ -21,6 +25,9 @@ def _make_switch_cover(
     open_switch="switch.open",
     close_switch="switch.close",
     stop_switch=None,
+    tilt_open_switch=None,
+    tilt_close_switch=None,
+    tilt_stop_switch=None,
 ):
     """Create a SwitchModeCover wired to a mock hass."""
     cover = SwitchModeCover(
@@ -38,6 +45,9 @@ def _make_switch_cover(
         open_switch_entity_id=open_switch,
         close_switch_entity_id=close_switch,
         stop_switch_entity_id=stop_switch,
+        tilt_open_switch=tilt_open_switch,
+        tilt_close_switch=tilt_close_switch,
+        tilt_stop_switch=tilt_stop_switch,
     )
     hass = MagicMock()
     hass.services.async_call = AsyncMock()
@@ -141,3 +151,242 @@ class TestSwitchModeSendStop:
             _ha("turn_off", "switch.close"),
             _ha("turn_off", "switch.open"),
         ]
+
+
+# ---------------------------------------------------------------------------
+# Observe-path up/down software interlock (issue #99)
+# ---------------------------------------------------------------------------
+
+# Where _mark_switch_pending schedules its safety timeout — patched to a no-op
+# so tests don't schedule real timers.
+_CALL_LATER = "custom_components.cover_time_based.cover_base.async_call_later"
+
+
+def _set_switch_states(cover, states):
+    """Wire cover.hass.states.get(entity_id) to return the given on/off states.
+
+    `states` maps entity_id -> "on"/"off"; anything absent reports as None.
+    """
+
+    def _get(entity_id):
+        value = states.get(entity_id)
+        if value is None:
+            return None
+        st = MagicMock()
+        st.state = value
+        return st
+
+    cover.hass.states.get = MagicMock(side_effect=_get)
+
+
+class TestSwitchModeObserveInterlock:
+    """When a direction relay is observed turning ON externally, the opposite
+    relay must be turned OFF (software interlock) without cancelling the move."""
+
+    @pytest.mark.asyncio
+    async def test_external_open_turns_close_off_and_still_tracks(self):
+        cover = _make_switch_cover()
+        _set_switch_states(cover, {"switch.close": "on"})
+
+        with (
+            patch(_CALL_LATER, return_value=MagicMock()),
+            patch.object(cover, "async_open_cover", new_callable=AsyncMock) as track,
+        ):
+            await cover._handle_external_state_change("switch.open", "off", "on")
+
+        assert _ha("turn_off", "switch.close") in _calls(cover.hass.services.async_call)
+        track.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_external_open_marks_close_echo_pending(self):
+        """The interlock's own turn_off is marked pending so the echo isn't
+        misread as a user releasing the close switch (which would stop us)."""
+        cover = _make_switch_cover()
+        _set_switch_states(cover, {"switch.close": "on"})
+
+        with (
+            patch(_CALL_LATER, return_value=MagicMock()),
+            patch.object(cover, "async_open_cover", new_callable=AsyncMock),
+        ):
+            await cover._handle_external_state_change("switch.open", "off", "on")
+
+        assert cover._pending_switch.get("switch.close") == 1
+
+    @pytest.mark.asyncio
+    async def test_external_close_turns_open_off_and_still_tracks(self):
+        cover = _make_switch_cover()
+        _set_switch_states(cover, {"switch.open": "on"})
+
+        with (
+            patch(_CALL_LATER, return_value=MagicMock()),
+            patch.object(cover, "async_close_cover", new_callable=AsyncMock) as track,
+        ):
+            await cover._handle_external_state_change("switch.close", "off", "on")
+
+        assert _ha("turn_off", "switch.open") in _calls(cover.hass.services.async_call)
+        assert cover._pending_switch.get("switch.open") == 1
+        track.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_no_interlock_write_when_opposite_already_off(self):
+        """If the opposite relay is already OFF there is nothing to interlock,
+        so no relay write (and no spurious echo) is produced."""
+        cover = _make_switch_cover()
+        _set_switch_states(cover, {"switch.close": "off"})
+
+        with (
+            patch(_CALL_LATER, return_value=MagicMock()),
+            patch.object(cover, "async_open_cover", new_callable=AsyncMock) as track,
+        ):
+            await cover._handle_external_state_change("switch.open", "off", "on")
+
+        assert cover.hass.services.async_call.call_count == 0
+        assert "switch.close" not in cover._pending_switch
+        track.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_external_off_stops_without_interlock_write(self):
+        """The OFF (relay released) path is unchanged: stop, no relay write."""
+        cover = _make_switch_cover()
+        _set_switch_states(cover, {})
+
+        with patch.object(cover, "async_stop_cover", new_callable=AsyncMock) as stop:
+            await cover._handle_external_state_change("switch.open", "on", "off")
+
+        stop.assert_awaited_once()
+        assert cover.hass.services.async_call.call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_interlock_off_echo_does_not_trigger_stop(self):
+        """End-to-end: the interlock's turn_off event, when it arrives back via
+        _async_switch_state_changed, is echo-filtered and does NOT stop us."""
+        cover = _make_switch_cover()
+        _set_switch_states(cover, {"switch.close": "on"})
+
+        with (
+            patch(_CALL_LATER, return_value=MagicMock()),
+            patch.object(cover, "async_open_cover", new_callable=AsyncMock),
+            patch.object(cover, "async_stop_cover", new_callable=AsyncMock) as stop,
+            patch.object(cover, "async_write_ha_state"),
+            patch.object(cover, "_entity_unavailable", return_value=False),
+        ):
+            # 1. open relay observed ON externally → interlock turns close OFF
+            await cover._handle_external_state_change("switch.open", "off", "on")
+            assert cover._pending_switch.get("switch.close") == 1
+
+            # 2. the close relay's resulting OFF event arrives
+            event = MagicMock()
+            old = MagicMock()
+            old.state = "on"
+            new = MagicMock()
+            new.state = "off"
+            event.data = {
+                "entity_id": "switch.close",
+                "old_state": old,
+                "new_state": new,
+            }
+            await cover._async_switch_state_changed(event)
+
+        assert "switch.close" not in cover._pending_switch
+        stop.assert_not_awaited()
+
+
+class TestSwitchModeTiltObserveInterlock:
+    """Dual-motor tilt relays also latch in switch mode, so observing one tilt
+    direction turn ON externally must turn the opposite tilt relay OFF — the
+    same interlock as travel (the tilt driver path already does this)."""
+
+    @pytest.mark.asyncio
+    async def test_external_tilt_open_turns_tilt_close_off_and_still_tracks(self):
+        cover = _make_switch_cover(
+            tilt_open_switch="switch.tilt_open",
+            tilt_close_switch="switch.tilt_close",
+        )
+        _set_switch_states(cover, {"switch.tilt_close": "on"})
+
+        with (
+            patch(_CALL_LATER, return_value=MagicMock()),
+            patch.object(
+                cover, "async_open_cover_tilt", new_callable=AsyncMock
+            ) as track,
+        ):
+            await cover._handle_external_tilt_state_change(
+                "switch.tilt_open", "off", "on"
+            )
+
+        assert _ha("turn_off", "switch.tilt_close") in _calls(
+            cover.hass.services.async_call
+        )
+        assert cover._pending_switch.get("switch.tilt_close") == 1
+        track.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_external_tilt_close_turns_tilt_open_off_and_still_tracks(self):
+        cover = _make_switch_cover(
+            tilt_open_switch="switch.tilt_open",
+            tilt_close_switch="switch.tilt_close",
+        )
+        _set_switch_states(cover, {"switch.tilt_open": "on"})
+
+        with (
+            patch(_CALL_LATER, return_value=MagicMock()),
+            patch.object(
+                cover, "async_close_cover_tilt", new_callable=AsyncMock
+            ) as track,
+        ):
+            await cover._handle_external_tilt_state_change(
+                "switch.tilt_close", "off", "on"
+            )
+
+        assert _ha("turn_off", "switch.tilt_open") in _calls(
+            cover.hass.services.async_call
+        )
+        assert cover._pending_switch.get("switch.tilt_open") == 1
+        track.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_no_tilt_interlock_write_when_opposite_already_off(self):
+        cover = _make_switch_cover(
+            tilt_open_switch="switch.tilt_open",
+            tilt_close_switch="switch.tilt_close",
+        )
+        _set_switch_states(cover, {"switch.tilt_close": "off"})
+
+        with (
+            patch(_CALL_LATER, return_value=MagicMock()),
+            patch.object(
+                cover, "async_open_cover_tilt", new_callable=AsyncMock
+            ) as track,
+        ):
+            await cover._handle_external_tilt_state_change(
+                "switch.tilt_open", "off", "on"
+            )
+
+        assert cover.hass.services.async_call.call_count == 0
+        assert "switch.tilt_close" not in cover._pending_switch
+        track.assert_awaited_once()
+
+
+class TestNonSwitchModesHaveNoInterlock:
+    """Toggle and pulse modes don't latch a direction relay, so their observe
+    path must not write to the relays (no interlock)."""
+
+    @pytest.mark.asyncio
+    async def test_pulse_observe_open_writes_no_relay(self, make_cover):
+        cover = make_cover(control_mode=CONTROL_MODE_PULSE)
+        _set_switch_states(cover, {"switch.close": "on"})
+
+        with patch.object(cover, "async_open_cover", new_callable=AsyncMock):
+            await cover._handle_external_state_change("switch.open", "off", "on")
+
+        assert cover.hass.services.async_call.call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_toggle_observe_open_writes_no_relay(self, make_cover):
+        cover = make_cover(control_mode=CONTROL_MODE_TOGGLE)
+        _set_switch_states(cover, {"switch.close": "on"})
+
+        with patch.object(cover, "async_open_cover", new_callable=AsyncMock):
+            await cover._handle_external_state_change("switch.open", "off", "on")
+
+        assert cover.hass.services.async_call.call_count == 0


### PR DESCRIPTION
Closes #99.

## What

In **switch (latching relay) mode**, the integration already interlocks the direction relays when *it* drives them: `_send_open`/`_send_close` turn the opposite relay OFF before energizing theirs. The **observe path** — for changes triggered *outside* Home Assistant (a decoupled wall switch, or the switch wired straight to the relays) — only tracked position and never cut the opposite relay, so on a motor with no hardware interlock **both directions could energize at once** (the problem @h4ng3r reported in #99).

`_handle_external_state_change` now turns the opposite relay OFF (via a new `_interlock_off` helper) when it observes one direction relay turn ON. This is applied to:
- the **travel** (up/down) relays, and
- the **dual-motor tilt** relays (which latch the same way; the tilt driver path `_send_tilt_open`/`_send_tilt_close` already interlocked, so this brings the observe path to parity).

The interlock `turn_off` is marked as a **pending echo** (`_mark_switch_pending`) so `_async_switch_state_changed` doesn't misread our own write as the user releasing that switch and call `async_stop_cover`, cancelling the move we just started. It only writes when the opposite relay is actually ON, so the passive observe path stays passive when there's nothing to interlock.

Switch mode only — **toggle/pulse don't latch a direction relay**, so they have nothing to interlock against and are unaffected.

## Scope notes

- No config option — always on, per the maintainer's decision in #99 ("both direction relays energized at once is never desirable").
- The existing direction-change behaviour is otherwise unchanged.
- Tilt coverage was added on top of the travel-only scope after review surfaced the same gap on the dual-motor tilt observe path.

## Tests

New tests in `tests/test_cover_switch_mode.py`:
- observing open-ON / close-ON externally turns the opposite relay OFF and still starts tracking;
- the interlock's `turn_off` is marked pending (echo-suppressed) — including an **end-to-end test** that feeds the resulting OFF event back through the real `_async_switch_state_changed` and asserts no spurious `async_stop_cover`;
- no relay write when the opposite is already OFF; the OFF (released) path is unchanged;
- the same set for the **dual-motor tilt** relays;
- contrast tests confirming **pulse and toggle** observe paths write no relay.

Full suite green (1016 passed); `ruff`, `check_docs`, `check_translations` clean. CHANGELOG updated.