### PR TITLE
test: cover the dual-relay restart reappearance repro (#105)

### DIFF
--- a/tests/test_state_monitoring.py
+++ b/tests/test_state_monitoring.py
@@ -1226,6 +1226,34 @@ class TestStartupReappearanceNotTreatedAsPress:
         handler.assert_awaited_once_with("switch.open", "off", "on")
 
     @pytest.mark.asyncio
+    async def test_dual_relay_reappearance_no_phantom_reverse(self, make_cover):
+        """Canonical repro from the reporter's restart log (issue #105).
+
+        On restart BOTH stuck-on relays reappear as ``unknown -> on`` a few ms
+        apart: the close relay first (which read as an external close), then the
+        open relay (an external open "while closing, reversing") — driving the
+        cover to an endpoint with no relay ever fired. Neither edge may start
+        movement.
+        """
+        cover = self._toggle_no_off_report(make_cover)
+
+        with (
+            patch.object(cover, "async_write_ha_state"),
+            patch.object(cover, "async_open_cover", new_callable=AsyncMock) as op,
+            patch.object(cover, "async_close_cover", new_callable=AsyncMock) as cl,
+        ):
+            await cover._async_switch_state_changed(
+                _make_state_event("switch.close", "unknown", "on")
+            )
+            await cover._async_switch_state_changed(
+                _make_state_event("switch.open", "unknown", "on")
+            )
+
+        op.assert_not_awaited()
+        cl.assert_not_awaited()
+        assert not cover.travel_calc.is_traveling()
+
+    @pytest.mark.asyncio
     async def test_default_toggle_reappearance_still_dispatched(self, make_cover):
         """Scope check: a relay that DOES report its OFF (the default) is not
         guarded — its reappearance still reaches the handler unchanged."""


### PR DESCRIPTION
Test-only follow-up to #120 (the v4.5.1 restart phantom-open fix). No production change.

The reporter's restart debug log captured the canonical failure on a `relay_reports_off=False` toggle cover: on restart **both** stuck-on relays reappear as `unknown -> on` ~3ms apart →

```
… switch.…_l2: unknown -> on (pending=0)
_handle_external_state_change :: external close toggle detected
… switch.…_l1: unknown -> on (pending=0)
_handle_external_state_change :: external open toggle detected
async_open_cover :: external open while closing, reversing
```

→ phantom travel to an endpoint with no relay ever fired.

#120's single-relay tests already cover the `unknown`/`unavailable -> on` skip mechanism. This adds the **dual-relay reversing sequence** (and the close-relay path) end-to-end, asserting that neither reappearance starts movement. Passes on `main` (the fix is present); would fail without `_is_stale_reappearance`, since the first `unknown -> on` would dispatch an external close.

Full suite 1053 passed; ruff clean.