### PR TITLE
fix: skip endpoint run-on for inline tilt moves (#125)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Fixes
+
+- **Inline tilt no longer overshoots when the cover is parked at an endpoint** ([#125](https://github.com/Sese-Schneider/ha-cover-time-based/issues/125)): in **inline** tilt mode the slats are articulated by the main travel motor, so a tilt move drives the same relay as travel. When the cover was parked at a travel endpoint (fully open or fully closed) — the usual case when adjusting slats — a tilt move that finished there was wrongly given the **endpoint run-on**, a *travel* concept that keeps a latched relay energized so the shutter seats against its physical limit. The result: a 50% tilt that should take 0.75s (half of a 1.5s tilt time) ran for ~2s, the run-on default, overdriving the slats and starting to move the cover off the endpoint. Run-on is now suppressed for tilt moves, so the relay de-energizes as soon as the tilt target is reached. **Switch** mode is the only mode affected (it is the only one that runs on at an endpoint); travel moves to an endpoint still run on as before so the shutter seats correctly.
+
 ## 4.5.1 (2026-06-22)
 
 ### Fixes

--- a/custom_components/cover_time_based/cover_base.py
+++ b/custom_components/cover_time_based/cover_base.py
@@ -129,6 +129,12 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         # True while the active movement drives a dedicated tilt motor (dual
         # motor), so auto-stop settles the tilt motor instead of travel.
         self._moving_tilt_motor = False
+        # True while the active movement is a tilt move (any tilt mode). The
+        # endpoint run-on is a *travel* concept — it keeps a latched relay
+        # energized so the shutter seats against its physical limit. A tilt
+        # move that finishes while the cover is parked at a travel endpoint is
+        # not at a limit, so it must not run on (issue #125).
+        self._moving_tilt = False
         self._state = True
         self._pending_switch = {}
         self._pending_switch_timers = {}
@@ -770,6 +776,9 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
             return
 
         self._last_command = command
+        # Committed past the no-op return above — mark this as a tilt move so it
+        # doesn't run on at a travel endpoint (#125); see set_tilt_position.
+        self._moving_tilt = True
         if self._tilt_strategy is not None and self._tilt_strategy.uses_tilt_motor:
             self._moving_tilt_motor = True
             # Externally triggered moves only track — the relay is already
@@ -995,6 +1004,11 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
             return
 
         self._last_command = command
+        # Set only now that the move is committed (past every no-op/too-short
+        # early return) — a tilt move must not run on at a travel endpoint, but
+        # leaking this onto a bailed-out call would wrongly suppress an
+        # in-flight travel move's run-on (issue #125).
+        self._moving_tilt = True
 
         if self._tilt_strategy is not None and self._tilt_strategy.uses_tilt_motor:
             self._moving_tilt_motor = True
@@ -1389,6 +1403,7 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
                     )
                 self._last_command = None
                 self._moving_tilt_motor = False
+                self._moving_tilt = False
                 await self._async_persist_position()
                 return
 
@@ -1405,6 +1420,7 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
                     )
                 self._last_command = None
                 self._moving_tilt_motor = False
+                self._moving_tilt = False
                 await self._async_persist_position()
                 return
 
@@ -1457,6 +1473,7 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
                 )
             elif (
                 self._at_endpoint(current_travel)
+                and not self._moving_tilt
                 and self._endpoint_runon_time is not None
                 and self._endpoint_runon_time > 0
             ):
@@ -1473,6 +1490,7 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
                 await self._async_handle_command(SERVICE_STOP_COVER)
             self._last_command = None
             self._moving_tilt_motor = False
+            self._moving_tilt = False
             await self._async_persist_position()
 
     def _motor_stops_itself(self) -> bool:
@@ -1591,8 +1609,9 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         self._pending_tilt_target = None
         self._pending_tilt_command = None
         # Each movement entry point funnels through here; default to a travel
-        # move and let the tilt-motor paths below opt in.
+        # move and let the tilt paths below opt in.
         self._moving_tilt_motor = False
+        self._moving_tilt = False
 
         if not was_restoring and not was_pre_stepping:
             return

--- a/tests/test_endpoint_self_stop.py
+++ b/tests/test_endpoint_self_stop.py
@@ -597,3 +597,148 @@ async def test_switch_dual_motor_external_open_can_be_stopped(make_cover):
         "switching the open relay off must stop the cover, not be filtered as an echo"
     )
     await _cancel_tasks(cover)
