### PR TITLE
ci: move GitHub Actions off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/hacs.yml
+++ b/.github/workflows/hacs.yml
@@ -11,7 +11,7 @@ jobs:
     name: HACS Action
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - uses: hacs/action@main
         with:
           category: integration

--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -10,5 +10,5 @@ jobs:
   validate:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v2"
+      - uses: "actions/checkout@v5"
       - uses: home-assistant/actions/hassfest@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       version: ${{ steps.version.outputs.version }}
       prerelease: ${{ steps.version.outputs.prerelease }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Extract and validate version from tag
         id: version
@@ -116,7 +116,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Bump main to next minor
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: main
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,10 +26,10 @@ jobs:
           - { ha-channel: minimum, python-version: "3.13" }
     continue-on-error: ${{ matrix.ha-channel == 'dev' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -63,10 +63,10 @@ jobs:
   frontend:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: "npm"
@@ -80,10 +80,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
 


### PR DESCRIPTION
GitHub Actions runners now execute actions on Node 24 by default and emit a deprecation warning for any action still declaring `using: node20` (see https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). This bumps the affected actions to their Node 24 majors:

- `actions/checkout` v2/v3/v4 → **v5**
- `actions/setup-node` v4 → **v5**
- `actions/setup-python` v5 → **v6**

Verified each target's `runs.using` is `node24` upstream. Version-only change — no behavioural difference. Left `softprops/action-gh-release@v3` (already Node 24), `hacs/action@main`, and `home-assistant/actions/hassfest@master` untouched.