### PR TITLE
ci: use the CHANGELOG section as GitHub Release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,10 +64,43 @@ jobs:
             exit 1
           fi
 
+      - name: Build release notes from CHANGELOG
+        id: notes
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          PRERELEASE: ${{ steps.version.outputs.prerelease }}
+        run: |
+          # Use the hand-written, user-facing CHANGELOG section as the release
+          # notes. changelog-section.sh exits 0 (found), 1 (no section for this
+          # version), or >=2 (its own error, e.g. CHANGELOG.md missing):
+          #   - found              -> use the section as the release body
+          #   - exit 1, pre-release -> auto-generated notes (-alpha/-beta/-rc may
+          #                            legitimately have no entry yet)
+          #   - exit 1, final tag   -> fail: a shipped release must have notes
+          #                            (matches the repo's block-on-drift posture)
+          #   - exit >=2            -> a real error; fail regardless of tag
+          rc=0
+          bin/changelog-section.sh "$VERSION" > release-notes.md || rc=$?
+          if [ "$rc" -eq 0 ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          elif [ "$rc" -eq 1 ] && [ "$PRERELEASE" = "true" ]; then
+            echo "No CHANGELOG.md section for pre-release $VERSION; using auto-generated notes."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          elif [ "$rc" -eq 1 ]; then
+            echo "::error::No CHANGELOG.md section for final release $VERSION — add the entry before tagging."
+            exit 1
+          else
+            echo "::error::changelog-section.sh failed (exit $rc) for $VERSION — see its message above."
+            exit "$rc"
+          fi
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
-          generate_release_notes: true
+          # The CHANGELOG section when present, otherwise GitHub's auto-generated
+          # notes (see the previous step).
+          body_path: ${{ steps.notes.outputs.found == 'true' && 'release-notes.md' || '' }}
+          generate_release_notes: ${{ steps.notes.outputs.found != 'true' }}
           # Every release is created as a pre-release and off "latest", so a new
           # version is never pushed straight to users on the default / HACS
           # channel. Test it, then promote to the full latest release with:

--- a/bin/changelog-section.sh
+++ b/bin/changelog-section.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Prints the CHANGELOG.md section for a single version, for use as the GitHub
+# Release notes — so a release shows the hand-written, user-facing changes
+# instead of an auto-generated commit/PR list.
+#
+# Usage: bin/changelog-section.sh <version> [changelog-path]
+#   bin/changelog-section.sh 4.4.0
+#
+# Prints everything under the `## <version> (date)` header up to the next `## `
+# header, with the version header itself omitted (the release already shows the
+# version) and surrounding blank lines trimmed (interior blanks preserved).
+#
+# Exits 1 (printing nothing) when the version has no section — the caller can
+# then fall back to auto-generated notes, e.g. for a pre-release tag that has no
+# changelog entry yet. Exits 2 on usage error or a missing changelog file.
+
+set -euo pipefail
+
+VERSION="${1:-}"
+CHANGELOG="${2:-CHANGELOG.md}"
+
+if [ -z "$VERSION" ]; then
+  echo "usage: $0 <version> [changelog-path]" >&2
+  exit 2
+fi
+
+if [ ! -f "$CHANGELOG" ]; then
+  echo "error: changelog not found: $CHANGELOG" >&2
+  exit 2
+fi
+
+# Match the target header by exact version field ($2), so `4.2.0` never matches
+# a `## 14.2.0` or `## 4.2.00` header. The section ends only at the next *version*
+# `## ` header — a non-version `## ` line (a prose subheading, or a comment in a
+# fenced code block) is body content, not a boundary, so it is kept. Drop only
+# leading blank lines (the `seen` guard); trailing blanks are stripped by the
+# `$(...)` capture below, which re-adds one newline.
+section="$(
+  awk -v ver="$VERSION" '
+    { sub(/\r$/, "") }  # normalize CRLF; a lone \r else reads as a field (NF>0)
+    /^## / && insec && $2 ~ /^[0-9]+\.[0-9]+\.[0-9]+/ { exit }   # next version
+    /^## / && !insec && $2 == ver { insec = 1; next }            # target header
+    insec { if (NF) seen = 1; if (seen) print }
+  ' "$CHANGELOG"
+)"
+
+if [ -z "$section" ]; then
+  exit 1
+fi
+
+printf '%s\n' "$section"