+
+
+# ===================================================================
+# Inline tilt at a travel endpoint (issue #125)
+#
+# Inline tilt drives the *travel* motor to articulate the slats. Endpoint
+# run-on is a travel concept — it keeps a latched relay energized so the
+# shutter seats against its physical limit. A tilt move that merely finishes
+# while the cover is parked at a travel endpoint (0/100) is NOT at a limit;
+# applying run-on overdrives the tilt well past its target (a 50% tilt that
+# should take 0.75s ran for ~2s, the run-on default).
+# ===================================================================
+
+
+def _make_inline(make_cover, control_mode=CONTROL_MODE_SWITCH):
+    return make_cover(
+        control_mode=control_mode,
+        tilt_time_close=1.5,
+        tilt_time_open=1.5,
+        tilt_mode="inline",
+        endpoint_runon_time=2.0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_inline_tilt_at_closed_endpoint_no_runon(make_cover):
+    """Switch + inline: tilting while parked fully closed must not run on past
+    the tilt target — the relay de-energizes immediately (issue #125)."""
+    cover = _make_inline(make_cover)
+    cover.travel_calc.set_position(0)  # parked fully closed
+    cover.tilt_calc.set_position(0)
+
+    with patch.object(cover, "async_write_ha_state"):
+        await cover.set_tilt_position(50)
+        cover.hass.services.async_call.reset_mock()
+        cover.tilt_calc.set_position(50)  # tilt reaches its 50% target
+        await cover.auto_stop_if_necessary()
+
+    assert cover._delay_task is None, "a tilt move must not schedule endpoint run-on"
+    off_calls = [c for c in _ha_calls(cover) if c.args[1] == "turn_off"]
+    assert off_calls, "switch mode must de-energize the relay when tilt completes"
+    await _cancel_tasks(cover)
+
+
+@pytest.mark.asyncio
+async def test_inline_tilt_at_open_endpoint_no_runon(make_cover):
+    """Switch + inline: the overshoot bites at the open endpoint too — tilting
+    while parked fully open must not run on either (issue #125)."""
+    cover = _make_inline(make_cover)
+    cover.travel_calc.set_position(100)  # parked fully open
+    cover.tilt_calc.set_position(100)
+
+    with patch.object(cover, "async_write_ha_state"):
+        await cover.set_tilt_position(50)
+        cover.hass.services.async_call.reset_mock()
+        cover.tilt_calc.set_position(50)
+        await cover.auto_stop_if_necessary()
+
+    assert cover._delay_task is None, "a tilt move must not schedule endpoint run-on"
+    await _cancel_tasks(cover)
+
+
+@pytest.mark.asyncio
+async def test_inline_open_tilt_at_closed_endpoint_no_runon(make_cover):
+    """`open_cover_tilt` is a tilt move too (it routes through a different
+    method than set_tilt_position): tilting open from the closed endpoint must
+    not run on and start lifting the cover off the endpoint (issue #125)."""
+    cover = _make_inline(make_cover)
+    cover.travel_calc.set_position(0)  # cover fully closed
+    cover.tilt_calc.set_position(0)  # slats closed
+
+    with patch.object(cover, "async_write_ha_state"):
+        await cover.async_open_cover_tilt()  # tilt fully open
+        cover.hass.services.async_call.reset_mock()
+        cover.tilt_calc.set_position(100)  # tilt reaches its open endpoint
+        await cover.auto_stop_if_necessary()
+
+    assert cover._delay_task is None, "open_cover_tilt must not schedule run-on"
+    await _cancel_tasks(cover)
+
+
+@pytest.mark.asyncio
+async def test_inline_travel_to_endpoint_keeps_runon(make_cover):
+    """The fix must suppress run-on for tilt moves only: a real *travel* move to
+    an endpoint must still run on so the shutter seats against its limit."""
+    cover = _make_inline(make_cover)
+    cover.travel_calc.set_position(50)
+    cover.tilt_calc.set_position(0)  # already at the closing tilt endpoint
+
+    with patch.object(cover, "async_write_ha_state"):
+        await cover.set_position(0)  # travel to fully closed
+        cover.travel_calc.set_position(0)
+        cover.tilt_calc.set_position(0)
+        await cover.auto_stop_if_necessary()
+
+    assert cover._delay_task is not None, "travel to an endpoint must still run on"
+    await _cancel_tasks(cover)
+
+
+@pytest.mark.asyncio
+async def test_noop_tilt_during_travel_does_not_suppress_travel_runon(make_cover):
+    """A redundant (no-op) tilt command arriving mid-travel must not leak the
+    tilt-move flag onto the in-flight TRAVEL move and suppress its endpoint
+    run-on. E.g. a "close cover AND set tilt to 0" automation where tilt is
+    already 0: the tilt command is a no-op but must not de-fang the close's
+    run-on at the closed endpoint."""
+    cover = _make_inline(make_cover)
+    cover.travel_calc.set_position(50)
+    cover.tilt_calc.set_position(0)  # tilt already at the closing endpoint
+
+    with patch.object(cover, "async_write_ha_state"):
+        await cover.set_position(0)  # start a travel move to fully closed
+        await cover.set_tilt_position(0)  # no-op: target == current tilt
+        # The travel move (still in flight) reaches the closed endpoint:
+        cover.travel_calc.set_position(0)
+        cover.tilt_calc.set_position(0)
+        await cover.auto_stop_if_necessary()
+
+    assert cover._delay_task is not None, (
+        "a no-op tilt command must not suppress the travel move's endpoint run-on"
+    )
+    await _cancel_tasks(cover)
+
+
+@pytest.mark.asyncio
+async def test_stop_during_tilt_then_travel_still_runs_on(make_cover):
+    """A committed tilt move interrupted by STOP must not de-fang the next
+    travel move's endpoint run-on. The next move clears the tilt-move flag via
+    _abandon_active_lifecycle, so this guards that reset staying load-bearing."""
+    cover = _make_inline(make_cover)
+    cover.travel_calc.set_position(50)
+    cover.tilt_calc.set_position(0)
+
+    with patch.object(cover, "async_write_ha_state"):
+        await cover.set_tilt_position(50)  # commit a tilt move (sets the flag)
+        await cover.async_stop_cover()  # STOP mid-tilt
+        cover.tilt_calc.set_position(0)  # park tilt so the close is pure travel
+        await cover.set_position(0)  # travel to the closed endpoint
+        cover.travel_calc.set_position(0)
+        await cover.auto_stop_if_necessary()
+
+    assert cover._delay_task is not None, (
+        "travel run-on must fire after a tilt move was committed then stopped"
+    )
+    await _cancel_tasks(cover)


### PR DESCRIPTION
Fixes #125.

## Problem
In **inline** tilt mode the slats are articulated by the main travel motor, so a tilt move drives the same relay as travel. The integration's **endpoint run-on** (switch mode only) keeps the latched relay energized for `endpoint_runon_time` (default 2.0s) after a *travel* move reaches a physical endpoint, so the shutter seats against its limit.

A **tilt** move that finished while the cover was parked at a travel endpoint (0%/100% — the usual case when adjusting slats) also got that run-on, overdriving the slats ~2s past target. A 50% tilt that should take 0.75s ran for ~2s, and the relay kept driving in the tilt direction, starting to move the cover off the endpoint.

## Fix
Add a per-move `_moving_tilt` flag and require `not self._moving_tilt` in the endpoint run-on branch of `auto_stop_if_necessary`, so a tilt move stops (de-energizes) as soon as its target is reached.

- Reset in `_abandon_active_lifecycle` (every movement entry funnels through it) and at the `auto_stop_if_necessary` terminals.
- Set at the **commit point** of both tilt entry points (`set_tilt_position`, `_async_move_tilt_to_endpoint`) — past every no-op/too-short/direction-change early return — so a bailed-out tilt command can't leak the flag onto an in-flight travel move and suppress *its* run-on.

Travel moves to an endpoint still run on (shutter still seats). Only switch mode is affected; sequential and dual-motor tilt were already covered by `allows_endpoint_runon` and `_moving_tilt_motor` respectively. `allows_endpoint_runon` keys off position only and structurally can't tell a travel-move-ending-at-0 from a tilt-move-ending-at-0, which is why a per-move flag is the right discriminator.

## Tests
6 new tests in `tests/test_endpoint_self_stop.py`:
- inline tilt to a mid position at the closed and open endpoints → no run-on (+ relay de-energizes);
- `open_cover_tilt` at the closed endpoint → no run-on (covers the second entry point);
- a real travel move to an endpoint → **still** runs on;
- a no-op tilt command mid-travel → does **not** suppress the travel move's run-on (the flag-leak regression guard);
- a tilt move committed then STOPped, then travel to an endpoint → still runs on.

Full suite: 1059 passing.