### PR TITLE
chore: release v4.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 4.4.0 (2026-06-18)
 
 ### ⚠ Breaking changes
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ It improves the original integration by adding tilt control, synchronized travel
 
 - **Control the position of your cover based on time**.
 - **External state monitoring:** Detects physical switch presses and keeps the position tracker in sync.
+- **Up/down interlock (Switch mode):** Never energizes both direction relays at once — when one direction relay turns on, even from outside Home Assistant (a wall switch wired straight to the relays), the opposite relay is switched off — protecting motors with no hardware interlock.
 - **Multiple input modes:** Latching switches, momentary pulse buttons, or toggle-style relays.
 - **Wrap an existing cover:** Add time-based position tracking to any cover entity.
 - **Control the tilt of your cover based on time** with four tilt modes: inline, sequential closes-then-tilts-closed, sequential closes-then-tilts-open, or separate tilt motor.


### PR DESCRIPTION
Release **v4.4.0** — finalizes the CHANGELOG (`## Unreleased` → `## 4.4.0 (2026-06-18)`) and documents the switch-mode up/down interlock in the README. The manifest is already at `4.4.0` (set by the dev-cycle bump), so there is no version change in this PR.

### What's in 4.4.0
- **Breaking:** no endpoint stop/run-on for self-stopping motors (pulse/toggle/wrapped); run-on is now Switch-mode only (#105)
- **Feature:** up/down interlock for switch mode, incl. externally-triggered relays (#99)
- **Fixes (switch-mode external-trigger cluster, #99):** de-energize latched relay at endpoint; dual-motor tilt reversal honours every press; external open-from-closed completes in one press; switching a re-driven relay off stops the cover
- **Fixes (#105):** separate tilt motor no longer nudges the travel motor; toggle mode no longer uses Pulse time

### After merge
Publish the GitHub Release by pushing the tag **to upstream** (where `release.yml` runs):

```
git tag v4.4.0
git push upstream v4.4.0
```

`release.yml` publishes the release and marks it latest. It also tries to roll `main` forward to the next minor, but `main` is protected, so do that bump via PR:

```
bin/bump-dev.sh   # opens a PR bumping main to 4.5.0 for development
```