--- a/tests/test_changelog_section.py
+++ b/tests/test_changelog_section.py
@@ -1,0 +1,196 @@
+"""Tests for bin/changelog-section.sh.
+
+Extracts a single version's section from CHANGELOG.md so the release workflow
+can use the hand-written, user-facing changes as the GitHub Release notes
+instead of an auto-generated commit list.
+"""
+
+import os
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "bin" / "changelog-section.sh"
+
+FIXTURE = """\
+## 4.5.0-rc.1 (2026-07-01)
+
+### Features
+
+- Pre-release only feature.
+
+## 4.4.0 (2026-06-18)
+
+### Breaking changes
+
+- Breaking thing happened.
+
+### Features
+
+- Feature one.
+- Feature two.
+
+## 4.3.0 (2026-06-17)
+
+### Features
+
+- Older feature.
+
+## 4.2.0 (2026-06-02)
+
+### Fixes
+
+- Oldest fix.
+"""
+
+
+def _clean_env() -> dict:
+    return {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+
+
+def _run(cwd: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(SCRIPT), *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        env=_clean_env(),
+    )
+
+
+def _make_changelog(tmp_path: Path, content: str = FIXTURE) -> Path:
+    cl = tmp_path / "CHANGELOG.md"
+    cl.write_text(content)
+    return tmp_path
+
+
+def test_extracts_top_section(tmp_path: Path):
+    _make_changelog(tmp_path)
+    result = _run(tmp_path, "4.5.0-rc.1")
+    assert result.returncode == 0, result.stderr
+    assert "Pre-release only feature." in result.stdout
+    # Must not bleed into the next section.
+    assert "Breaking thing happened." not in result.stdout
+    assert "## 4.4.0" not in result.stdout
+
+
+def test_extracts_middle_section(tmp_path: Path):
+    _make_changelog(tmp_path)
+    result = _run(tmp_path, "4.4.0")
+    assert result.returncode == 0, result.stderr
+    assert "Breaking thing happened." in result.stdout
+    assert "Feature one." in result.stdout
+    assert "Feature two." in result.stdout
+    # Neither the previous nor the next section leaks in.
+    assert "Pre-release only feature." not in result.stdout
+    assert "Older feature." not in result.stdout
+    assert "## 4.3.0" not in result.stdout
+
+
+def test_extracts_last_section(tmp_path: Path):
+    _make_changelog(tmp_path)
+    result = _run(tmp_path, "4.2.0")
+    assert result.returncode == 0, result.stderr
+    assert "Oldest fix." in result.stdout
+    assert "Older feature." not in result.stdout
+
+
+def test_version_header_line_is_omitted(tmp_path: Path):
+    _make_changelog(tmp_path)
+    result = _run(tmp_path, "4.4.0")
+    assert result.returncode == 0, result.stderr
+    assert "## 4.4.0" not in result.stdout
+
+
+def test_blank_lines_trimmed_but_interior_preserved(tmp_path: Path):
+    _make_changelog(tmp_path)
+    result = _run(tmp_path, "4.4.0")
+    assert result.returncode == 0, result.stderr
+    # No leading/trailing blank lines.
+    assert result.stdout.startswith("### Breaking changes")
+    assert result.stdout.rstrip("\n").endswith("- Feature two.")
+    # Interior blank line between the two subsections survives.
+    assert "\n\n### Features\n" in result.stdout
+
+
+def test_missing_version_exits_nonzero_with_no_output(tmp_path: Path):
+    _make_changelog(tmp_path)
+    result = _run(tmp_path, "9.9.9")
+    assert result.returncode == 1
+    assert result.stdout == ""
+
+
+def test_substring_version_not_mismatched(tmp_path: Path):
+    """`4.2.0` must not match a header for `14.2.0` or `4.2.00`."""
+    content = "## 14.2.0 (2026-01-01)\n\n### Fixes\n\n- Wrong section.\n"
+    _make_changelog(tmp_path, content)
+    result = _run(tmp_path, "4.2.0")
+    assert result.returncode == 1
+    assert result.stdout == ""
+
+
+def test_handles_crlf_line_endings(tmp_path: Path):
+    """The real CHANGELOG.md is CRLF; blank lines must still trim and the
+    output must be normalized to LF (no stray carriage returns)."""
+    cl = tmp_path / "CHANGELOG.md"
+    cl.write_bytes(FIXTURE.replace("\n", "\r\n").encode())
+    result = _run(tmp_path, "4.4.0")
+    assert result.returncode == 0, result.stderr
+    # Blank (CRLF) lines around the section must still be trimmed.
+    assert result.stdout.startswith("### Breaking changes")
+    assert result.stdout.rstrip("\n").endswith("- Feature two.")
+    assert "\n\n### Features\n" in result.stdout
+    assert "## 4.3.0" not in result.stdout
+
+
+def test_section_not_truncated_by_non_version_hash_heading(tmp_path: Path):
+    """A `## ` line that isn't a version header (a prose subheading, or a
+    comment inside a fenced code block) is release-note content, not the next
+    section — the section ends only at the next *version* heading."""
+    content = (
+        "## 4.4.0 (2026-06-18)\n\n"
+        "### Features\n\n- A feature.\n\n"
+        "## Upgrade notes\n\nDo the thing.\n\n"
+        "## 4.3.0 (2026-06-17)\n\n### Features\n\n- Old feature.\n"
+    )
+    _make_changelog(tmp_path, content)
+    result = _run(tmp_path, "4.4.0")
+    assert result.returncode == 0, result.stderr
+    assert "A feature." in result.stdout
+    assert "## Upgrade notes" in result.stdout
+    assert "Do the thing." in result.stdout
+    # The real next version still bounds the section.
+    assert "Old feature." not in result.stdout
+    assert "## 4.3.0" not in result.stdout
+
+
+def test_missing_changelog_file_errors(tmp_path: Path):
+    result = _run(tmp_path, "4.4.0")
+    assert result.returncode == 2
+    assert "not found" in (result.stdout + result.stderr).lower()
+
+
+def test_missing_version_arg_exits_2(tmp_path: Path):
+    """No version argument is a usage error (exit 2), distinct from exit 1."""
+    _make_changelog(tmp_path)
+    result = _run(tmp_path)
+    assert result.returncode == 2
+    assert "usage" in (result.stdout + result.stderr).lower()
+
+
+def test_empty_body_section_exits_1(tmp_path: Path):
+    """A header with no body (an unfilled stub) is treated as no section."""
+    content = "## 4.4.0 (2026-06-18)\n\n## 4.3.0 (2026-06-17)\n\n- Old.\n"
+    _make_changelog(tmp_path, content)
+    result = _run(tmp_path, "4.4.0")
+    assert result.returncode == 1
+    assert result.stdout == ""
+
+
+def test_real_changelog_known_version():
+    """Against the repo's real CHANGELOG.md, 4.4.0 yields its own section only."""
+    result = _run(REPO_ROOT, "4.4.0")
+    assert result.returncode == 0, result.stderr
+    assert "Breaking changes" in result.stdout
+    # Does not leak the previous released section's header.
+    assert "## 4.3.0" not in result.stdout


### PR DESCRIPTION
Releases now publish the hand-written, user-facing CHANGELOG.md section
for the tagged version instead of GitHub's auto-generated commit/PR list.

- bin/changelog-section.sh extracts a version's `## X.Y.Z` section (header
  dropped, blank lines trimmed, CRLF-safe; the section ends at the next
  version heading, so non-version `## ` lines stay as body content). Exits
  1 when there is no section, 2 on usage / missing-file errors.
- release.yml feeds that section in as the release body; a final tag with
  no section fails the job (matching the repo's block-on-drift posture),
  while a pre-release tag (-alpha/-beta/-rc) falls back to auto-generated
  notes.
- tests/test_changelog_section.py covers extraction, trimming, CRLF,
  exact-version matching, the non-version-heading boundary, and the exit
  codes the workflow relies on.
