### PR TITLE
feat: toggle-mode "relay reports its own OFF" option (#105)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,12 @@ Three input modes are available to describe how the switch entities for switch-b
 
 With the **Pulse** input mode, the **Pulse time** configures how long the switch should send the ON signal before it turns OFF. Defaults to **1s**. **Toggle** mode does not use it — toggle relays are momentary, so the integration sends a single ON pulse and lets the relay release itself.
 
+#### Relay reports its own OFF (Toggle mode)
+
+Toggle mode only. Leave it **on** (the default) for normal toggle relays — they switch themselves off after the pulse and report that OFF back to Home Assistant, so the integration can drive a still-ON relay OFF first to guarantee a clean ON edge.
+
+Turn it **off** for hardware-managed pulse modules — for example an **Aqara T2** in its 200 ms internal-pulse mode — that pulse the contact themselves but **never report the OFF** to Home Assistant, leaving the switch entity stuck `on`. On such hardware a `turn_off` is not an idempotent "off" but another activation pulse, so the integration's attempt to force a clean edge (`turn_off` then `turn_on`) lands as a doubled command and the motor's toggle counter drifts — the symptom is Stop reversing the cover and Up driving it down. With the option off, toggle mode only ever sends a **single `turn_on` per command and never a `turn_off`**, giving exactly one clean activation per press. A repeated `turn_on` still pulses the motor even while the entity reads `on`.
+
 ### Assumed state
 
 Available for every device type. A time-based cover calculates its position from travel time without feedback, so by default it reports an _assumed_ state and Home Assistant keeps both the open and close buttons active at all times. Turn **Assumed state** off if you trust the time-based calculation and want the UI to behave like a position-aware cover — greying out actions that can't apply (for example the close button once the cover is already fully closed). Leave it on if the calculation can drift (motor slip, manual operation, power loss mid-travel), since the always-active buttons let you re-issue a command to re-converge.
@@ -357,6 +363,7 @@ cover:
 | travel_startup_delay   | float   | _Optional_                                      | Motor startup time compensation (seconds) for travel movements          | None    |
 | tilt_startup_delay     | float   | _Optional_                                      | Motor startup time compensation (seconds) for tilt movements            | None    |
 | pulse_time             | float   | _Optional_                                      | Duration in seconds for button press in pulse mode                      | 1.0     |
+| relay_reports_off      | boolean | _Optional_                                      | Toggle mode: set false for pulse modules that never report their OFF    | true    |
 
 </details>
 

--- a/custom_components/cover_time_based/const.py
+++ b/custom_components/cover_time_based/const.py
@@ -24,3 +24,11 @@ DEFAULT_FORCE_TIME_BASED_POSITION = False
 
 CONF_ASSUMED_STATE = "assumed_state"
 DEFAULT_ASSUMED_STATE = True
+
+# Toggle mode only. When True (default) the relay is trusted to report its own
+# OFF, so a relay still reporting ON is driven OFF first to force a clean edge.
+# When False (hardware-managed pulse modules that self-release but never report
+# the OFF, e.g. Aqara T2 — see issue #105), toggle mode only ever sends turn_on
+# and never turn_off, since a turn_off is itself an activation pulse there.
+CONF_RELAY_REPORTS_OFF = "relay_reports_off"
+DEFAULT_RELAY_REPORTS_OFF = True

--- a/custom_components/cover_time_based/cover.py
+++ b/custom_components/cover_time_based/cover.py
@@ -31,6 +31,7 @@ from .const import (
     CONF_FORCE_TIME_BASED_POSITION,
     CONF_IGNORE_REPORTED_POSITION,
     CONF_MIN_MOVEMENT_TIME,
+    CONF_RELAY_REPORTS_OFF,
     CONF_TILT_MODE,
     CONF_TILT_STARTUP_DELAY,
     CONF_TILT_TIME_CLOSE,
@@ -43,6 +44,7 @@ from .const import (
     DEFAULT_ENDPOINT_RUNON_TIME,
     DEFAULT_FORCE_TIME_BASED_POSITION,
     DEFAULT_IGNORE_REPORTED_POSITION,
+    DEFAULT_RELAY_REPORTS_OFF,
 )
 from .cover_base import CoverTimeBased  # noqa: F401
 from .helpers import resolve_entity
@@ -121,6 +123,7 @@ SWITCH_COVER_SCHEMA = {
     vol.Optional(CONF_STOP_SWITCH_ENTITY_ID, default=None): vol.Any(cv.entity_id, None),
     vol.Optional(CONF_IS_BUTTON, default=False): cv.boolean,
     vol.Optional(CONF_PULSE_TIME): cv.positive_float,
+    vol.Optional(CONF_RELAY_REPORTS_OFF): cv.boolean,
     **TRAVEL_TIME_SCHEMA,
 }
 
@@ -351,7 +354,12 @@ def _create_cover_from_options(options, device_id="", name=""):
     if control_mode == CONTROL_MODE_PULSE:
         return PulseModeCover(pulse_time=pulse_time, **switch_args)
     elif control_mode == CONTROL_MODE_TOGGLE:
-        return ToggleModeCover(**switch_args)
+        return ToggleModeCover(
+            relay_reports_off=options.get(
+                CONF_RELAY_REPORTS_OFF, DEFAULT_RELAY_REPORTS_OFF
+            ),
+            **switch_args,
+        )
     else:
         return SwitchModeCover(**switch_args)
 
@@ -390,9 +398,14 @@ def devices_from_config(domain_config):
         control_mode = _resolve_control_mode(config, defaults, bool(cover_entity_id))
         pulse_time = _get_value(CONF_PULSE_TIME, config, defaults, DEFAULT_PULSE_TIME)
         config.pop(CONF_PULSE_TIME, None)
+        relay_reports_off = _get_value(
+            CONF_RELAY_REPORTS_OFF, config, defaults, DEFAULT_RELAY_REPORTS_OFF
+        )
+        config.pop(CONF_RELAY_REPORTS_OFF, None)
 
         options[CONF_CONTROL_MODE] = control_mode
         options[CONF_PULSE_TIME] = pulse_time
+        options[CONF_RELAY_REPORTS_OFF] = relay_reports_off
 
         if open_switch:
             options[CONF_OPEN_SWITCH_ENTITY_ID] = open_switch

--- a/custom_components/cover_time_based/cover_toggle_mode.py
+++ b/custom_components/cover_time_based/cover_toggle_mode.py
@@ -31,10 +31,20 @@ class ToggleModeCover(SwitchCoverTimeBased):
     ON: toggle relays are momentary/self-releasing, so the next command is
     naturally a clean rising edge. Position tracking starts from the moment the
     motor begins moving (the ON edge).
+
+    ``relay_reports_off`` (default ``True``) controls how a relay's OFF state is
+    treated. When ``True``, the relay is trusted to report its own OFF, so a
+    relay still *reporting* ON is driven OFF first to force a clean edge. When
+    ``False`` (hardware-managed pulse modules such as the Aqara T2, issue #105),
+    the relay self-releases physically but never reports the OFF to HA — the
+    entity stays stuck ``on`` — and a ``turn_off`` is itself an activation pulse
+    on that hardware. In that case the send methods only ever issue ``turn_on``
+    and never a ``turn_off``, so each command is exactly one clean activation.
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self, relay_reports_off=True, **kwargs):
         super().__init__(**kwargs)
+        self._relay_reports_off = relay_reports_off
         self._last_external_toggle_time = {}
         self._last_tilt_direction = None
 
@@ -50,28 +60,82 @@ class ToggleModeCover(SwitchCoverTimeBased):
         (which the motor would miss while the position tracker keeps advancing,
         desyncing the entity from the physical cover).
 
-        Mark the echo(es) this pulse produces so the integration ignores its
-        own state changes: one for the lone ``turn_on``, or two when a release
-        ``turn_off`` precedes it. Marking more echoes than are emitted would
-        leave a stale pending count that swallows the user's next genuine press
-        until the safety timeout clears it.
+        With ``relay_reports_off`` disabled the OFF→ON-edge release is skipped
+        entirely: the relay never reports its OFF (so a reported ON is stale,
+        not the real state) and a ``turn_off`` would fire a spurious activation
+        pulse. A lone ``turn_on`` still pulses the motor on such hardware.
+
+        Mark only the echoes this pulse actually emits, so the integration
+        ignores its own state changes without over-counting. Marking more echoes
+        than are emitted would leave a stale pending count that swallows the
+        user's next genuine press until the safety timeout clears it. A service
+        call that doesn't change the entity's state (``turn_off`` on an
+        already-off relay, ``turn_on`` on an already-on one) fires no event and
+        so produces no echo to mark.
         """
-        if self._switch_is_on(entity_id):
+        is_on = self._switch_is_on(entity_id)
+        if self._relay_reports_off and is_on:
+            # Relay reports ON and we trust that report: release it first so the
+            # following turn_on is a genuine OFF->ON edge. Two state changes
+            # (off, then on) → two echoes.
             self._mark_switch_pending(entity_id, 2)
-            await self.hass.services.async_call(
-                "homeassistant",
-                "turn_off",
-                {"entity_id": entity_id},
-                False,
-            )
-        else:
+            await self._turn_off_relay(entity_id)
+        elif not is_on:
+            # Relay reports OFF: the turn_on produces a real OFF->ON edge → one
+            # echo.
             self._mark_switch_pending(entity_id, 1)
+        # else: relay_reports_off is disabled and the relay still *reports* ON
+        # (it never announced its self-release). The turn_on lands on an
+        # already-on entity, so HA emits no state change and no echo — marking
+        # one would orphan a pending count that could swallow the user's next
+        # genuine press until the safety timeout clears it.
         await self.hass.services.async_call(
             "homeassistant",
             "turn_on",
             {"entity_id": entity_id},
             False,
         )
+
+    async def _turn_off_relay(self, entity_id):
+        """The single, gated path for every toggle-mode ``turn_off``.
+
+        Funnelling all OFF commands through here keeps one invariant enforceable
+        in one place: when ``relay_reports_off`` is disabled the relay never
+        receives a ``turn_off`` at all, because that hardware treats a
+        ``turn_off`` as an activation pulse rather than an idempotent "off"
+        (issue #105). A new relay path can't reintroduce the bug by forgetting
+        the gate as long as it issues its OFF through this method.
+
+        Echo-marking stays with the caller: how many echoes a command emits
+        depends on whether a ``turn_on`` follows the OFF, which only the caller
+        knows.
+        """
+        if not self._relay_reports_off:
+            return
+        await self.hass.services.async_call(
+            "homeassistant",
+            "turn_off",
+            {"entity_id": entity_id},
+            False,
+        )
+
+    async def _release_relay(self, entity_id):
+        """Drive the opposite-direction relay OFF before pulsing a direction.
+
+        Clears a direction relay that may still be latched (or reporting ON
+        across a restart) so the two directions are never energised together.
+
+        Delegates the actual OFF to :meth:`_turn_off_relay`, so it is skipped
+        entirely when ``relay_reports_off`` is disabled (that hardware
+        self-releases physically — the opposite direction is already clear — and
+        a ``turn_off`` there is a spurious extra activation). An echo is marked
+        only when the relay both reports OFF *and* actually reports ON now, since
+        a ``turn_off`` on a relay already reporting OFF produces no state change
+        to filter.
+        """
+        if self._relay_reports_off and self._switch_is_on(entity_id):
+            self._mark_switch_pending(entity_id, 1)
+        await self._turn_off_relay(entity_id)
 
     async def async_stop_cover(self, **kwargs):
         """Stop the cover, only sending relay command if it was active."""
@@ -219,26 +283,12 @@ class ToggleModeCover(SwitchCoverTimeBased):
     # --- Internal relay commands ---
 
     async def _send_open(self) -> None:
-        if self._switch_is_on(self._close_switch_entity_id):
-            self._mark_switch_pending(self._close_switch_entity_id, 1)
-        await self.hass.services.async_call(
-            "homeassistant",
-            "turn_off",
-            {"entity_id": self._close_switch_entity_id},
-            False,
-        )
+        await self._release_relay(self._close_switch_entity_id)
         # Motor controller acts on the ON edge (_pulse_relay marks its echoes)
         await self._pulse_relay(self._open_switch_entity_id)
 
     async def _send_close(self) -> None:
-        if self._switch_is_on(self._open_switch_entity_id):
-            self._mark_switch_pending(self._open_switch_entity_id, 1)
-        await self.hass.services.async_call(
-            "homeassistant",
-            "turn_off",
-            {"entity_id": self._open_switch_entity_id},
-            False,
-        )
+        await self._release_relay(self._open_switch_entity_id)
         # Motor controller acts on the ON edge (_pulse_relay marks its echoes)
         await self._pulse_relay(self._close_switch_entity_id)
 
@@ -255,26 +305,12 @@ class ToggleModeCover(SwitchCoverTimeBased):
     # --- Tilt motor relay commands ---
 
     async def _send_tilt_open(self) -> None:
-        if self._switch_is_on(self._tilt_close_switch_id):
-            self._mark_switch_pending(self._tilt_close_switch_id, 1)
-        await self.hass.services.async_call(
-            "homeassistant",
-            "turn_off",
-            {"entity_id": self._tilt_close_switch_id},
-            False,
-        )
+        await self._release_relay(self._tilt_close_switch_id)
         await self._pulse_relay(self._tilt_open_switch_id)
         self._last_tilt_direction = "open"
 
     async def _send_tilt_close(self) -> None:
-        if self._switch_is_on(self._tilt_open_switch_id):
-            self._mark_switch_pending(self._tilt_open_switch_id, 1)
-        await self.hass.services.async_call(
-            "homeassistant",
-            "turn_off",
-            {"entity_id": self._tilt_open_switch_id},
-            False,
-        )
+        await self._release_relay(self._tilt_open_switch_id)
         await self._pulse_relay(self._tilt_close_switch_id)
         self._last_tilt_direction = "close"
 

--- a/custom_components/cover_time_based/frontend/card-render.js
+++ b/custom_components/cover_time_based/frontend/card-render.js
@@ -280,6 +280,15 @@ export function renderInputEntities(card, c) {
         ></ha-entity-picker>
         ` : ""}
       </div>
+      ${c.control_mode === "toggle"
+        ? renderToggleWithHelp(
+            card,
+            "relay_reports_off.label",
+            "relay_reports_off.helper",
+            c.relay_reports_off !== false,
+            (e) => card._updateLocal({ relay_reports_off: e.target.checked }),
+          )
+        : ""}
       ${renderToggleWithHelp(
         card,
         "assumed_state.label",

--- a/custom_components/cover_time_based/frontend/translations.js
+++ b/custom_components/cover_time_based/frontend/translations.js
@@ -52,6 +52,9 @@ export const EN = {
   "assumed_state.label": "Assumed state",
   "assumed_state.helper":
     "When on, Home Assistant treats the position as estimated and keeps both open and close controls active. Turn off if you trust the time-based calculation and want the UI to grey out unavailable actions (e.g. close when already closed).",
+  "relay_reports_off.label": "Relay reports its own OFF",
+  "relay_reports_off.helper":
+    "Leave on for normal toggle relays, which switch themselves off after the pulse and report it. Turn off for hardware-managed pulse modules (e.g. Aqara T2) that pulse internally but never report when they switch off, leaving the switch entity stuck on. With it off, the integration only ever sends a single ON command per press and never an OFF — so each press is exactly one clean activation, with no doubled commands.",
   "more_info": "More info",
   "timing.attribute_header": "Attribute",
   "timing.travel_attribute_header": "Travel Attribute",
@@ -167,6 +170,9 @@ export const TRANSLATIONS = {
     "assumed_state.label": "Estado assumido",
     "assumed_state.helper":
       "Quando ativo, o Home Assistant trata a posição como estimada e mantém ativos os controlos de abrir e fechar. Desative se confiar no cálculo por tempo e quiser que a interface desative as ações indisponíveis (por exemplo, fechar quando já está fechado).",
+    "relay_reports_off.label": "O relé reporta o seu próprio OFF",
+    "relay_reports_off.helper":
+      "Deixe ativo para relés de alternância normais, que se desligam após o pulso e o reportam. Desative para módulos de pulso geridos por hardware (por exemplo, Aqara T2) que pulsam internamente mas nunca reportam quando se desligam, deixando a entidade de interruptor presa em ligado. Com a opção desativada, a integração envia apenas um único comando LIGAR por toque e nunca DESLIGAR — por isso cada toque é exatamente uma ativação limpa, sem comandos duplicados.",
     "more_info": "Mais informação",
     "timing.attribute_header": "Atributo",
     "timing.travel_attribute_header": "Atributo",
@@ -279,6 +285,9 @@ export const TRANSLATIONS = {
     "assumed_state.label": "Stan zakładany",
     "assumed_state.helper":
       "Gdy włączone, Home Assistant traktuje pozycję jako szacowaną i pozostawia aktywne przyciski otwierania i zamykania. Wyłącz, jeśli ufasz obliczeniom czasowym i chcesz, aby interfejs wyszarzał niedostępne akcje (np. zamknięcie, gdy roleta jest już zamknięta).",
+    "relay_reports_off.label": "Przekaźnik zgłasza własne wyłączenie",
+    "relay_reports_off.helper":
+      "Pozostaw włączone dla zwykłych przekaźników przełączających, które same się wyłączają po impulsie i to zgłaszają. Wyłącz dla modułów impulsowych zarządzanych sprzętowo (np. Aqara T2), które pulsują wewnętrznie, ale nigdy nie zgłaszają wyłączenia, pozostawiając encję przełącznika zablokowaną w stanie włączonym. Po wyłączeniu integracja wysyła tylko jedno polecenie WŁĄCZ na naciśnięcie i nigdy WYŁĄCZ — dzięki czemu każde naciśnięcie to dokładnie jedna czysta aktywacja, bez podwojonych poleceń.",
     "more_info": "Więcej informacji",
     "timing.attribute_header": "Atrybut",
     "timing.travel_attribute_header": "Atrybut",

--- a/custom_components/cover_time_based/websocket_api.py
+++ b/custom_components/cover_time_based/websocket_api.py
@@ -23,6 +23,7 @@ from .cover import (
     CONF_MAX_TILT_ALLOWED_POSITION,
     CONF_OPEN_SWITCH_ENTITY_ID,
     CONF_PULSE_TIME,
+    CONF_RELAY_REPORTS_OFF,
     CONF_SAFE_TILT_POSITION,
     CONF_STOP_SWITCH_ENTITY_ID,
     CONF_ENDPOINT_RUNON_TIME,
@@ -46,6 +47,7 @@ from .cover import (
     DEFAULT_FORCE_TIME_BASED_POSITION,
     DEFAULT_IGNORE_REPORTED_POSITION,
     DEFAULT_PULSE_TIME,
+    DEFAULT_RELAY_REPORTS_OFF,
 )
 from .const import DOMAIN
 from .helpers import resolve_entity_or_none
@@ -56,6 +58,7 @@ _LOGGER = logging.getLogger(__name__)
 _FIELD_MAP = {
     "control_mode": CONF_CONTROL_MODE,
     "pulse_time": CONF_PULSE_TIME,
+    "relay_reports_off": CONF_RELAY_REPORTS_OFF,
     "open_switch_entity_id": CONF_OPEN_SWITCH_ENTITY_ID,
     "close_switch_entity_id": CONF_CLOSE_SWITCH_ENTITY_ID,
     "stop_switch_entity_id": CONF_STOP_SWITCH_ENTITY_ID,
@@ -169,6 +172,9 @@ async def ws_get_config(
             "entry_id": config_entry.entry_id,
             "control_mode": options.get(CONF_CONTROL_MODE, CONTROL_MODE_SWITCH),
             "pulse_time": options.get(CONF_PULSE_TIME, DEFAULT_PULSE_TIME),
+            "relay_reports_off": options.get(
+                CONF_RELAY_REPORTS_OFF, DEFAULT_RELAY_REPORTS_OFF
+            ),
             "open_switch_entity_id": options.get(CONF_OPEN_SWITCH_ENTITY_ID),
             "close_switch_entity_id": options.get(CONF_CLOSE_SWITCH_ENTITY_ID),
             "stop_switch_entity_id": options.get(CONF_STOP_SWITCH_ENTITY_ID),
@@ -218,6 +224,7 @@ async def ws_get_config(
         vol.Optional("pulse_time"): vol.All(
             vol.Coerce(float), vol.Range(min=0.1, max=10)
         ),
+        vol.Optional("relay_reports_off"): vol.Any(None, bool),
         vol.Optional("open_switch_entity_id"): vol.Any(str, None),
         vol.Optional("close_switch_entity_id"): vol.Any(str, None),
         vol.Optional("stop_switch_entity_id"): vol.Any(str, None),

--- a/tests/test_cover_factory.py
+++ b/tests/test_cover_factory.py
@@ -13,6 +13,7 @@ from custom_components.cover_time_based.cover import (
     CONF_MIN_MOVEMENT_TIME,
     CONF_OPEN_SWITCH_ENTITY_ID,
     CONF_PULSE_TIME,
+    CONF_RELAY_REPORTS_OFF,
     CONF_STOP_SWITCH_ENTITY_ID,
     CONF_TILT_STARTUP_DELAY,
     CONF_TILTING_TIME_DOWN,
@@ -91,6 +92,22 @@ class TestCreateCoverFromOptions:
             name="Test",
         )
         assert isinstance(cover, ToggleModeCover)
+        # Default: relay is trusted to report its own OFF.
+        assert cover._relay_reports_off is True
+
+    def test_toggle_mode_relay_reports_off_from_options(self):
+        cover = _create_cover_from_options(
+            {
+                CONF_CONTROL_MODE: CONTROL_MODE_TOGGLE,
+                CONF_OPEN_SWITCH_ENTITY_ID: "switch.open",
+                CONF_CLOSE_SWITCH_ENTITY_ID: "switch.close",
+                CONF_RELAY_REPORTS_OFF: False,
+            },
+            device_id="test",
+            name="Test",
+        )
+        assert isinstance(cover, ToggleModeCover)
+        assert cover._relay_reports_off is False
 
     def test_creates_wrapped_cover(self):
         cover = _create_cover_from_options(
@@ -224,6 +241,25 @@ class TestDevicesFromConfig:
         }
         devices = devices_from_config(config)
         assert isinstance(devices[0], ToggleModeCover)
+        # Default: relay is trusted to report its own OFF.
+        assert devices[0]._relay_reports_off is True
+
+    def test_toggle_relay_reports_off_from_yaml(self):
+        config = {
+            CONF_DEFAULTS: {},
+            CONF_DEVICES: {
+                "blind1": {
+                    "name": "Kitchen",
+                    CONF_OPEN_SWITCH_ENTITY_ID: "switch.open",
+                    CONF_CLOSE_SWITCH_ENTITY_ID: "switch.close",
+                    "input_mode": "toggle",
+                    CONF_RELAY_REPORTS_OFF: False,
+                },
+            },
+        }
+        devices = devices_from_config(config)
+        assert isinstance(devices[0], ToggleModeCover)
+        assert devices[0]._relay_reports_off is False
 
     def test_defaults_applied(self):
         """Old YAML keys in defaults are migrated to new names."""

--- a/tests/test_cover_toggle_mode.py
+++ b/tests/test_cover_toggle_mode.py
@@ -39,6 +39,7 @@ def _make_toggle_cover(
     tilt_open_switch=None,
     tilt_close_switch=None,
     tilt_stop_switch=None,
+    relay_reports_off=True,
 ):
     """Create a ToggleModeCover wired to a mock hass."""
     cover = ToggleModeCover(
@@ -59,6 +60,7 @@ def _make_toggle_cover(
         tilt_open_switch=tilt_open_switch,
         tilt_close_switch=tilt_close_switch,
         tilt_stop_switch=tilt_stop_switch,
+        relay_reports_off=relay_reports_off,
     )
     hass = MagicMock()
     hass.services.async_call = AsyncMock()
@@ -1062,3 +1064,142 @@ class TestTogglePulseEdge:
         await cover._send_close()
 
         assert cover._test_tasks == []
+
+
+# ===================================================================
+# relay_reports_off=False: never send turn_off (hardware-pulse modules)
+# ===================================================================
+
+
+class TestToggleRelayDoesNotReportOff:
+    """Hardware-managed pulse relays (e.g. Aqara T2, issue #105).
+
+    Such a relay self-releases physically after its own internal pulse but
+    never reports the OFF back to HA, so the entity stays stuck ``on``. On
+    that hardware a ``turn_off`` is itself an activation pulse, not an
+    idempotent 'off' — so when the option is disabled, toggle mode must send
+    *only* ``turn_on`` and never a ``turn_off``, giving exactly one clean
+    activation per command. A repeated ``turn_on`` still pulses the motor even
+    while HA reports the entity ``on``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_pulse_held_relay_is_single_turn_on(self):
+        """Relay reports ON (stuck): pulse is one turn_on, no release turn_off."""
+        cover = _make_toggle_cover(relay_reports_off=False)
+        _hold_relay_on(cover, "switch.close")
+        cover._last_command = SERVICE_CLOSE_COVER
+
+        await cover._send_stop()
+
+        assert _calls_for(cover, "switch.close") == [_ha("turn_on", "switch.close")]
+
+    @pytest.mark.asyncio
+    async def test_pulse_held_relay_marks_no_echo(self):
+        """turn_on on an already-on relay changes nothing → no echo to mark.
+
+        Marking a pending echo here would orphan the count (no state change ever
+        arrives to consume it), risking swallowing the user's next genuine press
+        until the 5s safety timeout clears it.
+        """
+        cover = _make_toggle_cover(relay_reports_off=False)
+        _hold_relay_on(cover, "switch.close")
+        cover._last_command = SERVICE_CLOSE_COVER
+
+        await cover._send_stop()
+
+        assert "switch.close" not in cover._pending_switch
+
+    @pytest.mark.asyncio
+    async def test_idle_pulse_marks_single_echo(self):
+        """turn_on on an off relay produces a real OFF->ON edge → one echo."""
+        cover = _make_toggle_cover(relay_reports_off=False)
+        _all_relays_off(cover)
+        cover._last_command = SERVICE_CLOSE_COVER
+
+        await cover._send_stop()
+
+        assert cover._pending_switch.get("switch.close") == 1
+
+    @pytest.mark.asyncio
+    async def test_send_open_only_turn_on_no_opposite_turn_off(self):
+        """_send_open sends one turn_on and no turn_off on the opposite relay."""
+        cover = _make_toggle_cover(relay_reports_off=False)
+        _all_relays_off(cover)
+
+        await cover._send_open()
+
+        assert _calls(cover.hass.services.async_call) == [
+            _ha("turn_on", "switch.open"),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_send_open_no_turn_off_even_when_opposite_held_on(self):
+        """The opposite relay reading ON must NOT trigger a turn_off.
+
+        On hardware-pulse modules the opposite relay self-releases physically;
+        a turn_off would be a spurious extra activation.
+        """
+        cover = _make_toggle_cover(relay_reports_off=False)
+        _hold_relay_on(cover, "switch.close")
+
+        await cover._send_open()
+
+        assert _calls(cover.hass.services.async_call) == [
+            _ha("turn_on", "switch.open"),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_send_close_only_turn_on_no_opposite_turn_off(self):
+        cover = _make_toggle_cover(relay_reports_off=False)
+        _all_relays_off(cover)
+
+        await cover._send_close()
+
+        assert _calls(cover.hass.services.async_call) == [
+            _ha("turn_on", "switch.close"),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_send_close_no_turn_off_even_when_opposite_held_on(self):
+        """Opposite (open) relay reading ON must NOT trigger a turn_off."""
+        cover = _make_toggle_cover(relay_reports_off=False)
+        _hold_relay_on(cover, "switch.open")
+
+        await cover._send_close()
+
+        assert _calls(cover.hass.services.async_call) == [
+            _ha("turn_on", "switch.close"),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_send_tilt_open_only_turn_on_no_opposite_turn_off(self):
+        cover = _make_toggle_cover(
+            tilt_open_switch="switch.tilt_open",
+            tilt_close_switch="switch.tilt_close",
+            relay_reports_off=False,
+        )
+        _all_relays_off(cover)
+
+        await cover._send_tilt_open()
+
+        assert _calls(cover.hass.services.async_call) == [
+            _ha("turn_on", "switch.tilt_open"),
+        ]
+        assert cover._last_tilt_direction == "open"
+
+    @pytest.mark.asyncio
+    async def test_send_tilt_close_only_turn_on_no_opposite_turn_off(self):
+        cover = _make_toggle_cover(
+            tilt_open_switch="switch.tilt_open",
+            tilt_close_switch="switch.tilt_close",
+            relay_reports_off=False,
+        )
+        _all_relays_off(cover)
+
+        await cover._send_tilt_close()
+
+        assert _calls(cover.hass.services.async_call) == [
+            _ha("turn_on", "switch.tilt_close"),
+        ]
+        assert cover._last_tilt_direction == "close"

--- a/tests/test_websocket_api.py
+++ b/tests/test_websocket_api.py
@@ -11,6 +11,7 @@ from custom_components.cover_time_based.cover import (
     CONF_MIN_MOVEMENT_TIME,
     CONF_OPEN_SWITCH_ENTITY_ID,
     CONF_PULSE_TIME,
+    CONF_RELAY_REPORTS_OFF,
     CONF_STOP_SWITCH_ENTITY_ID,
     CONF_TILT_CLOSE_SWITCH,
     CONF_TILT_MODE,
@@ -453,6 +454,84 @@ class TestForceTimeBasedPositionRoundTrip:
 
         new_options = hass.config_entries.async_update_entry.call_args[1]["options"]
         assert new_options[CONF_FORCE_TIME_BASED_POSITION] is True
+
+
+class TestRelayReportsOffRoundTrip:
+    """relay_reports_off is returned in get_config and saved in update_config."""
+
+    @pytest.mark.asyncio
+    async def test_get_config_defaults_to_true(self):
+        hass, _, entity_reg = _make_hass(options={})
+        conn = _make_connection()
+
+        with patch(
+            "custom_components.cover_time_based.websocket_api.er.async_get",
+            return_value=entity_reg,
+        ):
+            await _ws_get_config(
+                hass,
+                conn,
+                {
+                    "id": 1,
+                    "type": "cover_time_based/get_config",
+                    "entity_id": ENTITY_ID,
+                },
+            )
+
+        result = conn.send_result.call_args[0][1]
+        assert result["relay_reports_off"] is True
+
+    @pytest.mark.asyncio
+    async def test_get_config_returns_stored_false(self):
+        hass, _, entity_reg = _make_hass(
+            options={
+                CONF_CONTROL_MODE: CONTROL_MODE_TOGGLE,
+                CONF_RELAY_REPORTS_OFF: False,
+            }
+        )
+        conn = _make_connection()
+
+        with patch(
+            "custom_components.cover_time_based.websocket_api.er.async_get",
+            return_value=entity_reg,
+        ):
+            await _ws_get_config(
+                hass,
+                conn,
+                {
+                    "id": 1,
+                    "type": "cover_time_based/get_config",
+                    "entity_id": ENTITY_ID,
+                },
+            )
+
+        result = conn.send_result.call_args[0][1]
+        assert result["relay_reports_off"] is False
+
+    @pytest.mark.asyncio
+    async def test_update_config_saves_false(self):
+        hass, _, entity_reg = _make_hass(
+            options={CONF_CONTROL_MODE: CONTROL_MODE_TOGGLE}
+        )
+        conn = _make_connection()
+
+        with patch(
+            "custom_components.cover_time_based.websocket_api.er.async_get",
+            return_value=entity_reg,
+        ):
+            await _ws_update_config(
+                hass,
+                conn,
+                {
+                    "id": 1,
+                    "type": "cover_time_based/update_config",
+                    "entity_id": ENTITY_ID,
+                    "relay_reports_off": False,
+                },
+            )
+
+        new_options = hass.config_entries.async_update_entry.call_args[1]["options"]
+        assert new_options[CONF_RELAY_REPORTS_OFF] is False
 
 
 class TestAssumedStateRoundTrip:


### PR DESCRIPTION
Closes #105.

## Problem

Hardware-managed pulse relay modules (the reporter's **Aqara T2** in 200 ms internal-pulse mode, driving **Bubendorff MI2** motors) pulse the contact themselves and self-release, but **never report the resulting OFF** back to Home Assistant — the switch entity stays stuck `on`. On that hardware a `turn_off` is itself an *activation pulse*, not an idempotent "off".

Since v4.4.0, toggle mode forces a clean ON edge by sending `turn_off` then `turn_on` whenever the relay still reports ON. On this hardware that's **two** activations, so the motor's single-button toggle counter drifts by one each press — the reported symptom: *Stop reverses the cover, Up drives it down*. (Diagnosed in the issue thread together with the reporter, confirmed by their MQTT activity log showing `homeassistant.turn_off` producing an `allumé`/ON pulse.)

## Fix

A per-cover **Toggle-mode** option **"Relay reports its own OFF"** (`relay_reports_off`, default **`True`** = unchanged v4.4.0 behaviour).

When set to **`False`**, toggle mode only ever sends `turn_on` and **never** `turn_off`, giving exactly one clean activation per command. The reporter confirmed a repeated `turn_on` still pulses the motor even while HA shows the entity stuck `on`.

- Every toggle-mode `turn_off` now funnels through a single gated `_turn_off_relay` choke-point, so the "never turn_off" invariant can't be bypassed by any direction/tilt path.
- The echo-filter marks **exactly** the state changes each command emits (a `turn_on` on an already-on relay fires no event → marks none), avoiding an orphaned pending count that could swallow the user's next genuine press.
- Default `True` is byte-for-byte identical to before.

Wired through const → cover factory (UI + YAML schema/parse) → websocket get/update config → the config card (toggle-mode only, EN/PT/PL) → README.

## Testing

- New + updated unit tests for the relay command surface in both option states (stuck-on echo accounting, never-turn_off across direction + tilt, factory + websocket round-trip).
- Full suite green: **1047** Python tests, **250** frontend tests (coverage gate ≥90%), ruff + translation/docs drift checks clean.

## Note for @GuiPoM

This needs a hardware confirmation on your Aqara T2 / MI2 rig before it's promoted from pre-release — the unit tests prove the command surface (only `turn_on`, never `turn_off`), but only your hardware can confirm the motor behaves. Enable **"Relay reports its own OFF" → off** on the toggle cover and retry the calibration Up/Down/Stop buttons.