### PR TITLE
chore: release v4.5.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,6 @@ __pycache__/
 coverage/
 docs/plans/
 docs/superpowers/
+docs/handoffs/
 .ha-changes-state.json
 HA_CHANGES_REPORT.md


### PR DESCRIPTION
Release `v4.5.1`.

The manifest version (`4.5.1`) and the `CHANGELOG.md` `## 4.5.1` section already
landed via #120, so this PR is the `chore: release` marker the tag will point
at. It also folds in a small chore: ignoring `docs/handoffs/` (local session
handoff docs that were never tracked).

After merge, publish the GitHub Release by pushing the tag to upstream:

```
git tag v4.5.1
git push upstream v4.5.1
```

The release workflow publishes it as a **pre-release**; test it, then promote:

```
gh release edit v4.5.1 --prerelease=false --latest=true
```
