### PR TITLE
fix: ignore a non-self-reporting toggle relay reappearing on restart (#105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 4.5.1 (2026-06-22)
+
+### Fixes
+
+- **Toggle mode with “Relay reports its own OFF” off: restart no longer phantom-opens the cover** ([#105](https://github.com/Sese-Schneider/ha-cover-time-based/issues/105)): a relay configured as not self-reporting its OFF (an **Aqara T2** in hardware-pulse mode, the case the 4.5.0 option addresses) pulses and physically releases but never tells Home Assistant, so its switch entity stays stuck `on`. On a restart — or a Zigbee/Z2M reconnect — the entity reappeared as `unavailable → on`, which the integration mistook for a fresh button press and started a phantom movement: tracked all the way to an endpoint but with **no relay actually fired**, so the reported position silently diverged from the physical cover (for example showing fully open while the cover is closed). That stale-reappearance edge is no longer treated as a command for these relays, since there is no way to reconstruct whether or when a real press happened while Home Assistant was down. Only this configuration is affected — relays that report their OFF come back `off` on restart, so every other mode and the default toggle behaviour are unchanged.
+
 ## 4.5.0 (2026-06-22)
 
 ### Features

--- a/custom_components/cover_time_based/cover_base.py
+++ b/custom_components/cover_time_based/cover_base.py
@@ -2078,6 +2078,24 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
             self._log("_async_switch_state_changed :: calibration active, skipping")
             return
 
+        # A relay that does not report its own OFF stays stuck reporting 'on'
+        # across a restart/reconnect (it pulsed and physically released but
+        # never told HA). The entity (re)appearing — unavailable/unknown -> on —
+        # is then that stale retained state resurfacing, NOT a fresh button
+        # press; replaying it as one would start a phantom movement (tracked,
+        # but with no relay fired since _triggered_externally) and desync the
+        # tracker from the physical cover. Modes that know their relay is
+        # unreliable this way opt in via _is_stale_reappearance.
+        if self._is_stale_reappearance(old_val, new_val):
+            self._log(
+                "_async_switch_state_changed :: %s came online (%s -> %s),"
+                " not treating as a command",
+                entity_id,
+                old_val,
+                new_val,
+            )
+            return
+
         # External state change (physical button / remote / HA button).
         # Delegate to mode-specific handlers which start/stop position
         # tracking normally via async_open_cover / async_close_cover etc.
@@ -2100,6 +2118,18 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
     # -----------------------------------------------------------------------
     # External state change handlers
     # -----------------------------------------------------------------------
+
+    def _is_stale_reappearance(self, old_val, new_val) -> bool:
+        """Whether this transition is an unreliable relay (re)appearing.
+
+        Default ``False`` — most relays report their own OFF, so they come back
+        ``off`` after a restart and a real ``off->on`` press is unambiguous.
+        Overridden by modes whose relay's reported state can't be trusted
+        across a restart/reconnect (see ToggleModeCover with
+        ``relay_reports_off`` disabled), so the dispatcher skips treating the
+        reappearance as a command.
+        """
+        return False
 
     async def _handle_external_tilt_state_change(self, entity_id, old_val, new_val):
         """Handle external state change on tilt switches (dual_motor).

--- a/custom_components/cover_time_based/cover_toggle_mode.py
+++ b/custom_components/cover_time_based/cover_toggle_mode.py
@@ -6,6 +6,8 @@ import time
 from homeassistant.const import (
     SERVICE_CLOSE_COVER,
     SERVICE_OPEN_COVER,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
 )
 
 from .cover_switch import SwitchCoverTimeBased
@@ -165,6 +167,24 @@ class ToggleModeCover(SwitchCoverTimeBased):
         self._last_tilt_direction = None
 
     # --- External state change handlers ---
+
+    def _is_stale_reappearance(self, old_val, new_val) -> bool:
+        """A non-self-reporting relay coming back online is not a press.
+
+        When ``relay_reports_off`` is disabled the relay pulses and physically
+        releases but never reports its OFF (e.g. an Aqara T2 in hardware-pulse
+        mode — see issue #105), so its HA entity stays stuck ``on``. After a
+        restart or Zigbee reconnect the entity reappears as
+        ``unavailable``/``unknown`` → ``on``: that is the stale retained state
+        resurfacing, not a button press. Treating it as one would start a
+        phantom movement with no relay fired and desync the tracker. Relays
+        that report their OFF (the default) come back ``off``, so there is
+        nothing to guard and a genuine ``off`` → ``on`` press is unambiguous.
+        """
+        return not self._relay_reports_off and old_val in (
+            STATE_UNAVAILABLE,
+            STATE_UNKNOWN,
+        )
 
     async def _handle_external_state_change(self, entity_id, old_val, new_val):
         """Handle external state change in toggle mode.

--- a/custom_components/cover_time_based/manifest.json
+++ b/custom_components/cover_time_based/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/Sese-Schneider/ha-cover-time-based/issues",
   "requirements": [],
-  "version": "4.6.0"
+  "version": "4.5.1"
 }

--- a/tests/test_state_monitoring.py
+++ b/tests/test_state_monitoring.py
@@ -1132,6 +1132,121 @@ class TestToggleE2EThroughStateListener:
 
 
 # ===================================================================
+# Startup / reconnect: a switch (re)appearing must not look like a press
+# ===================================================================
+
+
+class TestStartupReappearanceNotTreatedAsPress:
+    """Toggle mode with ``relay_reports_off`` disabled.
+
+    Such a relay (e.g. an Aqara T2 in hardware-pulse mode) pulses and releases
+    itself but never reports the OFF, so its HA entity stays stuck ``on``. On a
+    restart / Zigbee reconnect it reappears as ``unavailable``/``unknown`` ->
+    ``on`` — the stale retained state resurfacing, NOT a genuine ``off -> on``
+    press. Replaying it as a command starts a phantom movement (tracked, but
+    with no relay fired because it's "external") and desyncs the tracker.
+
+    The guard is scoped to exactly this case: relays that report their OFF (the
+    default, and every other mode) come back ``off``, so there is nothing to
+    guard there and their behaviour is unchanged.
+    """
+
+    @staticmethod
+    def _toggle_no_off_report(make_cover):
+        cover = make_cover(control_mode=CONTROL_MODE_TOGGLE)
+        cover._relay_reports_off = False
+        cover.travel_calc.set_position(25)
+        return cover
+
+    @pytest.mark.asyncio
+    async def test_unavailable_to_on_does_not_trigger(self, make_cover):
+        cover = self._toggle_no_off_report(make_cover)
+
+        with (
+            patch.object(cover, "async_write_ha_state"),
+            patch.object(
+                cover, "_handle_external_state_change", new_callable=AsyncMock
+            ) as handler,
+        ):
+            await cover._async_switch_state_changed(
+                _make_state_event("switch.open", "unavailable", "on")
+            )
+
+        handler.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unknown_to_on_does_not_trigger(self, make_cover):
+        cover = self._toggle_no_off_report(make_cover)
+
+        with (
+            patch.object(cover, "async_write_ha_state"),
+            patch.object(
+                cover, "_handle_external_state_change", new_callable=AsyncMock
+            ) as handler,
+        ):
+            await cover._async_switch_state_changed(
+                _make_state_event("switch.open", "unknown", "on")
+            )
+
+        handler.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unavailable_to_on_starts_no_movement(self, make_cover):
+        """Symptom-level: the cover must not start opening on reappearance."""
+        cover = self._toggle_no_off_report(make_cover)
+
+        with (
+            patch.object(cover, "async_write_ha_state"),
+            patch.object(cover, "async_open_cover", new_callable=AsyncMock) as op,
+            patch.object(cover, "async_close_cover", new_callable=AsyncMock) as cl,
+        ):
+            await cover._async_switch_state_changed(
+                _make_state_event("switch.open", "unavailable", "on")
+            )
+
+        op.assert_not_awaited()
+        cl.assert_not_awaited()
+        assert not cover.travel_calc.is_traveling()
+
+    @pytest.mark.asyncio
+    async def test_genuine_off_to_on_still_triggers(self, make_cover):
+        """Regression: a real off->on press must still reach the handler."""
+        cover = self._toggle_no_off_report(make_cover)
+
+        with (
+            patch.object(cover, "async_write_ha_state"),
+            patch.object(
+                cover, "_handle_external_state_change", new_callable=AsyncMock
+            ) as handler,
+        ):
+            await cover._async_switch_state_changed(
+                _make_state_event("switch.open", "off", "on")
+            )
+
+        handler.assert_awaited_once_with("switch.open", "off", "on")
+
+    @pytest.mark.asyncio
+    async def test_default_toggle_reappearance_still_dispatched(self, make_cover):
+        """Scope check: a relay that DOES report its OFF (the default) is not
+        guarded — its reappearance still reaches the handler unchanged."""
+        cover = make_cover(control_mode=CONTROL_MODE_TOGGLE)
+        assert cover._relay_reports_off is True
+        cover.travel_calc.set_position(25)
+
+        with (
+            patch.object(cover, "async_write_ha_state"),
+            patch.object(
+                cover, "_handle_external_state_change", new_callable=AsyncMock
+            ) as handler,
+        ):
+            await cover._async_switch_state_changed(
+                _make_state_event("switch.open", "unavailable", "on")
+            )
+
+        handler.assert_awaited_once_with("switch.open", "unavailable", "on")
+
+
+# ===================================================================
 # External tilt state changes (pulse mode — base class handler)
 # Covers cover_base.py lines 1664-1688
 # ===================================================================


### PR DESCRIPTION
Follow-up to #117 (the v4.5.0 `relay_reports_off` toggle option).

## Problem

A toggle relay configured with **“Relay reports its own OFF” disabled** (`relay_reports_off=False` — an **Aqara T2** in hardware-pulse mode) pulses and physically self-releases but **never reports the OFF** to Home Assistant, so its switch entity stays stuck `on`.

On an HA **restart** (or a Zigbee/Z2M reconnect) that stuck-on entity reappears as `unavailable → on` (or `unknown → on`). `_async_switch_state_changed` mistook this reappearance for a fresh external button press and started a **phantom movement**: tracked all the way to an endpoint but with **no relay actually fired** (the move is treated as external, so the relay send is suppressed). The reported position then silently diverged from the physical cover — e.g. showing fully open while the cover is closed.

## Fix

Add a `_is_stale_reappearance(old_val, new_val)` hook — base returns `False`; `ToggleModeCover` overrides it to return `True` for an `unavailable`/`unknown` → transition **only when `relay_reports_off` is disabled**. The dispatcher skips treating such a reappearance as a command.

Deliberately **narrow scope**: relays that report their OFF (the default, and every other mode) come back `off` on restart, so there's nothing to guard there and their behaviour is unchanged. A genuine `off → on` press is still honoured.

## Tests

New `TestStartupReappearanceNotTreatedAsPress` covering: `unavailable→on` / `unknown→on` skipped (handler not dispatched, no movement started), a genuine `off→on` still dispatches, and a **default-toggle contrast** test proving a relay that reports its OFF is *not* guarded. Full suite **1052 passed**, ruff + frontend gate + drift checks clean.

## Notes

- Like #117, this wants **GuiPoM's confirmation on his Aqara T2 / Bubendorff MI2 rig** before promoting from pre-release. His restart debug log should show `_async_switch_state_changed :: switch.<open>: unavailable -> on` followed by `... came online ..., not treating as a command` (and no phantom open).
- The reported 25%/13% restored position was likely residue of a prior phantom-open being persisted; this fix should stop new ones from being recorded.
- Ships as **v4.5.1** (patch on 4.5.0), per maintainer direction — resetting the in-dev 4.6.0 manifest to 4.5.1 and adding the CHANGELOG section.