### PR TITLE
fix: drop pulse_time for toggle mode (#105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixes
 
 - **Separate tilt motor no longer nudges the travel motor** ([#105](https://github.com/Sese-Schneider/ha-cover-time-based/issues/105)): completing a tilt-only move on a separate-tilt-motor cover previously fell through to the travel stop and re-pulsed the *travel* relay (off a stale last-command), while never issuing a proper tilt stop. Tilt completions now settle the tilt motor directly.
+- **Toggle mode no longer uses Pulse time** ([#105](https://github.com/Sese-Schneider/ha-cover-time-based/issues/105)): toggle-style relays are momentary — a brief press latches the motor and the relay releases itself — so holding the relay ON for the configured **Pulse time** served no purpose. Toggle covers now send a single switch-on per command (briefly switching the relay off first only when it is still reported ON, to guarantee a clean rising edge) and the **Pulse time** option is hidden for toggle mode. **Pulse** mode is unchanged and still uses Pulse time. If you had set a pulse time on a toggle cover it was doing nothing useful, so no action is needed.
 
 ## 4.3.0 (2026-06-17)
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Three input modes are available to describe how the switch entities for switch-b
 
 #### Pulse time
 
-With the **Pulse** and **Toggle** input modes, the **Pulse time** configures how long the switch should send the ON signal before it turns OFF. Defaults to **1s**.
+With the **Pulse** input mode, the **Pulse time** configures how long the switch should send the ON signal before it turns OFF. Defaults to **1s**. **Toggle** mode does not use it — toggle relays are momentary, so the integration sends a single ON pulse and lets the relay release itself.
 
 ### Assumed state
 

--- a/custom_components/cover_time_based/cover.py
+++ b/custom_components/cover_time_based/cover.py
@@ -351,7 +351,7 @@ def _create_cover_from_options(options, device_id="", name=""):
     if control_mode == CONTROL_MODE_PULSE:
         return PulseModeCover(pulse_time=pulse_time, **switch_args)
     elif control_mode == CONTROL_MODE_TOGGLE:
-        return ToggleModeCover(pulse_time=pulse_time, **switch_args)
+        return ToggleModeCover(**switch_args)
     else:
         return SwitchModeCover(**switch_args)
 

--- a/custom_components/cover_time_based/cover_base.py
+++ b/custom_components/cover_time_based/cover_base.py
@@ -478,10 +478,7 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         await self._async_move_to_endpoint(target=100)
 
     async def _direction_change_delay(self):
-        """Pause between stop and direction change to let the motor settle.
-
-        Toggle mode overrides this with pulse_time (the relay pulse duration).
-        """
+        """Pause between stop and direction change to let the motor settle."""
         await sleep(1.0)
 
     async def async_stop_cover(self, **kwargs):

--- a/custom_components/cover_time_based/cover_calibration.py
+++ b/custom_components/cover_time_based/cover_calibration.py
@@ -427,9 +427,11 @@ class CalibrationMixin:
                 )
                 return 0.0
             continuous_time = time.monotonic() - continuous_start
-            # Subtract pulse overhead from continuous phase start for
-            # pulse/toggle modes (the ON command includes a relay pulse
-            # that doesn't contribute to motor travel time).
+            # Subtract pulse overhead from the continuous phase for pulse mode
+            # (the ON command holds the relay for pulse_time, which doesn't
+            # contribute to motor travel time). Toggle mode no longer sets
+            # _pulse_time — it sends a momentary edge with no hold — so getattr
+            # yields None and nothing is subtracted.
             pulse_time = getattr(self, "_pulse_time", None)
             if pulse_time:
                 continuous_time -= pulse_time

--- a/custom_components/cover_time_based/cover_toggle_mode.py
+++ b/custom_components/cover_time_based/cover_toggle_mode.py
@@ -1,9 +1,7 @@
 """Toggle mode cover."""
 
-import asyncio
 import logging
 import time
-from asyncio import sleep
 
 from homeassistant.const import (
     SERVICE_CLOSE_COVER,
@@ -29,101 +27,51 @@ class ToggleModeCover(SwitchCoverTimeBased):
     A second pulse on the same direction button stops the motor.
     _send_stop therefore re-presses the last-used direction button.
 
-    The send methods return immediately after the ON edge so that position
-    tracking starts from the moment the motor begins moving. The pulse
-    completion (sleep + turn_off) runs in the background.
+    The send methods pulse a relay with a single ``turn_on`` and never hold it
+    ON: toggle relays are momentary/self-releasing, so the next command is
+    naturally a clean rising edge. Position tracking starts from the moment the
+    motor begins moving (the ON edge).
     """
 
-    def __init__(self, pulse_time, **kwargs):
+    def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self._pulse_time = pulse_time
         self._last_external_toggle_time = {}
         self._last_tilt_direction = None
-        # In-flight _complete_pulse tasks, keyed by relay entity_id. Tracked so
-        # a new pulse on the same relay can cancel the stale completion before
-        # it releases the fresh pulse mid-flight (see _pulse_relay).
-        self._pulse_tasks = {}
-        # Serializes _pulse_relay: cover service calls aren't serialized by HA
-        # (no PARALLEL_UPDATES), so concurrent pulses on the same relay could
-        # otherwise interleave between the task pop and the task store, each
-        # missing the other's in-flight pulse.
-        self._pulse_lock = asyncio.Lock()
 
-    async def _complete_pulse(self, entity_id):
-        """Complete a relay pulse by turning OFF after pulse_time.
+    async def _pulse_relay(self, entity_id):
+        """Pulse a relay ON with a guaranteed rising edge.
 
-        Only releases the relay if this task is still the one registered for it.
-        A newer pulse replaces the registration (and cancels this task), but
-        asyncio cancellation is cooperative — a task already past the sleep and
-        into the turn_off call could otherwise still fire it and release the
-        fresh pulse. Keying off the registration makes that impossible
-        regardless of cancellation timing.
+        A toggle motor controller acts on the relay's OFF→ON edge, so a plain
+        ``turn_on`` is enough when the relay is already OFF (the momentary relay
+        released itself — see the class docstring); no deferred ``turn_off`` is
+        scheduled. Only when the relay still *reports* ON (a non-self-releasing
+        relay, or one left ON across a restart) is it driven OFF first, so the
+        ``turn_on`` is a genuine edge rather than a no-op on an already-on relay
+        (which the motor would miss while the position tracker keeps advancing,
+        desyncing the entity from the physical cover).
+
+        Mark the echo(es) this pulse produces so the integration ignores its
+        own state changes: one for the lone ``turn_on``, or two when a release
+        ``turn_off`` precedes it. Marking more echoes than are emitted would
+        leave a stale pending count that swallows the user's next genuine press
+        until the safety timeout clears it.
         """
-        try:
-            await sleep(self._pulse_time)
-            if self._pulse_tasks.get(entity_id) is not asyncio.current_task():
-                return
+        if self._switch_is_on(entity_id):
+            self._mark_switch_pending(entity_id, 2)
             await self.hass.services.async_call(
                 "homeassistant",
                 "turn_off",
                 {"entity_id": entity_id},
                 False,
             )
-        except asyncio.CancelledError:
-            pass
-
-    async def _pulse_relay(self, entity_id):
-        """Pulse a relay ON with a guaranteed edge, then schedule its release.
-
-        A toggle motor controller acts on the relay's rising edge. The OFF half
-        of a pulse is deferred to a background ``_complete_pulse`` task, so a
-        new command can arrive while the relay is still held ON. A bare
-        ``turn_on`` on an already-on relay produces no edge — the motor misses
-        the pulse while the position tracker keeps advancing, desyncing the
-        entity from the physical cover.
-
-        Cancel any stale completion for this relay (so it can't release the
-        fresh pulse mid-flight) and, if the relay is still held ON, drive it OFF
-        first so the ``turn_on`` is a genuine edge. The release OFF echo is
-        absorbed by the pending count the caller already marked for this relay's
-        own completion turn_off, so no extra echo bookkeeping is needed. Finally
-        schedule (and track) the OFF half so the next pulse can cancel it.
-
-        "Still held ON" is decided by the in-flight pulse *task*, not by
-        ``_switch_is_on``: a real switch confirms its state only after a device
-        round-trip (tens of ms), which is far longer than the gap between rapid
-        presses, so the reported state still reads OFF while our own pulse holds
-        the relay ON. ``_switch_is_on`` is kept as a secondary trigger for the
-        relay being ON for some other reason (e.g. left ON across a restart);
-        that path emits one extra OFF echo over the caller's pending budget, but
-        a stray OFF is harmless — external handlers act only on the rising edge.
-
-        The whole body runs under ``_pulse_lock`` so the pop/cancel/turn_on/
-        store sequence is atomic: HA does not serialize cover service calls, so
-        two concurrent pulses on the same relay would otherwise both pop before
-        either stored, both miss the in-flight pulse, and skip the release.
-        """
-        async with self._pulse_lock:
-            stale = self._pulse_tasks.pop(entity_id, None)
-            pulse_in_flight = stale is not None and not stale.done()
-            if pulse_in_flight:
-                stale.cancel()
-            if pulse_in_flight or self._switch_is_on(entity_id):
-                await self.hass.services.async_call(
-                    "homeassistant",
-                    "turn_off",
-                    {"entity_id": entity_id},
-                    False,
-                )
-            await self.hass.services.async_call(
-                "homeassistant",
-                "turn_on",
-                {"entity_id": entity_id},
-                False,
-            )
-            self._pulse_tasks[entity_id] = self.hass.async_create_task(
-                self._complete_pulse(entity_id)
-            )
+        else:
+            self._mark_switch_pending(entity_id, 1)
+        await self.hass.services.async_call(
+            "homeassistant",
+            "turn_on",
+            {"entity_id": entity_id},
+            False,
+        )
 
     async def async_stop_cover(self, **kwargs):
         """Stop the cover, only sending relay command if it was active."""
@@ -260,12 +208,12 @@ class ToggleModeCover(SwitchCoverTimeBased):
             opposite = SERVICE_CLOSE_COVER if command == "open" else SERVICE_OPEN_COVER
             if self._last_command == opposite:
                 await self._send_stop()
-                await sleep(self._pulse_time)
+                await self._direction_change_delay()
         elif command in ("tilt_open", "tilt_close"):
             opposite_dir = "close" if command == "tilt_open" else "open"
             if self._last_tilt_direction == opposite_dir:
                 await self._send_tilt_stop()
-                await sleep(self._pulse_time)
+                await self._direction_change_delay()
         await super()._raw_direction_command(command)
 
     # --- Internal relay commands ---
@@ -273,37 +221,33 @@ class ToggleModeCover(SwitchCoverTimeBased):
     async def _send_open(self) -> None:
         if self._switch_is_on(self._close_switch_entity_id):
             self._mark_switch_pending(self._close_switch_entity_id, 1)
-        self._mark_switch_pending(self._open_switch_entity_id, 2)
         await self.hass.services.async_call(
             "homeassistant",
             "turn_off",
             {"entity_id": self._close_switch_entity_id},
             False,
         )
-        # Motor controller acts on ON edge; complete pulse in background
+        # Motor controller acts on the ON edge (_pulse_relay marks its echoes)
         await self._pulse_relay(self._open_switch_entity_id)
 
     async def _send_close(self) -> None:
         if self._switch_is_on(self._open_switch_entity_id):
             self._mark_switch_pending(self._open_switch_entity_id, 1)
-        self._mark_switch_pending(self._close_switch_entity_id, 2)
         await self.hass.services.async_call(
             "homeassistant",
             "turn_off",
             {"entity_id": self._open_switch_entity_id},
             False,
         )
-        # Motor controller acts on ON edge; complete pulse in background
+        # Motor controller acts on the ON edge (_pulse_relay marks its echoes)
         await self._pulse_relay(self._close_switch_entity_id)
 
     async def _send_stop(self) -> None:
+        # Stop re-pulses the last-used direction relay; the motor toggles on
+        # the ON edge (_pulse_relay marks its own echoes).
         if self._last_command == SERVICE_CLOSE_COVER:
-            self._mark_switch_pending(self._close_switch_entity_id, 2)
-            # Motor toggles on ON edge; complete pulse in background
             await self._pulse_relay(self._close_switch_entity_id)
         elif self._last_command == SERVICE_OPEN_COVER:
-            self._mark_switch_pending(self._open_switch_entity_id, 2)
-            # Motor toggles on ON edge; complete pulse in background
             await self._pulse_relay(self._open_switch_entity_id)
         else:
             self._log("_send_stop :: toggle mode with no last command, skipping")
@@ -313,7 +257,6 @@ class ToggleModeCover(SwitchCoverTimeBased):
     async def _send_tilt_open(self) -> None:
         if self._switch_is_on(self._tilt_close_switch_id):
             self._mark_switch_pending(self._tilt_close_switch_id, 1)
-        self._mark_switch_pending(self._tilt_open_switch_id, 2)
         await self.hass.services.async_call(
             "homeassistant",
             "turn_off",
@@ -326,7 +269,6 @@ class ToggleModeCover(SwitchCoverTimeBased):
     async def _send_tilt_close(self) -> None:
         if self._switch_is_on(self._tilt_open_switch_id):
             self._mark_switch_pending(self._tilt_open_switch_id, 1)
-        self._mark_switch_pending(self._tilt_close_switch_id, 2)
         await self.hass.services.async_call(
             "homeassistant",
             "turn_off",
@@ -338,10 +280,8 @@ class ToggleModeCover(SwitchCoverTimeBased):
 
     async def _send_tilt_stop(self) -> None:
         if self._last_tilt_direction == "close":
-            self._mark_switch_pending(self._tilt_close_switch_id, 2)
             await self._pulse_relay(self._tilt_close_switch_id)
         elif self._last_tilt_direction == "open":
-            self._mark_switch_pending(self._tilt_open_switch_id, 2)
             await self._pulse_relay(self._tilt_open_switch_id)
         else:
             self._log(

--- a/custom_components/cover_time_based/frontend/cover-time-based-card.js
+++ b/custom_components/cover_time_based/frontend/cover-time-based-card.js
@@ -17,6 +17,7 @@ import {
   filterEntitiesByValidEntries,
   switchPickerDomains,
   switchLabelKey,
+  showsPulseTime,
   clearedEntitiesForMode,
   clearedTiltConfig,
   coverHasNativeTilt,
@@ -1035,7 +1036,7 @@ class CoverTimeBasedCard extends LitElement {
 
   _renderControlMode(c) {
     const mode = c.control_mode || "switch";
-    const showPulseTime = mode === "pulse" || mode === "toggle";
+    const showPulseTime = showsPulseTime(mode);
 
     return html`
       <div class="section">

--- a/custom_components/cover_time_based/frontend/entity-filter.js
+++ b/custom_components/cover_time_based/frontend/entity-filter.js
@@ -48,6 +48,17 @@ export function switchLabelKey(baseKey, controlMode) {
   return controlMode === "pulse" ? `${baseKey}_pulse` : baseKey;
 }
 
+/**
+ * Whether the control mode exposes the "Pulse time" field.
+ *
+ * Only pulse mode holds the relay ON for a configured duration. Toggle relays
+ * are momentary/self-releasing — the integration sends a single turn_on and
+ * never holds the relay — so pulse_time is irrelevant there.
+ */
+export function showsPulseTime(controlMode) {
+  return controlMode === "pulse";
+}
+
 // CoverEntityFeature bit flags.
 const OPEN_TILT = 16;
 const CLOSE_TILT = 32;

--- a/tests/frontend/switch_picker.test.mjs
+++ b/tests/frontend/switch_picker.test.mjs
@@ -9,6 +9,7 @@ import assert from "node:assert/strict";
 import {
   switchPickerDomains,
   switchLabelKey,
+  showsPulseTime,
   clearedEntitiesForMode,
   clearedTiltConfig,
   coverHasNativeTilt,
@@ -17,6 +18,16 @@ import {
 
 test("pulse mode allows switch and script domains", () => {
   assert.deepEqual(switchPickerDomains("pulse"), ["switch", "script"]);
+});
+
+test("the pulse-time field shows only for pulse mode", () => {
+  // Toggle relays are momentary/self-releasing and no longer use pulse_time,
+  // so only pulse mode configures it.
+  assert.equal(showsPulseTime("pulse"), true);
+  assert.equal(showsPulseTime("toggle"), false);
+  assert.equal(showsPulseTime("switch"), false);
+  assert.equal(showsPulseTime("wrapped"), false);
+  assert.equal(showsPulseTime(undefined), false);
 });
 
 test("non-pulse modes allow only the switch domain", () => {

--- a/tests/test_cover_toggle_mode.py
+++ b/tests/test_cover_toggle_mode.py
@@ -6,8 +6,11 @@ Tests cover:
 - Stop guard: idle cover should not send relay commands
 - Direction change: closing while opening stops first
 
-Pulse completion (sleep + turn_off) now runs in background tasks. Tests
-await those tasks to verify the full call sequence.
+Toggle mode pulses a relay with a single ``turn_on`` and never holds it ON:
+self-releasing/momentary toggle relays return to OFF on their own, so the next
+command is naturally a clean rising edge. The relay is only driven OFF first
+when it still *reports* ON (a non-self-releasing relay, or one left ON across a
+restart), to guarantee the motor sees a genuine OFF->ON edge.
 """
 
 import asyncio
@@ -33,7 +36,6 @@ def _make_toggle_cover(
     open_switch="switch.open",
     close_switch="switch.close",
     stop_switch=None,
-    pulse_time=1.0,
     tilt_open_switch=None,
     tilt_close_switch=None,
     tilt_stop_switch=None,
@@ -54,7 +56,6 @@ def _make_toggle_cover(
         open_switch_entity_id=open_switch,
         close_switch_entity_id=close_switch,
         stop_switch_entity_id=stop_switch,
-        pulse_time=pulse_time,
         tilt_open_switch=tilt_open_switch,
         tilt_close_switch=tilt_close_switch,
         tilt_stop_switch=tilt_stop_switch,
@@ -74,15 +75,8 @@ def _make_toggle_cover(
     return cover
 
 
-async def _drain_tasks(cover):
-    """Await all background tasks created during a send call."""
-    for task in cover._test_tasks:
-        await task
-    cover._test_tasks.clear()
-
-
 async def _cancel_tasks(cover):
-    """Cancel all pending background tasks (for tests that don't drain)."""
+    """Cancel all pending background tasks (lifecycle auto-updater etc.)."""
     for task in cover._test_tasks:
         if not task.done():
             task.cancel()
@@ -107,13 +101,20 @@ def _ha(service, entity_id):
 def _hold_relay_on(cover, entity_id):
     """Make hass report ``entity_id`` as currently ON, every other relay OFF.
 
-    Simulates a relay still held ON by a previous pulse whose background
-    ``_complete_pulse`` (turn_off) has not fired yet.
+    Simulates a non-self-releasing relay still latched ON (or one left ON
+    across a restart) when the next command arrives.
     """
     on = SimpleNamespace(state="on")
     off = SimpleNamespace(state="off")
     cover.hass.states.get = MagicMock(
         side_effect=lambda eid: on if eid == entity_id else off
+    )
+
+
+def _all_relays_off(cover):
+    """Make hass report every relay as currently OFF (idle, self-released)."""
+    cover.hass.states.get = MagicMock(
+        side_effect=lambda eid: SimpleNamespace(state="off")
     )
 
 
@@ -135,36 +136,24 @@ class TestToggleModeSendOpen:
     @pytest.mark.asyncio
     async def test_open_pulses_open_switch(self):
         cover = _make_toggle_cover()
-        with patch(
-            "custom_components.cover_time_based.cover_toggle_mode.sleep",
-            new_callable=AsyncMock,
-        ):
-            await cover._send_open()
-            await _drain_tasks(cover)
+        _all_relays_off(cover)
+        await cover._send_open()
 
         assert _calls(cover.hass.services.async_call) == [
             _ha("turn_off", "switch.close"),
             _ha("turn_on", "switch.open"),
-            # pulse completion (background)
-            _ha("turn_off", "switch.open"),
         ]
 
     @pytest.mark.asyncio
     async def test_open_with_stop_switch(self):
         """Stop switch is not valid in toggle mode; it must be ignored."""
         cover = _make_toggle_cover(stop_switch="switch.stop")
-        with patch(
-            "custom_components.cover_time_based.cover_toggle_mode.sleep",
-            new_callable=AsyncMock,
-        ):
-            await cover._send_open()
-            await _drain_tasks(cover)
+        _all_relays_off(cover)
+        await cover._send_open()
 
         assert _calls(cover.hass.services.async_call) == [
             _ha("turn_off", "switch.close"),
             _ha("turn_on", "switch.open"),
-            # pulse completion (background)
-            _ha("turn_off", "switch.open"),
         ]
 
 
@@ -177,36 +166,24 @@ class TestToggleModeSendClose:
     @pytest.mark.asyncio
     async def test_close_pulses_close_switch(self):
         cover = _make_toggle_cover()
-        with patch(
-            "custom_components.cover_time_based.cover_toggle_mode.sleep",
-            new_callable=AsyncMock,
-        ):
-            await cover._send_close()
-            await _drain_tasks(cover)
+        _all_relays_off(cover)
+        await cover._send_close()
 
         assert _calls(cover.hass.services.async_call) == [
             _ha("turn_off", "switch.open"),
             _ha("turn_on", "switch.close"),
-            # pulse completion (background)
-            _ha("turn_off", "switch.close"),
         ]
 
     @pytest.mark.asyncio
     async def test_close_with_stop_switch(self):
         """Stop switch is not valid in toggle mode; it must be ignored."""
         cover = _make_toggle_cover(stop_switch="switch.stop")
-        with patch(
-            "custom_components.cover_time_based.cover_toggle_mode.sleep",
-            new_callable=AsyncMock,
-        ):
-            await cover._send_close()
-            await _drain_tasks(cover)
+        _all_relays_off(cover)
+        await cover._send_close()
 
         assert _calls(cover.hass.services.async_call) == [
             _ha("turn_off", "switch.open"),
             _ha("turn_on", "switch.close"),
-            # pulse completion (background)
-            _ha("turn_off", "switch.close"),
         ]
 
 
@@ -219,35 +196,23 @@ class TestToggleModeSendStop:
     @pytest.mark.asyncio
     async def test_stop_after_close_pulses_close_switch(self):
         cover = _make_toggle_cover()
+        _all_relays_off(cover)
         cover._last_command = SERVICE_CLOSE_COVER
-        with patch(
-            "custom_components.cover_time_based.cover_toggle_mode.sleep",
-            new_callable=AsyncMock,
-        ):
-            await cover._send_stop()
-            await _drain_tasks(cover)
+        await cover._send_stop()
 
         assert _calls(cover.hass.services.async_call) == [
             _ha("turn_on", "switch.close"),
-            # pulse completion (background)
-            _ha("turn_off", "switch.close"),
         ]
 
     @pytest.mark.asyncio
     async def test_stop_after_open_pulses_open_switch(self):
         cover = _make_toggle_cover()
+        _all_relays_off(cover)
         cover._last_command = SERVICE_OPEN_COVER
-        with patch(
-            "custom_components.cover_time_based.cover_toggle_mode.sleep",
-            new_callable=AsyncMock,
-        ):
-            await cover._send_stop()
-            await _drain_tasks(cover)
+        await cover._send_stop()
 
         assert _calls(cover.hass.services.async_call) == [
             _ha("turn_on", "switch.open"),
-            # pulse completion (background)
-            _ha("turn_off", "switch.open"),
         ]
 
     @pytest.mark.asyncio
@@ -338,10 +303,6 @@ class TestToggleDirectionChange:
             patch.object(
                 cover, "async_stop_cover", new_callable=AsyncMock
             ) as mock_stop,
-            patch(
-                "custom_components.cover_time_based.cover_toggle_mode.sleep",
-                new_callable=AsyncMock,
-            ),
         ):
             await cover.async_close_cover()
 
@@ -362,10 +323,6 @@ class TestToggleDirectionChange:
             patch.object(
                 cover, "async_stop_cover", new_callable=AsyncMock
             ) as mock_stop,
-            patch(
-                "custom_components.cover_time_based.cover_toggle_mode.sleep",
-                new_callable=AsyncMock,
-            ),
         ):
             await cover.async_open_cover()
 
@@ -406,7 +363,6 @@ class TestToggleStopWithTilt:
             open_switch_entity_id="switch.open",
             close_switch_entity_id="switch.close",
             stop_switch_entity_id=None,
-            pulse_time=1.0,
         )
         hass = MagicMock()
         hass.services.async_call = AsyncMock()
@@ -446,18 +402,12 @@ class TestToggleModeSendTiltOpen:
             tilt_open_switch="switch.tilt_open",
             tilt_close_switch="switch.tilt_close",
         )
-        with patch(
-            "custom_components.cover_time_based.cover_toggle_mode.sleep",
-            new_callable=AsyncMock,
-        ):
-            await cover._send_tilt_open()
-            await _drain_tasks(cover)
+        _all_relays_off(cover)
+        await cover._send_tilt_open()
 
         assert _calls(cover.hass.services.async_call) == [
             _ha("turn_off", "switch.tilt_close"),
             _ha("turn_on", "switch.tilt_open"),
-            # pulse completion (background)
-            _ha("turn_off", "switch.tilt_open"),
         ]
         assert cover._last_tilt_direction == "open"
 
@@ -469,18 +419,12 @@ class TestToggleModeSendTiltClose:
             tilt_open_switch="switch.tilt_open",
             tilt_close_switch="switch.tilt_close",
         )
-        with patch(
-            "custom_components.cover_time_based.cover_toggle_mode.sleep",
-            new_callable=AsyncMock,
-        ):
-            await cover._send_tilt_close()
-            await _drain_tasks(cover)
+        _all_relays_off(cover)
+        await cover._send_tilt_close()
 
         assert _calls(cover.hass.services.async_call) == [
             _ha("turn_off", "switch.tilt_open"),
             _ha("turn_on", "switch.tilt_close"),
-            # pulse completion (background)
-            _ha("turn_off", "switch.tilt_close"),
         ]
         assert cover._last_tilt_direction == "close"
 
@@ -492,18 +436,12 @@ class TestToggleModeSendTiltStop:
             tilt_open_switch="switch.tilt_open",
             tilt_close_switch="switch.tilt_close",
         )
+        _all_relays_off(cover)
         cover._last_tilt_direction = "open"
-        with patch(
-            "custom_components.cover_time_based.cover_toggle_mode.sleep",
-            new_callable=AsyncMock,
-        ):
-            await cover._send_tilt_stop()
-            await _drain_tasks(cover)
+        await cover._send_tilt_stop()
 
         assert _calls(cover.hass.services.async_call) == [
             _ha("turn_on", "switch.tilt_open"),
-            # pulse completion (background)
-            _ha("turn_off", "switch.tilt_open"),
         ]
         assert cover._last_tilt_direction is None
 
@@ -513,18 +451,12 @@ class TestToggleModeSendTiltStop:
             tilt_open_switch="switch.tilt_open",
             tilt_close_switch="switch.tilt_close",
         )
+        _all_relays_off(cover)
         cover._last_tilt_direction = "close"
-        with patch(
-            "custom_components.cover_time_based.cover_toggle_mode.sleep",
-            new_callable=AsyncMock,
-        ):
-            await cover._send_tilt_stop()
-            await _drain_tasks(cover)
+        await cover._send_tilt_stop()
 
         assert _calls(cover.hass.services.async_call) == [
             _ha("turn_on", "switch.tilt_close"),
-            # pulse completion (background)
-            _ha("turn_off", "switch.tilt_close"),
         ]
         assert cover._last_tilt_direction is None
 
@@ -558,15 +490,10 @@ class TestToggleHandleCommandSetsLastCommand:
     @pytest.mark.asyncio
     async def test_handle_open_sets_last_command(self):
         cover = _make_toggle_cover()
+        _all_relays_off(cover)
         assert cover._last_command is None
 
-        with (
-            patch.object(cover, "async_write_ha_state"),
-            patch(
-                "custom_components.cover_time_based.cover_toggle_mode.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
+        with patch.object(cover, "async_write_ha_state"):
             await cover._async_handle_command(SERVICE_OPEN_COVER)
 
         assert cover._last_command == SERVICE_OPEN_COVER
@@ -575,15 +502,10 @@ class TestToggleHandleCommandSetsLastCommand:
     @pytest.mark.asyncio
     async def test_handle_close_sets_last_command(self):
         cover = _make_toggle_cover()
+        _all_relays_off(cover)
         assert cover._last_command is None
 
-        with (
-            patch.object(cover, "async_write_ha_state"),
-            patch(
-                "custom_components.cover_time_based.cover_toggle_mode.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
+        with patch.object(cover, "async_write_ha_state"):
             await cover._async_handle_command(SERVICE_CLOSE_COVER)
 
         assert cover._last_command == SERVICE_CLOSE_COVER
@@ -598,50 +520,34 @@ class TestToggleHandleCommandSetsLastCommand:
         async_open_cover), as the calibration code does.
         """
         cover = _make_toggle_cover()
-        with (
-            patch.object(cover, "async_write_ha_state"),
-            patch(
-                "custom_components.cover_time_based.cover_toggle_mode.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
+        _all_relays_off(cover)
+        with patch.object(cover, "async_write_ha_state"):
             await cover._async_handle_command(SERVICE_OPEN_COVER)
-            await _drain_tasks(cover)
             cover.hass.services.async_call.reset_mock()
 
             await cover._send_stop()
-            await _drain_tasks(cover)
 
         # _send_stop should re-pulse the open switch to toggle the motor off
         assert _calls(cover.hass.services.async_call) == [
             _ha("turn_on", "switch.open"),
-            # pulse completion (background)
-            _ha("turn_off", "switch.open"),
         ]
+        await _cancel_tasks(cover)
 
     @pytest.mark.asyncio
     async def test_calibration_pattern_close_then_stop(self):
         """Same pattern for close direction."""
         cover = _make_toggle_cover()
-        with (
-            patch.object(cover, "async_write_ha_state"),
-            patch(
-                "custom_components.cover_time_based.cover_toggle_mode.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
+        _all_relays_off(cover)
+        with patch.object(cover, "async_write_ha_state"):
             await cover._async_handle_command(SERVICE_CLOSE_COVER)
-            await _drain_tasks(cover)
             cover.hass.services.async_call.reset_mock()
 
             await cover._send_stop()
-            await _drain_tasks(cover)
 
         assert _calls(cover.hass.services.async_call) == [
             _ha("turn_on", "switch.close"),
-            # pulse completion (background)
-            _ha("turn_off", "switch.close"),
         ]
+        await _cancel_tasks(cover)
 
 
 # ===================================================================
@@ -653,59 +559,45 @@ class TestToggleRawDirectionCommand:
     """Test _raw_direction_command override in toggle mode.
 
     In toggle mode, opposite-direction = stop (not reverse). The override
-    must send stop + wait pulse_time before sending the new direction.
+    must send stop + a direction-change settle delay before the new direction.
     """
 
     @pytest.mark.asyncio
     async def test_open_sets_last_command(self):
         cover = _make_toggle_cover()
-        with patch(
-            "custom_components.cover_time_based.cover_toggle_mode.sleep",
-            new_callable=AsyncMock,
-        ):
-            await cover._raw_direction_command("open")
-            await _drain_tasks(cover)
+        _all_relays_off(cover)
+        await cover._raw_direction_command("open")
         assert cover._last_command == SERVICE_OPEN_COVER
 
     @pytest.mark.asyncio
     async def test_close_sets_last_command(self):
         cover = _make_toggle_cover()
-        with patch(
-            "custom_components.cover_time_based.cover_toggle_mode.sleep",
-            new_callable=AsyncMock,
-        ):
-            await cover._raw_direction_command("close")
-            await _drain_tasks(cover)
+        _all_relays_off(cover)
+        await cover._raw_direction_command("close")
         assert cover._last_command == SERVICE_CLOSE_COVER
 
     @pytest.mark.asyncio
     async def test_stop_clears_last_command(self):
         cover = _make_toggle_cover()
+        _all_relays_off(cover)
         cover._last_command = SERVICE_OPEN_COVER
-        with patch(
-            "custom_components.cover_time_based.cover_toggle_mode.sleep",
-            new_callable=AsyncMock,
-        ):
-            await cover._raw_direction_command("stop")
-            await _drain_tasks(cover)
+        await cover._raw_direction_command("stop")
         assert cover._last_command is None
 
     @pytest.mark.asyncio
     async def test_direction_change_sends_stop_first(self):
-        """Close while _last_command=OPEN → stop pulse, wait, then close."""
+        """Close while _last_command=OPEN -> stop pulse, settle, then close."""
         cover = _make_toggle_cover()
+        _all_relays_off(cover)
         cover._last_command = SERVICE_OPEN_COVER
 
-        sleep_mock = AsyncMock()
-        with patch(
-            "custom_components.cover_time_based.cover_toggle_mode.sleep",
-            sleep_mock,
-        ):
+        with patch.object(
+            cover, "_direction_change_delay", new_callable=AsyncMock
+        ) as delay_mock:
             await cover._raw_direction_command("close")
-            await _drain_tasks(cover)
 
-        # Sleep called with pulse_time (includes stop-before-reverse + pulse completions)
-        sleep_mock.assert_any_await(cover._pulse_time)
+        # A direction change inserts a settle delay between stop and reverse.
+        delay_mock.assert_awaited()
 
         calls = _calls(cover.hass.services.async_call)
         # First: stop pulse on open switch (re-pulse same direction to stop)
@@ -717,19 +609,17 @@ class TestToggleRawDirectionCommand:
 
     @pytest.mark.asyncio
     async def test_reverse_direction_open_while_closing(self):
-        """Open while _last_command=CLOSE → stop pulse, wait, then open."""
+        """Open while _last_command=CLOSE -> stop pulse, settle, then open."""
         cover = _make_toggle_cover()
+        _all_relays_off(cover)
         cover._last_command = SERVICE_CLOSE_COVER
 
-        sleep_mock = AsyncMock()
-        with patch(
-            "custom_components.cover_time_based.cover_toggle_mode.sleep",
-            sleep_mock,
-        ):
+        with patch.object(
+            cover, "_direction_change_delay", new_callable=AsyncMock
+        ) as delay_mock:
             await cover._raw_direction_command("open")
-            await _drain_tasks(cover)
 
-        sleep_mock.assert_any_await(cover._pulse_time)
+        delay_mock.assert_awaited()
 
         calls = _calls(cover.hass.services.async_call)
         # First: stop pulse on close switch
@@ -741,18 +631,18 @@ class TestToggleRawDirectionCommand:
 
     @pytest.mark.asyncio
     async def test_same_direction_no_extra_stop(self):
-        """Open while _last_command=OPEN → no stop-before-reverse needed."""
+        """Open while _last_command=OPEN -> no stop-before-reverse needed."""
         cover = _make_toggle_cover()
+        _all_relays_off(cover)
         cover._last_command = SERVICE_OPEN_COVER
 
-        sleep_mock = AsyncMock()
-        with patch(
-            "custom_components.cover_time_based.cover_toggle_mode.sleep",
-            sleep_mock,
-        ):
+        with patch.object(
+            cover, "_direction_change_delay", new_callable=AsyncMock
+        ) as delay_mock:
             await cover._raw_direction_command("open")
-            await _drain_tasks(cover)
 
+        # No direction change -> no settle delay
+        delay_mock.assert_not_awaited()
         calls = _calls(cover.hass.services.async_call)
         # First relay call should be _send_open (not a stop pulse)
         # _send_open turns off close switch first, then turns on open switch
@@ -760,18 +650,17 @@ class TestToggleRawDirectionCommand:
 
     @pytest.mark.asyncio
     async def test_no_last_command_no_stop(self):
-        """Open with _last_command=None → no stop needed."""
+        """Open with _last_command=None -> no stop needed."""
         cover = _make_toggle_cover()
+        _all_relays_off(cover)
         assert cover._last_command is None
 
-        sleep_mock = AsyncMock()
-        with patch(
-            "custom_components.cover_time_based.cover_toggle_mode.sleep",
-            sleep_mock,
-        ):
+        with patch.object(
+            cover, "_direction_change_delay", new_callable=AsyncMock
+        ) as delay_mock:
             await cover._raw_direction_command("open")
-            await _drain_tasks(cover)
 
+        delay_mock.assert_not_awaited()
         calls = _calls(cover.hass.services.async_call)
         # First relay call is _send_open (turn_off close, then turn_on open)
         assert calls[0] == _ha("turn_off", "switch.close")
@@ -779,23 +668,20 @@ class TestToggleRawDirectionCommand:
 
     @pytest.mark.asyncio
     async def test_tilt_direction_change_sends_tilt_stop_first(self):
-        """tilt_close while _last_tilt_direction=open → tilt stop, wait, then tilt close."""
+        """tilt_close while _last_tilt_direction=open -> tilt stop, settle, then tilt close."""
         cover = _make_toggle_cover(
             tilt_open_switch="switch.tilt_open",
             tilt_close_switch="switch.tilt_close",
         )
+        _all_relays_off(cover)
         cover._last_tilt_direction = "open"
 
-        sleep_mock = AsyncMock()
-        with patch(
-            "custom_components.cover_time_based.cover_toggle_mode.sleep",
-            sleep_mock,
-        ):
+        with patch.object(
+            cover, "_direction_change_delay", new_callable=AsyncMock
+        ) as delay_mock:
             await cover._raw_direction_command("tilt_close")
-            await _drain_tasks(cover)
 
-        # Sleep called for tilt stop-before-reverse + pulse completions
-        sleep_mock.assert_any_await(cover._pulse_time)
+        delay_mock.assert_awaited()
 
         calls = _calls(cover.hass.services.async_call)
         # First: tilt stop pulse on tilt_open switch
@@ -843,7 +729,6 @@ class TestToggleTiltRestoreStop:
             open_switch_entity_id="switch.open",
             close_switch_entity_id="switch.close",
             stop_switch_entity_id=None,
-            pulse_time=1.0,
         )
         hass = MagicMock()
         hass.services.async_call = AsyncMock()
@@ -865,17 +750,10 @@ class TestToggleTiltRestoreStop:
         cover._tilt_restore_active = True
         cover._last_command = SERVICE_OPEN_COVER
 
-        with (
-            patch.object(cover, "async_write_ha_state"),
-            patch(
-                "custom_components.cover_time_based.cover_toggle_mode.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
+        with patch.object(cover, "async_write_ha_state"):
             # Tilt restore reaches target
             cover.tilt_calc.set_position(50)
             await cover.auto_stop_if_necessary()
-            await _drain_tasks(cover)
 
         assert cover._tilt_restore_active is False
 
@@ -893,8 +771,6 @@ class TestToggleTiltRestoreStop:
 class TestToggleStopSendsTiltStopOnTiltRestore:
     """Verify async_stop_cover calls _send_tilt_stop when tilt_restore was active
     and cover has a dual motor tilt (i.e. _has_tilt_motor() returns True).
-
-    Covers cover_toggle_mode.py line 109.
     """
 
     @pytest.mark.asyncio
@@ -921,7 +797,6 @@ class TestToggleStopSendsTiltStopOnTiltRestore:
             open_switch_entity_id="switch.open",
             close_switch_entity_id="switch.close",
             stop_switch_entity_id=None,
-            pulse_time=1.0,
             tilt_open_switch="switch.tilt_open",
             tilt_close_switch="switch.tilt_close",
             tilt_stop_switch="switch.tilt_stop",
@@ -948,15 +823,8 @@ class TestToggleStopSendsTiltStopOnTiltRestore:
         cover._last_command = SERVICE_OPEN_COVER
         cover._last_tilt_direction = "open"
 
-        with (
-            patch.object(cover, "async_write_ha_state"),
-            patch(
-                "custom_components.cover_time_based.cover_toggle_mode.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
+        with patch.object(cover, "async_write_ha_state"):
             await cover.async_stop_cover()
-            await _drain_tasks(cover)
 
         # Verify _send_stop re-pulsed the open switch (main motor stop)
         calls = _calls(cover.hass.services.async_call)
@@ -975,8 +843,6 @@ class TestToggleStopSendsTiltStopOnTiltRestore:
 class TestToggleExternalTiltCloseWhileTraveling:
     """Verify _handle_external_tilt_state_change with the tilt close switch
     while tilt_calc is traveling triggers async_stop_cover.
-
-    Covers cover_toggle_mode.py lines 177-180.
     """
 
     @pytest.mark.asyncio
@@ -1003,7 +869,6 @@ class TestToggleExternalTiltCloseWhileTraveling:
             open_switch_entity_id="switch.open",
             close_switch_entity_id="switch.close",
             stop_switch_entity_id=None,
-            pulse_time=1.0,
             tilt_open_switch="switch.tilt_open",
             tilt_close_switch="switch.tilt_close",
             tilt_stop_switch="switch.tilt_stop",
@@ -1053,9 +918,7 @@ class TestToggleExternalTravelWhileTraveling:
     Parity with the existing tilt-while-traveling handler: a second pulse on
     the same direction button (or any travel button) while the motor is
     running is interpreted as a stop, matching how toggle-style motor
-    controllers physically behave. Previously the travel handler unconditionally
-    re-issued the direction command, which on real hardware was ignored while
-    the motor was already running in that direction — the cover would not stop.
+    controllers physically behave.
     """
 
     @pytest.mark.asyncio
@@ -1113,199 +976,89 @@ class TestToggleExternalTravelWhileTraveling:
 
 
 # ===================================================================
-# Rising-edge guarantee: re-pulsing a still-held relay
+# Rising-edge guarantee: single turn_on, release-first only when held ON
 # ===================================================================
 
 
-class TestToggleEdgeGuaranteeOnHeldRelay:
-    """A fresh pulse on a relay still held ON must produce a real rising edge.
+class TestTogglePulseEdge:
+    """A toggle pulse is a single ``turn_on`` and never holds the relay ON.
 
-    Toggle motor controllers act on the relay's OFF→ON edge. The OFF half of
-    a pulse is deferred to a background ``_complete_pulse`` task, so a second
-    command can land while the relay is still held ON. A bare ``turn_on`` on
-    an already-on relay produces no edge — the motor misses the pulse while
-    the position tracker advances, desyncing the entity from the physical
-    cover. The send methods must release the relay (turn_off) first so the
-    motor sees a genuine edge.
+    Self-releasing/momentary toggle relays return to OFF on their own, so the
+    next command is naturally a clean rising edge — no deferred ``turn_off`` is
+    issued. The relay is only driven OFF first when it still *reports* ON (a
+    non-self-releasing relay, or one left ON across a restart), so the motor is
+    guaranteed a genuine OFF->ON edge rather than a no-op ``turn_on``.
     """
 
     @pytest.mark.asyncio
-    async def test_close_while_close_relay_held_releases_first(self):
+    async def test_idle_pulse_is_single_turn_on(self):
+        """Relay reported OFF: the pulse is one turn_on, no deferred turn_off."""
+        cover = _make_toggle_cover()
+        _all_relays_off(cover)
+        cover._last_command = SERVICE_CLOSE_COVER
+
+        await cover._send_stop()
+
+        assert _calls_for(cover, "switch.close") == [_ha("turn_on", "switch.close")]
+
+    @pytest.mark.asyncio
+    async def test_held_relay_releases_first_then_pulses(self):
+        """Relay reported ON: drive it OFF first, then turn_on (a real edge)."""
         cover = _make_toggle_cover()
         _hold_relay_on(cover, "switch.close")
+        cover._last_command = SERVICE_CLOSE_COVER
 
-        with patch(
-            "custom_components.cover_time_based.cover_toggle_mode.sleep",
-            new_callable=AsyncMock,
-        ):
-            await cover._send_close()
-            await _drain_tasks(cover)
+        await cover._send_stop()
 
-        close_calls = _calls_for(cover, "switch.close")
-        assert close_calls[0] == _ha("turn_off", "switch.close")
-        assert close_calls[1] == _ha("turn_on", "switch.close")
+        assert _calls_for(cover, "switch.close") == [
+            _ha("turn_off", "switch.close"),
+            _ha("turn_on", "switch.close"),
+        ]
 
     @pytest.mark.asyncio
     async def test_open_while_open_relay_held_releases_first(self):
         cover = _make_toggle_cover()
         _hold_relay_on(cover, "switch.open")
 
-        with patch(
-            "custom_components.cover_time_based.cover_toggle_mode.sleep",
-            new_callable=AsyncMock,
-        ):
-            await cover._send_open()
-            await _drain_tasks(cover)
+        await cover._send_open()
 
         open_calls = _calls_for(cover, "switch.open")
         assert open_calls[0] == _ha("turn_off", "switch.open")
         assert open_calls[1] == _ha("turn_on", "switch.open")
 
     @pytest.mark.asyncio
-    async def test_stop_while_relay_held_releases_first(self):
+    async def test_idle_pulse_marks_single_echo(self):
+        """An idle pulse emits ONE state change, so exactly one echo is pending.
+
+        Marking two (as the old deferred-turn_off design did) would leave a
+        stale pending count that swallows the user's next genuine press until
+        the safety timeout clears it.
+        """
         cover = _make_toggle_cover()
+        _all_relays_off(cover)
         cover._last_command = SERVICE_CLOSE_COVER
+
+        await cover._send_stop()
+
+        assert cover._pending_switch.get("switch.close") == 1
+
+    @pytest.mark.asyncio
+    async def test_held_relay_pulse_marks_two_echoes(self):
+        """A held relay emits turn_off + turn_on, so two echoes are pending."""
+        cover = _make_toggle_cover()
         _hold_relay_on(cover, "switch.close")
+        cover._last_command = SERVICE_CLOSE_COVER
 
-        with patch(
-            "custom_components.cover_time_based.cover_toggle_mode.sleep",
-            new_callable=AsyncMock,
-        ):
-            await cover._send_stop()
-            await _drain_tasks(cover)
+        await cover._send_stop()
 
-        close_calls = _calls_for(cover, "switch.close")
-        assert close_calls[0] == _ha("turn_off", "switch.close")
-        assert close_calls[1] == _ha("turn_on", "switch.close")
+        assert cover._pending_switch.get("switch.close") == 2
 
     @pytest.mark.asyncio
-    async def test_idle_relay_pulse_unchanged(self):
-        """When the relay is OFF, no redundant release is issued."""
+    async def test_no_pulse_completion_tasks_created(self):
+        """A pulse schedules no background task (no deferred turn_off)."""
         cover = _make_toggle_cover()
-        _hold_relay_on(cover, "switch.nothing")  # close + open both report OFF
+        _all_relays_off(cover)
 
-        with patch(
-            "custom_components.cover_time_based.cover_toggle_mode.sleep",
-            new_callable=AsyncMock,
-        ):
-            await cover._send_close()
-            await _drain_tasks(cover)
-
-        assert _calls(cover.hass.services.async_call) == [
-            _ha("turn_off", "switch.open"),
-            _ha("turn_on", "switch.close"),
-            _ha("turn_off", "switch.close"),
-        ]
-
-    @pytest.mark.asyncio
-    async def test_repulse_within_pulse_releases_despite_state_lag(self):
-        """The reported desync: a second pulse arrives within pulse_time, before
-        HA's switch state reflects the first turn_on (a real switch confirms
-        state only after a device round-trip — ~76 ms in the field log, vs the
-        2 ms between presses). The in-flight pulse *task*, not the laggy reported
-        switch state, must trigger the release so the motor gets a real edge.
-        """
-        cover = _make_toggle_cover()
-        # hass keeps reporting every relay OFF for the whole test — simulating
-        # switch-state commit lag (the turn_on hasn't been confirmed yet).
-        cover.hass.states.get = MagicMock(
-            side_effect=lambda eid: SimpleNamespace(state="off")
-        )
-
-        # First pulse: schedules a live completion (relay is commanded on).
         await cover._send_close()
-        assert not cover._pulse_tasks["switch.close"].done()
 
-        # Second pulse lands while the first is still in flight.
-        with patch(
-            "custom_components.cover_time_based.cover_toggle_mode.sleep",
-            new_callable=AsyncMock,
-        ):
-            await cover._send_close()
-
-        close_calls = _calls_for(cover, "switch.close")
-        # pulse 1 -> turn_on; pulse 2 must release (turn_off) then re-pulse,
-        # despite the reported relay state still being "off".
-        assert close_calls[0] == _ha("turn_on", "switch.close")
-        assert close_calls[1] == _ha("turn_off", "switch.close")
-        assert close_calls[2] == _ha("turn_on", "switch.close")
-        await _cancel_tasks(cover)
-
-    @pytest.mark.asyncio
-    async def test_superseded_completion_does_not_release_relay(self):
-        """A completion whose registration was replaced by a newer pulse must
-        not issue turn_off, even if cancellation didn't stop it in time.
-
-        asyncio cancellation is cooperative: a _complete_pulse already past its
-        sleep and into the turn_off call can finish. Keying the release on the
-        registered task (not on cancellation) makes "a stale completion can't
-        release a fresh pulse" deterministic.
-        """
-        cover = _make_toggle_cover()
-        with patch(
-            "custom_components.cover_time_based.cover_toggle_mode.sleep",
-            new_callable=AsyncMock,
-        ):
-            task = cover.hass.async_create_task(cover._complete_pulse("switch.close"))
-            # A newer pulse has since claimed the relay (different registration).
-            cover._pulse_tasks["switch.close"] = object()
-            await task
-
-        assert _ha("turn_off", "switch.close") not in _calls(
-            cover.hass.services.async_call
-        )
-        await _cancel_tasks(cover)
-
-    @pytest.mark.asyncio
-    async def test_concurrent_same_relay_pulses_serialize_and_release(self):
-        """Two _send_close calls that interleave at their awaits must each get a
-        real edge. Cover service calls aren't serialized (no PARALLEL_UPDATES),
-        so without a lock both could pop the pulse task before either stores it,
-        both see no in-flight pulse, neither releases, and the second turn_on is
-        a no-op — the original desync, under true concurrency. _pulse_relay must
-        serialize so the second pulse sees the first's in-flight pulse.
-        """
-        cover = _make_toggle_cover()
-        # Relays report OFF (state lag) and each service call yields control,
-        # forcing the two pulses to interleave under asyncio.gather.
-        cover.hass.states.get = MagicMock(
-            side_effect=lambda eid: SimpleNamespace(state="off")
-        )
-
-        async def _yielding_call(*args, **kwargs):
-            await asyncio.sleep(0)
-
-        cover.hass.services.async_call = AsyncMock(side_effect=_yielding_call)
-
-        # Do NOT patch sleep: the first pulse's completion stays in flight, so
-        # the second must detect it and release the relay.
-        await asyncio.gather(cover._send_close(), cover._send_close())
-
-        close_calls = _calls_for(cover, "switch.close")
-        # One turn_on per pulse, plus a release turn_off for the second.
-        assert close_calls.count(_ha("turn_on", "switch.close")) == 2
-        assert _ha("turn_off", "switch.close") in close_calls
-        first_on = close_calls.index(_ha("turn_on", "switch.close"))
-        release = close_calls.index(_ha("turn_off", "switch.close"))
-        assert release > first_on  # a release, not a leading opposite turn_off
-        await _cancel_tasks(cover)
-
-    @pytest.mark.asyncio
-    async def test_new_pulse_cancels_stale_completion(self):
-        """A new pulse cancels the previous pulse's pending completion so it
-        cannot release the new pulse's relay mid-flight."""
-        cover = _make_toggle_cover()
-
-        # First pulse: completion task scheduled, relay left ON until it fires.
-        await cover._send_close()
-        stale = cover._pulse_tasks["switch.close"]
-        assert not stale.done()
-
-        # Second pulse arrives while the relay is still held ON.
-        _hold_relay_on(cover, "switch.close")
-        await cover._send_close()
-        await asyncio.sleep(0)  # let the cancellation propagate
-
-        assert stale.cancelled()
-        assert cover._pulse_tasks["switch.close"] is not stale
-        await _cancel_tasks(cover)
+        assert cover._test_tasks == []

--- a/tests/test_endpoint_self_stop.py
+++ b/tests/test_endpoint_self_stop.py
@@ -233,10 +233,7 @@ async def test_mid_tilt_at_travel_endpoint_still_stops_tilt(make_cover):
     cover.travel_calc.set_position(100)  # cover at a travel endpoint
     cover.tilt_calc.set_position(0)
 
-    with (
-        patch.object(cover, "async_write_ha_state"),
-        patch("custom_components.cover_time_based.cover_toggle_mode.sleep"),
-    ):
+    with patch.object(cover, "async_write_ha_state"):
         await cover.set_tilt_position(50)  # mid-tilt
         cover.hass.services.async_call.reset_mock()
         cover.tilt_calc.set_position(50)  # tilt reaches its mid target
@@ -306,10 +303,7 @@ def _make_dual_motor(make_cover, control_mode=CONTROL_MODE_TOGGLE):
 
 async def _run_tilt_move(cover, target):
     """Drive a real dual-motor tilt move to `target` and complete it."""
-    with (
-        patch.object(cover, "async_write_ha_state"),
-        patch("custom_components.cover_time_based.cover_toggle_mode.sleep"),
-    ):
+    with patch.object(cover, "async_write_ha_state"):
         await cover.set_tilt_position(target)
         cover.hass.services.async_call.reset_mock()
         cover.tilt_calc.set_position(target)

--- a/tests/test_relay_commands.py
+++ b/tests/test_relay_commands.py
@@ -3,8 +3,9 @@
 Each test class covers one input mode and verifies the exact sequence
 of service calls that the current implementation sends to Home Assistant.
 
-Pulse/toggle modes defer pulse completion to background tasks. Tests
-drain those tasks to verify the full call sequence.
+Pulse mode defers pulse completion (the OFF half) to a background task;
+those tests drain the task to verify the full call sequence. Toggle mode
+pulses a relay with a single turn_on and schedules no completion task.
 """
 
 import pytest
@@ -244,21 +245,12 @@ class TestToggleModeClose:
     @pytest.mark.asyncio
     async def test_close_pulses_close_switch(self, make_cover):
         cover = make_cover(control_mode=CONTROL_MODE_TOGGLE)
-        with (
-            patch.object(cover, "async_write_ha_state"),
-            patch(
-                "custom_components.cover_time_based.cover_toggle_mode.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
+        with patch.object(cover, "async_write_ha_state"):
             await cover._async_handle_command(SERVICE_CLOSE_COVER)
-            await _drain_tasks(cover)
 
         assert _calls(cover.hass.services.async_call) == [
             _ha("turn_off", "switch.open"),
             _ha("turn_on", "switch.close"),
-            # pulse completion (background)
-            _ha("turn_off", "switch.close"),
         ]
 
 
@@ -268,21 +260,12 @@ class TestToggleModeOpen:
     @pytest.mark.asyncio
     async def test_open_pulses_open_switch(self, make_cover):
         cover = make_cover(control_mode=CONTROL_MODE_TOGGLE)
-        with (
-            patch.object(cover, "async_write_ha_state"),
-            patch(
-                "custom_components.cover_time_based.cover_toggle_mode.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
+        with patch.object(cover, "async_write_ha_state"):
             await cover._async_handle_command(SERVICE_OPEN_COVER)
-            await _drain_tasks(cover)
 
         assert _calls(cover.hass.services.async_call) == [
             _ha("turn_off", "switch.close"),
             _ha("turn_on", "switch.open"),
-            # pulse completion (background)
-            _ha("turn_off", "switch.open"),
         ]
 
 
@@ -293,40 +276,22 @@ class TestToggleModeStop:
     async def test_stop_after_close_pulses_close_switch(self, make_cover):
         cover = make_cover(control_mode=CONTROL_MODE_TOGGLE)
         cover._last_command = SERVICE_CLOSE_COVER
-        with (
-            patch.object(cover, "async_write_ha_state"),
-            patch(
-                "custom_components.cover_time_based.cover_toggle_mode.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
+        with patch.object(cover, "async_write_ha_state"):
             await cover._async_handle_command(SERVICE_STOP_COVER)
-            await _drain_tasks(cover)
 
         assert _calls(cover.hass.services.async_call) == [
             _ha("turn_on", "switch.close"),
-            # pulse completion (background)
-            _ha("turn_off", "switch.close"),
         ]
 
     @pytest.mark.asyncio
     async def test_stop_after_open_pulses_open_switch(self, make_cover):
         cover = make_cover(control_mode=CONTROL_MODE_TOGGLE)
         cover._last_command = SERVICE_OPEN_COVER
-        with (
-            patch.object(cover, "async_write_ha_state"),
-            patch(
-                "custom_components.cover_time_based.cover_toggle_mode.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
+        with patch.object(cover, "async_write_ha_state"):
             await cover._async_handle_command(SERVICE_STOP_COVER)
-            await _drain_tasks(cover)
 
         assert _calls(cover.hass.services.async_call) == [
             _ha("turn_on", "switch.open"),
-            # pulse completion (background)
-            _ha("turn_off", "switch.open"),
         ]
 
     @pytest.mark.asyncio
@@ -931,21 +896,13 @@ class TestToggleModePendingSwitchOpen:
     async def test_open_marks_close_switch_pending_when_on(self, make_cover):
         cover = make_cover(control_mode=CONTROL_MODE_TOGGLE)
         _mock_switch_on(cover.hass, "switch.close")
-        with (
-            patch.object(cover, "async_write_ha_state"),
-            patch(
-                "custom_components.cover_time_based.cover_toggle_mode.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
+        with patch.object(cover, "async_write_ha_state"):
             await cover._async_handle_command(SERVICE_OPEN_COVER)
-            await _drain_tasks(cover)
 
-        # close switch was ON -> line 191 hit
+        # close switch was ON -> opposite-relay turn_off marked pending
         assert _calls(cover.hass.services.async_call) == [
             _ha("turn_off", "switch.close"),
             _ha("turn_on", "switch.open"),
-            _ha("turn_off", "switch.open"),
         ]
 
     @pytest.mark.asyncio
@@ -953,20 +910,12 @@ class TestToggleModePendingSwitchOpen:
         """Stop switch is not valid in toggle mode; it must be ignored even when ON."""
         cover = make_cover(control_mode=CONTROL_MODE_TOGGLE, stop_switch="switch.stop")
         _mock_switch_on(cover.hass, "switch.stop")
-        with (
-            patch.object(cover, "async_write_ha_state"),
-            patch(
-                "custom_components.cover_time_based.cover_toggle_mode.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
+        with patch.object(cover, "async_write_ha_state"):
             await cover._async_handle_command(SERVICE_OPEN_COVER)
-            await _drain_tasks(cover)
 
         assert _calls(cover.hass.services.async_call) == [
             _ha("turn_off", "switch.close"),
             _ha("turn_on", "switch.open"),
-            _ha("turn_off", "switch.open"),
         ]
 
 
@@ -977,21 +926,13 @@ class TestToggleModePendingSwitchClose:
     async def test_close_marks_open_switch_pending_when_on(self, make_cover):
         cover = make_cover(control_mode=CONTROL_MODE_TOGGLE)
         _mock_switch_on(cover.hass, "switch.open")
-        with (
-            patch.object(cover, "async_write_ha_state"),
-            patch(
-                "custom_components.cover_time_based.cover_toggle_mode.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
+        with patch.object(cover, "async_write_ha_state"):
             await cover._async_handle_command(SERVICE_CLOSE_COVER)
-            await _drain_tasks(cover)
 
-        # open switch was ON -> line 220 hit
+        # open switch was ON -> opposite-relay turn_off marked pending
         assert _calls(cover.hass.services.async_call) == [
             _ha("turn_off", "switch.open"),
             _ha("turn_on", "switch.close"),
-            _ha("turn_off", "switch.close"),
         ]
 
     @pytest.mark.asyncio
@@ -999,20 +940,12 @@ class TestToggleModePendingSwitchClose:
         """Stop switch is not valid in toggle mode; it must be ignored even when ON."""
         cover = make_cover(control_mode=CONTROL_MODE_TOGGLE, stop_switch="switch.stop")
         _mock_switch_on(cover.hass, "switch.stop")
-        with (
-            patch.object(cover, "async_write_ha_state"),
-            patch(
-                "custom_components.cover_time_based.cover_toggle_mode.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
+        with patch.object(cover, "async_write_ha_state"):
             await cover._async_handle_command(SERVICE_CLOSE_COVER)
-            await _drain_tasks(cover)
 
         assert _calls(cover.hass.services.async_call) == [
             _ha("turn_off", "switch.open"),
             _ha("turn_on", "switch.close"),
-            _ha("turn_off", "switch.close"),
         ]
 
 
@@ -1035,15 +968,10 @@ class TestToggleModePendingTiltOpen:
             tilt_close_switch="switch.tilt_close",
         )
         _mock_switch_on(cover.hass, "switch.tilt_close")
-        with patch(
-            "custom_components.cover_time_based.cover_toggle_mode.sleep",
-            new_callable=AsyncMock,
-        ):
-            await cover._send_tilt_open()
-            await _drain_tasks(cover)
+        await cover._send_tilt_open()
 
-        # tilt close was ON -> line 279 hit
-        # Also covers line 294: _last_tilt_direction = "open"
+        # tilt close was ON -> opposite-relay turn_off marked pending
+        # Also sets _last_tilt_direction = "open"
         assert cover._last_tilt_direction == "open"
 
     @pytest.mark.asyncio
@@ -1056,14 +984,9 @@ class TestToggleModePendingTiltOpen:
             tilt_open_switch="switch.tilt_open",
             tilt_close_switch="switch.tilt_close",
         )
-        with patch(
-            "custom_components.cover_time_based.cover_toggle_mode.sleep",
-            new_callable=AsyncMock,
-        ):
-            await cover._send_tilt_open()
-            await _drain_tasks(cover)
+        await cover._send_tilt_open()
 
-        # line 294: _last_tilt_direction = "open"
+        # sets _last_tilt_direction = "open"
         assert cover._last_tilt_direction == "open"
 
 
@@ -1081,15 +1004,10 @@ class TestToggleModePendingTiltClose:
             tilt_close_switch="switch.tilt_close",
         )
         _mock_switch_on(cover.hass, "switch.tilt_open")
-        with patch(
-            "custom_components.cover_time_based.cover_toggle_mode.sleep",
-            new_callable=AsyncMock,
-        ):
-            await cover._send_tilt_close()
-            await _drain_tasks(cover)
+        await cover._send_tilt_close()
 
-        # tilt open was ON -> line 298 hit
-        # Also covers line 313: _last_tilt_direction = "close"
+        # tilt open was ON -> opposite-relay turn_off marked pending
+        # Also sets _last_tilt_direction = "close"
         assert cover._last_tilt_direction == "close"
 
     @pytest.mark.asyncio
@@ -1102,14 +1020,9 @@ class TestToggleModePendingTiltClose:
             tilt_open_switch="switch.tilt_open",
             tilt_close_switch="switch.tilt_close",
         )
-        with patch(
-            "custom_components.cover_time_based.cover_toggle_mode.sleep",
-            new_callable=AsyncMock,
-        ):
-            await cover._send_tilt_close()
-            await _drain_tasks(cover)
+        await cover._send_tilt_close()
 
-        # line 313: _last_tilt_direction = "close"
+        # sets _last_tilt_direction = "close"
         assert cover._last_tilt_direction == "close"
 
 
@@ -1215,15 +1128,8 @@ class TestToggleModeIgnoresStopSwitch:
     async def test_open_with_stop_switch_never_references_it(self, make_cover):
         """OPEN in toggle mode must not call any service on the stop switch."""
         cover = make_cover(control_mode=CONTROL_MODE_TOGGLE, stop_switch="switch.stop")
-        with (
-            patch.object(cover, "async_write_ha_state"),
-            patch(
-                "custom_components.cover_time_based.cover_toggle_mode.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
+        with patch.object(cover, "async_write_ha_state"):
             await cover._async_handle_command(SERVICE_OPEN_COVER)
-            await _drain_tasks(cover)
 
         for c in _calls(cover.hass.services.async_call):
             assert c != _ha("turn_off", "switch.stop"), (
@@ -1237,15 +1143,8 @@ class TestToggleModeIgnoresStopSwitch:
     async def test_close_with_stop_switch_never_references_it(self, make_cover):
         """CLOSE in toggle mode must not call any service on the stop switch."""
         cover = make_cover(control_mode=CONTROL_MODE_TOGGLE, stop_switch="switch.stop")
-        with (
-            patch.object(cover, "async_write_ha_state"),
-            patch(
-                "custom_components.cover_time_based.cover_toggle_mode.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
+        with patch.object(cover, "async_write_ha_state"):
             await cover._async_handle_command(SERVICE_CLOSE_COVER)
-            await _drain_tasks(cover)
 
         for c in _calls(cover.hass.services.async_call):
             assert c != _ha("turn_off", "switch.stop"), (
@@ -1259,42 +1158,24 @@ class TestToggleModeIgnoresStopSwitch:
     async def test_open_exact_calls_with_stop_switch_configured(self, make_cover):
         """OPEN in toggle mode with stop switch: only open/close switches used."""
         cover = make_cover(control_mode=CONTROL_MODE_TOGGLE, stop_switch="switch.stop")
-        with (
-            patch.object(cover, "async_write_ha_state"),
-            patch(
-                "custom_components.cover_time_based.cover_toggle_mode.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
+        with patch.object(cover, "async_write_ha_state"):
             await cover._async_handle_command(SERVICE_OPEN_COVER)
-            await _drain_tasks(cover)
 
         assert _calls(cover.hass.services.async_call) == [
             _ha("turn_off", "switch.close"),
             _ha("turn_on", "switch.open"),
-            # pulse completion (background)
-            _ha("turn_off", "switch.open"),
         ]
 
     @pytest.mark.asyncio
     async def test_close_exact_calls_with_stop_switch_configured(self, make_cover):
         """CLOSE in toggle mode with stop switch: only open/close switches used."""
         cover = make_cover(control_mode=CONTROL_MODE_TOGGLE, stop_switch="switch.stop")
-        with (
-            patch.object(cover, "async_write_ha_state"),
-            patch(
-                "custom_components.cover_time_based.cover_toggle_mode.sleep",
-                new_callable=AsyncMock,
-            ),
-        ):
+        with patch.object(cover, "async_write_ha_state"):
             await cover._async_handle_command(SERVICE_CLOSE_COVER)
-            await _drain_tasks(cover)
 
         assert _calls(cover.hass.services.async_call) == [
             _ha("turn_off", "switch.open"),
             _ha("turn_on", "switch.close"),
-            # pulse completion (background)
-            _ha("turn_off", "switch.close"),
         ]
 
 
@@ -1309,7 +1190,7 @@ class TestSwitchModeTiltPendingCounts:
     mark pending for the opposite switch when it's actually on.
 
     Pre-existing bug fix: the base implementation marked pending=2 for the
-    target switch (copied from pulse/toggle where _complete_pulse adds a
+    target switch (copied from pulse mode where _complete_pulse adds a
     follow-up turn_off, giving 2 echoes). Switch mode is latching, so only
     1 echo fires. The extra pending leaked, consuming the user's eventual
     on→off release as if it were an echo and preventing the external stop

--- a/tests/test_state_monitoring.py
+++ b/tests/test_state_monitoring.py
@@ -405,9 +405,9 @@ class TestToggleModeExternalStateChange:
                 assert cover._last_command == SERVICE_OPEN_COVER
                 assert cover.is_opening
 
-                # Simulate time passing (beyond debounce window)
+                # Simulate time passing (well beyond the debounce window)
                 cover._last_external_toggle_time["switch.open"] = (
-                    time_module.monotonic() - cover._pulse_time - 0.5 - 0.1
+                    time_module.monotonic() - 2.0
                 )
 
                 # Click 2: same direction stops the motor (matches toggle
@@ -1773,14 +1773,12 @@ class TestRawDirectionChangeEchoFiltering:
 
         with (
             patch.object(cover, "async_write_ha_state"),
-            patch(
-                "custom_components.cover_time_based.cover_toggle_mode.sleep",
-                new_callable=AsyncMock,
-            ),
+            patch.object(cover, "_direction_change_delay", new_callable=AsyncMock),
         ):
-            # Raw close: pulse on close switch -> 2 echoes (ON + OFF)
+            # Raw close: single turn_on on the close switch -> one commanded
+            # echo. A self-releasing relay then reports OFF on its own (a
+            # falling edge, which the toggle handler ignores).
             await cover._raw_direction_command("close")
-            await _drain_bg_tasks(cover)
 
             await cover._async_switch_state_changed(
                 _make_state_event("switch.close", "off", "on")
@@ -1792,9 +1790,8 @@ class TestRawDirectionChangeEchoFiltering:
 
             # Raw open (direction change): stop-pulse on close + open-pulse on open
             await cover._raw_direction_command("open")
-            await _drain_bg_tasks(cover)
 
-            # Stop pulse echoes on close switch
+            # Stop re-pulse on close: turn_on echo, then the relay self-releases
             await cover._async_switch_state_changed(
                 _make_state_event("switch.close", "off", "on")
             )
@@ -1803,7 +1800,7 @@ class TestRawDirectionChangeEchoFiltering:
             )
             assert not cover.travel_calc.is_traveling()
 
-            # Open pulse echoes on open switch
+            # Open pulse on open: turn_on echo, then the relay self-releases
             await cover._async_switch_state_changed(
                 _make_state_event("switch.open", "off", "on")
             )


### PR DESCRIPTION
## What

Removes the **Pulse time** setting from **Toggle** control mode. Toggle-style relays are momentary/self-releasing — a brief press latches the motor and the relay returns to OFF on its own — so holding the relay ON for a configured `pulse_time` served no purpose.

Toggle covers now send a **single `turn_on`** per command, driving the relay OFF first *only* when it still reports ON (`_switch_is_on`), to guarantee a clean rising edge. The **Pulse time** field is hidden for toggle mode in the config card. **Pulse** mode is unchanged and still uses `pulse_time`.

Driver: discussion in #105.

## Why this also retires most of #100

[#100](https://github.com/Sese-Schneider/ha-cover-time-based/pull/100) (`_complete_pulse` / `_pulse_tasks` / `_pulse_lock`) existed solely to manage the relay being **held ON** during `pulse_time` (the deferred `turn_off`) on rapid re-pulse. Once the relay is no longer held ON, a self-releasing toggle relay is already OFF by the next command, so each `turn_on` is naturally a clean edge and that machinery has nothing left to do. It is removed here, along with its `TestToggleEdgeGuaranteeOnHeldRelay` tests.

## Details

- `cover_toggle_mode.py`: drop the `pulse_time` ctor param, `_pulse_time`, `_pulse_tasks`, `_pulse_lock`, `_complete_pulse`; simplify `_pulse_relay`. Echo-marking (`_mark_switch_pending`) moves **into** `_pulse_relay` — 1 echo for the lone `turn_on`, 2 when it must release-first — so the pending count always matches the transitions HA actually emits (over-marking would swallow the user's next genuine press; under-marking would leak a phantom toggle).
- `_raw_direction_command`'s stop-before-reverse gap now reuses the base `_direction_change_delay()` instead of `sleep(pulse_time)`.
- `cover.py`: drop `pulse_time=pulse_time` from `ToggleModeCover(...)`.
- Frontend: hide Pulse time for toggle via a pure `showsPulseTime(mode)` helper.
- Calibration's `getattr(self, "_pulse_time", None)` now yields `None` for toggle → no pulse-overhead subtraction (correct: no relay hold). Websocket/YAML still carry `pulse_time` harmlessly (ignored for toggle).

## Caveat to validate on hardware

The simplified edge-guard decides "still held ON" from the relay's **reported** state. For a genuinely **non-self-releasing** toggle relay driven faster than HA commits the state (~tens of ms), a re-pulse could miss an edge — the case #100 originally addressed by holding the pulse. Both known toggle users run self-releasing/momentary relays; **this is the documented revert trigger if hardware testing shows otherwise.**

## Tests

- Rewrote the toggle tests (`test_cover_toggle_mode.py`, toggle parts of `test_relay_commands.py`, `test_state_monitoring.py`) for the single-`turn_on` contract; added explicit echo-count tests (idle marks 1, held marks 2).
- Frontend test for `showsPulseTime`.
- Full suite green (1003 passed); `ruff`, `check_docs`, `check_translations`, frontend `node --test` all pass via the pre-push hook.

Rebased on top of #106 (endpoint self-stop), which landed first; merged the CHANGELOG entry into its `## Unreleased` section and adapted one dead `sleep` patch in #106's new endpoint tests.
