### PR TITLE
chore: bump version to 4.6.0 for development

### DIFF
--- a/custom_components/cover_time_based/manifest.json
+++ b/custom_components/cover_time_based/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/Sese-Schneider/ha-cover-time-based/issues",
   "requirements": [],
-  "version": "4.5.3"
+  "version": "4.6.0"
 }


### PR DESCRIPTION
Rolls `main` forward to the next minor (`4.6.0`) for development, so unreleased work no longer carries the just-released `4.5.3`.

This is the post-release dev-cycle bump. `release.yml` normally pushes it
straight to `main`, but this repo's `main` is protected (PR-only + required
status checks), so it lands as a PR instead.
