### PR TITLE
fix: make pulse-mode endpoint stop configurable (#133)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Fixes
+
+- **Pulse mode: the endpoint stop is now configurable** ([#133](https://github.com/Sese-Schneider/ha-cover-time-based/issues/133)): "Pulse" mode actually serves two physically opposite momentary controllers, and the 4.5.3 fix for [#129](https://github.com/Sese-Schneider/ha-cover-time-based/issues/129) — which made the endpoint stop **unconditional** — is right for one and wrong for the other. A **latching** controller keeps running until it receives a dedicated stop pulse, so it *needs* the endpoint stop or it gets stuck "moving" (the #129 case). An **auto-stop** controller halts itself at its 0%/100% limit switches, and a stop pulse received *while already stopped* is read as "go to favourite/preset position" (classic Somfy "my" behaviour) — so for that hardware every limit hit silently repositioned the cover (the #133 regression). Tuning the run-on delay can't help: the motor has already self-stopped, so *any* stop pulse arrives "while stopped". A new per-cover option, **Send stop signal at endpoints** (default **on**, the unchanged 4.5.3 behaviour), can be turned **off** for auto-stop controllers so the endpoint stop pulse is not sent at all; the same flag also governs a separate **tilt motor**'s endpoint stop. Configurable from the config card (EN/PT/PL) and as the `send_endpoint_stop` YAML option. As a related cleanup, the **Endpoint run-on time** field is now also shown for pulse covers that send the endpoint stop (it was silently using the 2.0s default and was unconfigurable from the card). **Switch**, **Toggle** and **wrapped-cover** modes are unchanged; the default keeps #129 fixed out of the box.
+
 ## 4.5.3 (2026-06-27)
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -136,6 +136,12 @@ Toggle mode only. Leave it **on** (the default) for normal toggle relays — the
 
 Turn it **off** for hardware-managed pulse modules — for example an **Aqara T2** in its 200 ms internal-pulse mode — that pulse the contact themselves but **never report the OFF** to Home Assistant, leaving the switch entity stuck `on`. On such hardware a `turn_off` is not an idempotent "off" but another activation pulse, so the integration's attempt to force a clean edge (`turn_off` then `turn_on`) lands as a doubled command and the motor's toggle counter drifts — the symptom is Stop reversing the cover and Up driving it down. With the option off, toggle mode only ever sends a **single `turn_on` per command and never a `turn_off`**, giving exactly one clean activation per press. A repeated `turn_on` still pulses the motor even while the entity reads `on`.
 
+#### Send stop signal at endpoints (Pulse mode)
+
+Pulse mode only. Leave it **on** (the default) for controllers that **latch** the direction command and keep running until they receive a separate stop pulse. Without the endpoint stop they stay stuck "moving" — the cover only responds after several clicks and the physical wall/PLC buttons appear blocked. With the option on, the integration pulses the dedicated stop relay when the cover reaches an endpoint (deferred by the **Endpoint run-on time**, see below); because the stop is a separate relay it can never restart the motor.
+
+Turn it **off** for controllers with **automatic end-stop detection**: the motor halts itself at its 0%/100% limit switches, and a stop pulse received _while it is already stopped_ is read as "go to favourite/preset position" (the classic Somfy _my_ behaviour), repositioning the cover on every limit hit. With the option off, no stop is sent at the endpoints. The same flag governs a **separate tilt motor**'s tilt-stop relay at the tilt endpoints. **Switch**, **Toggle** and wrapped-cover modes are unaffected.
+
 ### Assumed state
 
 Available for every device type. A time-based cover calculates its position from travel time without feedback, so by default it reports an _assumed_ state and Home Assistant keeps both the open and close buttons active at all times. Turn **Assumed state** off if you trust the time-based calculation and want the UI to behave like a position-aware cover — greying out actions that can't apply (for example the close button once the cover is already fully closed). Leave it on if the calculation can drift (motor slip, manual operation, power loss mid-travel), since the always-active buttons let you re-issue a command to re-converge.
@@ -195,7 +201,7 @@ Select the attribute that you wish to calibrate. The available attributes depend
 | Travel time (close)  | Time in seconds for the cover to fully close                          |         |
 | Travel time (open)   | Time in seconds for the cover to fully open                           |         |
 | Travel startup delay | Motor startup compensation for travel (see below)                     | None    |
-| Endpoint run-on time | Extra relay time at endpoints to reset position (Switch mode only)    | 2.0     |
+| Endpoint run-on time | Extra relay time at endpoints to reset position (Switch mode; Pulse when it sends the stop) | 2.0     |
 | Min movement time    | Minimum movement duration - blocks shorter movements to prevent drift | None    |
 
 ### Calibration Attributes for Tilt
@@ -225,11 +231,11 @@ Recommended values: 0.05 - 0.15 seconds. Can be configured separately for travel
 
 Position tracking is not exact and can drift over time, so the tracker resyncs itself whenever the cover is sent fully to the 0% or 100% endpoint.
 
-Most cover motors have internal limit switches and stop themselves at the endpoints. In **Pulse**, **Toggle** and wrapped-cover modes the integration therefore sends **no stop command at an endpoint** — it lets the motor run into its own limit. This avoids an unwanted extra movement (in Toggle mode a stop pulse on an already-stopped motor would restart it) and resyncs the tracker for free, as the motor always reaches its true endpoint.
+Most cover motors have internal limit switches and stop themselves at the endpoints. In **Toggle** and wrapped-cover modes the integration therefore sends **no stop command at an endpoint** — it lets the motor run into its own limit. This avoids an unwanted extra movement (in Toggle mode a stop pulse on an already-stopped motor would restart it) and resyncs the tracker for free, as the motor always reaches its true endpoint. **Pulse** mode is configurable (see [Send stop signal at endpoints](#send-stop-signal-at-endpoints-pulse-mode) above): by default it pulses its dedicated stop relay at the endpoint, which a latching controller needs, but that can be turned off for controllers that self-stop at their own limits.
 
-In **Switch** mode the direction relay is latched ON for the whole movement, so it must be actively switched off at the endpoint. Because tracking is approximate, the relay is held on for an extra **Endpoint Run-on Time** (default 2s) so the motor reaches the physical endpoint before power is cut. **This setting applies only to Switch mode.**
+In **Switch** mode the direction relay is latched ON for the whole movement, so it must be actively switched off at the endpoint. Because tracking is approximate, the relay is held on for an extra **Endpoint Run-on Time** (default 2s) so the motor reaches the physical endpoint before power is cut. **This setting applies to Switch mode, and to Pulse mode when it sends the endpoint stop** (it defers that stop pulse by the run-on so the motor seats against its limit first).
 
-The same self-stop handling applies to a **separate tilt motor** (separate-tilt-motor mode): no stop is sent when tilt reaches its 0%/100% endpoints — the tilt motor self-stops on its own limit — except in **Switch** mode, which de-energizes the latched tilt relay. Mid-tilt positions are always stopped (nothing self-stops there).
+The same self-stop handling applies to a **separate tilt motor** (separate-tilt-motor mode): no stop is sent when tilt reaches its 0%/100% endpoints — the tilt motor self-stops on its own limit — except in **Switch** mode (which de-energizes the latched tilt relay) and in **Pulse** mode when _Send stop signal at endpoints_ is on (which pulses the tilt-stop relay). Mid-tilt positions are always stopped (nothing self-stops there).
 
 Under the **sequential closes-then-tilts-closed** and **sequential closes-then-tilts-open** tilt modes, run-on is skipped at the closed (0%) endpoint, because the motor is already driven past cover-closed for the tilt phase. Run-on still applies at the open (100%) endpoint.
 
@@ -364,6 +370,7 @@ cover:
 | tilt_startup_delay     | float   | _Optional_                                      | Motor startup time compensation (seconds) for tilt movements            | None    |
 | pulse_time             | float   | _Optional_                                      | Duration in seconds for button press in pulse mode                      | 1.0     |
 | relay_reports_off      | boolean | _Optional_                                      | Toggle mode: set false for pulse modules that never report their OFF    | true    |
+| send_endpoint_stop     | boolean | _Optional_                                      | Pulse mode: set false for auto-stop controllers that reposition on a stop received while stopped | true    |
 
 </details>
 

--- a/custom_components/cover_time_based/const.py
+++ b/custom_components/cover_time_based/const.py
@@ -32,3 +32,13 @@ DEFAULT_ASSUMED_STATE = True
 # and never turn_off, since a turn_off is itself an activation pulse there.
 CONF_RELAY_REPORTS_OFF = "relay_reports_off"
 DEFAULT_RELAY_REPORTS_OFF = True
+
+# Pulse mode only. When True (default) the integration sends the dedicated stop
+# pulse when the cover reaches an endpoint (0%/100%) — required by latching
+# controllers that keep running until they receive a stop (issue #129).
+# When False, the endpoint stop is skipped: for auto-stop controllers that have
+# already halted at their limit switch, a stop pulse received "while stopped"
+# triggers a go-to-favourite reposition (classic Somfy "my" behaviour, issue
+# #133), so the stop must not be sent at all.
+CONF_SEND_ENDPOINT_STOP = "send_endpoint_stop"
+DEFAULT_SEND_ENDPOINT_STOP = True

--- a/custom_components/cover_time_based/cover.py
+++ b/custom_components/cover_time_based/cover.py
@@ -32,6 +32,7 @@ from .const import (
     CONF_IGNORE_REPORTED_POSITION,
     CONF_MIN_MOVEMENT_TIME,
     CONF_RELAY_REPORTS_OFF,
+    CONF_SEND_ENDPOINT_STOP,
     CONF_TILT_MODE,
     CONF_TILT_STARTUP_DELAY,
     CONF_TILT_TIME_CLOSE,
@@ -45,6 +46,7 @@ from .const import (
     DEFAULT_FORCE_TIME_BASED_POSITION,
     DEFAULT_IGNORE_REPORTED_POSITION,
     DEFAULT_RELAY_REPORTS_OFF,
+    DEFAULT_SEND_ENDPOINT_STOP,
 )
 from .cover_base import CoverTimeBased  # noqa: F401
 from .helpers import resolve_entity
@@ -124,6 +126,7 @@ SWITCH_COVER_SCHEMA = {
     vol.Optional(CONF_IS_BUTTON, default=False): cv.boolean,
     vol.Optional(CONF_PULSE_TIME): cv.positive_float,
     vol.Optional(CONF_RELAY_REPORTS_OFF): cv.boolean,
+    vol.Optional(CONF_SEND_ENDPOINT_STOP): cv.boolean,
     **TRAVEL_TIME_SCHEMA,
 }
 
@@ -352,7 +355,13 @@ def _create_cover_from_options(options, device_id="", name=""):
     pulse_time = options.get(CONF_PULSE_TIME, DEFAULT_PULSE_TIME)
 
     if control_mode == CONTROL_MODE_PULSE:
-        return PulseModeCover(pulse_time=pulse_time, **switch_args)
+        return PulseModeCover(
+            pulse_time=pulse_time,
+            send_endpoint_stop=options.get(
+                CONF_SEND_ENDPOINT_STOP, DEFAULT_SEND_ENDPOINT_STOP
+            ),
+            **switch_args,
+        )
     elif control_mode == CONTROL_MODE_TOGGLE:
         return ToggleModeCover(
             relay_reports_off=options.get(
@@ -402,10 +411,15 @@ def devices_from_config(domain_config):
             CONF_RELAY_REPORTS_OFF, config, defaults, DEFAULT_RELAY_REPORTS_OFF
         )
         config.pop(CONF_RELAY_REPORTS_OFF, None)
+        send_endpoint_stop = _get_value(
+            CONF_SEND_ENDPOINT_STOP, config, defaults, DEFAULT_SEND_ENDPOINT_STOP
+        )
+        config.pop(CONF_SEND_ENDPOINT_STOP, None)
 
         options[CONF_CONTROL_MODE] = control_mode
         options[CONF_PULSE_TIME] = pulse_time
         options[CONF_RELAY_REPORTS_OFF] = relay_reports_off
+        options[CONF_SEND_ENDPOINT_STOP] = send_endpoint_stop
 
         if open_switch:
             options[CONF_OPEN_SWITCH_ENTITY_ID] = open_switch

--- a/custom_components/cover_time_based/cover_pulse_mode.py
+++ b/custom_components/cover_time_based/cover_pulse_mode.py
@@ -18,9 +18,10 @@ class PulseModeCover(SwitchCoverTimeBased):
     completion (sleep + turn_off) runs in the background.
     """
 
-    def __init__(self, pulse_time, **kwargs):
+    def __init__(self, pulse_time, send_endpoint_stop=True, **kwargs):
         super().__init__(**kwargs)
         self._pulse_time = pulse_time
+        self._send_endpoint_stop = send_endpoint_stop
 
     def _get_missing_configuration(self) -> list[str]:
         """Return list of missing configuration items."""
@@ -32,23 +33,29 @@ class PulseModeCover(SwitchCoverTimeBased):
         return missing
 
     def _self_stops_at_endpoints(self) -> bool:
-        """Pulse mode must still pulse its dedicated stop relay at an endpoint.
+        """Whether to treat a pulse cover's motor as self-stopping at endpoints.
 
-        The base default (True) skips the endpoint stop because, for toggle mode,
-        re-pulsing the *direction* relay there would restart the motor. Pulse
-        mode is different: its stop is a *separate* relay (a stop switch is
-        required), so the endpoint stop can never restart the motor. The
-        momentary controller latches the direction command and keeps running
-        until it receives that stop pulse — skipping it leaves the controller
-        stuck "moving", blocking the next press and external buttons (issue
-        #129). Returning False restores the 4.3.0 behaviour: endpoint stop pulse,
-        deferred by endpoint_runon_time if configured.
+        Pulse mode serves two opposite momentary controllers, selected by the
+        per-cover ``send_endpoint_stop`` option:
 
-        The same reasoning covers a dedicated tilt motor: this flag also gates
-        ``_tilt_settle``, so a pulse dual-motor cover likewise pulses its
-        (required) tilt-stop relay at the tilt endpoints.
+        - ``send_endpoint_stop=True`` (default) → return False. The endpoint stop
+          IS sent. Pulse mode's stop is a *separate* relay (a stop switch is
+          required), so it can never restart the motor. A latching controller
+          keeps running until it receives that stop pulse — skipping it leaves
+          the controller stuck "moving", blocking the next press and external
+          buttons (issue #129). This restores the 4.3.0 / v4.5.3 behaviour:
+          endpoint stop pulse, deferred by endpoint_runon_time if configured.
+
+        - ``send_endpoint_stop=False`` → return True. The endpoint stop is
+          SKIPPED (the self-stopping path). An auto-stop controller has already
+          halted at its limit switch, and a stop pulse received "while stopped"
+          is read as go-to-favourite, repositioning the cover (issue #133), so
+          the stop must not be sent at all.
+
+        The same flag gates ``_tilt_settle``, so a pulse dual-motor cover's
+        (required) tilt-stop relay follows the option at the tilt endpoints too.
         """
-        return False
+        return not self._send_endpoint_stop
 
     async def _complete_pulse(self, entity_id):
         """Complete a relay pulse by turning OFF after pulse_time."""

--- a/custom_components/cover_time_based/frontend/card-render.js
+++ b/custom_components/cover_time_based/frontend/card-render.js
@@ -289,6 +289,15 @@ export function renderInputEntities(card, c) {
             (e) => card._updateLocal({ relay_reports_off: e.target.checked }),
           )
         : ""}
+      ${c.control_mode === "pulse"
+        ? renderToggleWithHelp(
+            card,
+            "send_endpoint_stop.label",
+            "send_endpoint_stop.helper",
+            c.send_endpoint_stop !== false,
+            (e) => card._updateLocal({ send_endpoint_stop: e.target.checked }),
+          )
+        : ""}
       ${renderToggleWithHelp(
         card,
         "assumed_state.label",
@@ -465,10 +474,16 @@ export function renderTimingTable(card, c) {
     ["timing.travel_startup_delay", "travel_startup_delay", c.travel_startup_delay],
     ["timing.min_movement_time", "min_movement_time", c.min_movement_time],
   ];
-  // Endpoint run-on only applies to switch mode (its latched relay must be
-  // de-energized at the endpoint). Pulse/toggle/wrapped covers self-stop at
-  // their limit switches, so the setting has no effect there.
-  if ((c.control_mode || "switch") === "switch") {
+  // Endpoint run-on applies to modes that send a relay stop at the endpoint:
+  // switch mode (its latched relay must be de-energized) and pulse mode when it
+  // sends the endpoint stop (send_endpoint_stop, default on — it pulses a
+  // dedicated stop relay, deferred by run-on). Toggle/wrapped covers — and pulse
+  // covers with the endpoint stop turned off — self-stop at their limit
+  // switches, so the setting has no effect there.
+  const mode = c.control_mode || "switch";
+  const sendsEndpointStop =
+    mode === "switch" || (mode === "pulse" && c.send_endpoint_stop !== false);
+  if (sendsEndpointStop) {
     travelRows.push([
       "timing.endpoint_runon_time",
       "endpoint_runon_time",

--- a/custom_components/cover_time_based/frontend/translations.js
+++ b/custom_components/cover_time_based/frontend/translations.js
@@ -55,6 +55,9 @@ export const EN = {
   "relay_reports_off.label": "Relay reports its own OFF",
   "relay_reports_off.helper":
     "Leave on for normal toggle relays, which switch themselves off after the pulse and report it. Turn off for hardware-managed pulse modules (e.g. Aqara T2) that pulse internally but never report when they switch off, leaving the switch entity stuck on. With it off, the integration only ever sends a single ON command per press and never an OFF — so each press is exactly one clean activation, with no doubled commands.",
+  "send_endpoint_stop.label": "Send stop signal at endpoints",
+  "send_endpoint_stop.helper":
+    "When your cover reaches fully open or closed, send the stop pulse. Keep this on for controllers that keep running until they receive a stop (the cover otherwise gets stuck and physical buttons stop responding). Turn it off if your motor stops itself at its limits and an extra stop makes it move to a preset/favourite position.",
   "more_info": "More info",
   "timing.attribute_header": "Attribute",
   "timing.travel_attribute_header": "Travel Attribute",
@@ -173,6 +176,9 @@ export const TRANSLATIONS = {
     "relay_reports_off.label": "O relé reporta o seu próprio OFF",
     "relay_reports_off.helper":
       "Deixe ativo para relés de alternância normais, que se desligam após o pulso e o reportam. Desative para módulos de pulso geridos por hardware (por exemplo, Aqara T2) que pulsam internamente mas nunca reportam quando se desligam, deixando a entidade de interruptor presa em ligado. Com a opção desativada, a integração envia apenas um único comando LIGAR por toque e nunca DESLIGAR — por isso cada toque é exatamente uma ativação limpa, sem comandos duplicados.",
+    "send_endpoint_stop.label": "Enviar sinal de paragem nos extremos",
+    "send_endpoint_stop.helper":
+      "Quando a cobertura chega totalmente aberta ou fechada, envia o pulso de paragem. Mantenha ativo para controladores que continuam a funcionar até receberem uma paragem (caso contrário a cobertura fica presa e os botões físicos deixam de responder). Desative se o seu motor para sozinho nos limites e um pulso de paragem adicional o faz mover para uma posição predefinida/favorita.",
     "more_info": "Mais informação",
     "timing.attribute_header": "Atributo",
     "timing.travel_attribute_header": "Atributo",
@@ -288,6 +294,9 @@ export const TRANSLATIONS = {
     "relay_reports_off.label": "Przekaźnik zgłasza własne wyłączenie",
     "relay_reports_off.helper":
       "Pozostaw włączone dla zwykłych przekaźników przełączających, które same się wyłączają po impulsie i to zgłaszają. Wyłącz dla modułów impulsowych zarządzanych sprzętowo (np. Aqara T2), które pulsują wewnętrznie, ale nigdy nie zgłaszają wyłączenia, pozostawiając encję przełącznika zablokowaną w stanie włączonym. Po wyłączeniu integracja wysyła tylko jedno polecenie WŁĄCZ na naciśnięcie i nigdy WYŁĄCZ — dzięki czemu każde naciśnięcie to dokładnie jedna czysta aktywacja, bez podwojonych poleceń.",
+    "send_endpoint_stop.label": "Wysyłaj sygnał zatrzymania na krańcach",
+    "send_endpoint_stop.helper":
+      "Gdy roleta osiągnie pełne otwarcie lub zamknięcie, wyślij impuls zatrzymania. Pozostaw włączone dla sterowników, które działają, dopóki nie otrzymają zatrzymania (w przeciwnym razie roleta blokuje się, a fizyczne przyciski przestają reagować). Wyłącz, jeśli silnik sam zatrzymuje się na krańcach, a dodatkowe zatrzymanie powoduje przejście do zaprogramowanej/ulubionej pozycji.",
     "more_info": "Więcej informacji",
     "timing.attribute_header": "Atrybut",
     "timing.travel_attribute_header": "Atrybut",

--- a/custom_components/cover_time_based/websocket_api.py
+++ b/custom_components/cover_time_based/websocket_api.py
@@ -25,6 +25,7 @@ from .cover import (
     CONF_PULSE_TIME,
     CONF_RELAY_REPORTS_OFF,
     CONF_SAFE_TILT_POSITION,
+    CONF_SEND_ENDPOINT_STOP,
     CONF_STOP_SWITCH_ENTITY_ID,
     CONF_ENDPOINT_RUNON_TIME,
     CONF_TILT_CLOSE_SWITCH,
@@ -48,6 +49,7 @@ from .cover import (
     DEFAULT_IGNORE_REPORTED_POSITION,
     DEFAULT_PULSE_TIME,
     DEFAULT_RELAY_REPORTS_OFF,
+    DEFAULT_SEND_ENDPOINT_STOP,
 )
 from .const import DOMAIN
 from .helpers import resolve_entity_or_none
@@ -59,6 +61,7 @@ _FIELD_MAP = {
     "control_mode": CONF_CONTROL_MODE,
     "pulse_time": CONF_PULSE_TIME,
     "relay_reports_off": CONF_RELAY_REPORTS_OFF,
+    "send_endpoint_stop": CONF_SEND_ENDPOINT_STOP,
     "open_switch_entity_id": CONF_OPEN_SWITCH_ENTITY_ID,
     "close_switch_entity_id": CONF_CLOSE_SWITCH_ENTITY_ID,
     "stop_switch_entity_id": CONF_STOP_SWITCH_ENTITY_ID,
@@ -175,6 +178,9 @@ async def ws_get_config(
             "relay_reports_off": options.get(
                 CONF_RELAY_REPORTS_OFF, DEFAULT_RELAY_REPORTS_OFF
             ),
+            "send_endpoint_stop": options.get(
+                CONF_SEND_ENDPOINT_STOP, DEFAULT_SEND_ENDPOINT_STOP
+            ),
             "open_switch_entity_id": options.get(CONF_OPEN_SWITCH_ENTITY_ID),
             "close_switch_entity_id": options.get(CONF_CLOSE_SWITCH_ENTITY_ID),
             "stop_switch_entity_id": options.get(CONF_STOP_SWITCH_ENTITY_ID),
@@ -225,6 +231,7 @@ async def ws_get_config(
             vol.Coerce(float), vol.Range(min=0.1, max=10)
         ),
         vol.Optional("relay_reports_off"): vol.Any(None, bool),
+        vol.Optional("send_endpoint_stop"): vol.Any(None, bool),
         vol.Optional("open_switch_entity_id"): vol.Any(str, None),
         vol.Optional("close_switch_entity_id"): vol.Any(str, None),
         vol.Optional("stop_switch_entity_id"): vol.Any(str, None),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,7 @@ from custom_components.cover_time_based.const import (
     CONF_CLOSE_INCLUDES_TILT,
     CONF_FORCE_TIME_BASED_POSITION,
     CONF_IGNORE_REPORTED_POSITION,
+    CONF_SEND_ENDPOINT_STOP,
 )
 
 DEFAULT_TRAVEL_TIME = 30
@@ -87,6 +88,7 @@ def make_cover(make_hass, _mock_position_store):
         close_switch="switch.close",
         stop_switch=None,
         pulse_time=DEFAULT_PULSE_TIME,
+        send_endpoint_stop=None,
         travel_time_close=DEFAULT_TRAVEL_TIME,
         travel_time_open=DEFAULT_TRAVEL_TIME,
         tilt_time_close=None,
@@ -155,6 +157,8 @@ def make_cover(make_hass, _mock_position_store):
             options[CONF_SAFE_TILT_POSITION] = safe_tilt_position
         if max_tilt_allowed_position is not None:
             options[CONF_MAX_TILT_ALLOWED_POSITION] = max_tilt_allowed_position
+        if send_endpoint_stop is not None:
+            options[CONF_SEND_ENDPOINT_STOP] = send_endpoint_stop
         if close_includes_tilt is not None:
             options[CONF_CLOSE_INCLUDES_TILT] = close_includes_tilt
         if ignore_reported_position is not None:

--- a/tests/frontend/card_render.test.mjs
+++ b/tests/frontend/card_render.test.mjs
@@ -539,10 +539,17 @@ test("switch mode timing table includes endpoint_runon_time row (5 travel rows: 
   expect(inputs.length).toBe(5);
 });
 
-test("non-switch mode (pulse) timing table does NOT include endpoint_runon_time (4 travel rows)", async () => {
-  card = await mountCard(makeHass(), { selectedEntity: "cover.x", config: pulseCfg(), activeTab: "timing" });
+test("pulse mode with send_endpoint_stop off timing table does NOT include endpoint_runon_time (4 travel rows)", async () => {
+  // Pulse covers that send the endpoint stop (default) DO show the run-on row;
+  // only when send_endpoint_stop is off does pulse self-stop at endpoints and
+  // hide it. See send_endpoint_stop.test.mjs for the full gating matrix.
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: pulseCfg({ send_endpoint_stop: false }),
+    activeTab: "timing",
+  });
   const inputs = card.shadowRoot.querySelectorAll("input.timing-input");
-  // pulse mode: travel_time_close, travel_time_open, travel_startup_delay, min_movement_time (no endpoint_runon)
+  // pulse w/stop-off: travel_time_close, travel_time_open, travel_startup_delay, min_movement_time (no endpoint_runon)
   expect(inputs.length).toBe(4);
 });
 

--- a/tests/frontend/send_endpoint_stop.test.mjs
+++ b/tests/frontend/send_endpoint_stop.test.mjs
@@ -1,0 +1,163 @@
+/**
+ * send_endpoint_stop (pulse-mode endpoint stop) UI — issue #133.
+ *
+ * The toggle renders ONLY for pulse mode (mirroring how relay_reports_off
+ * renders only for toggle mode). The endpoint run-on timing row shows for
+ * switch mode and for pulse-with-stop-on, and is hidden for
+ * pulse-with-stop-off / toggle / wrapped.
+ *
+ * Run: npm run test:fe -- tests/frontend/send_endpoint_stop.test.mjs
+ */
+
+import { test, expect, afterEach, vi } from "vitest";
+import { makeHass } from "./helpers/hass.mjs";
+import { mountCard, defineHaStubs } from "./helpers/mount.mjs";
+
+defineHaStubs();
+let card;
+afterEach(() => {
+  vi.restoreAllMocks();
+  card?.remove();
+  card = null;
+});
+
+const SEND_STOP_LABEL = "Send stop signal at endpoints";
+
+const switchCfg = (over = {}) => ({
+  control_mode: "switch",
+  open_switch_entity_id: "switch.o",
+  close_switch_entity_id: "switch.c",
+  ...over,
+});
+
+const pulseCfg = (over = {}) => ({
+  control_mode: "pulse",
+  open_switch_entity_id: "switch.o",
+  close_switch_entity_id: "switch.c",
+  stop_switch_entity_id: "switch.s",
+  ...over,
+});
+
+const toggleCfg = (over = {}) => ({
+  control_mode: "toggle",
+  open_switch_entity_id: "switch.o",
+  close_switch_entity_id: "switch.c",
+  ...over,
+});
+
+const wrappedCfg = (over = {}) => ({
+  control_mode: "wrapped",
+  cover_entity_id: "cover.real",
+  ...over,
+});
+
+function hasSendStopToggle(card) {
+  const labels = [...card.shadowRoot.querySelectorAll(".toggle-label")];
+  return labels.some((el) => el.textContent.trim() === SEND_STOP_LABEL);
+}
+
+function timingInputCount(card) {
+  return card.shadowRoot.querySelectorAll("input.timing-input").length;
+}
+
+// ---------------------------------------------------------------------------
+// The toggle renders only for pulse mode
+// ---------------------------------------------------------------------------
+
+test("send_endpoint_stop toggle renders for pulse mode (default on)", async () => {
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: pulseCfg(),
+    activeTab: "device",
+  });
+  expect(hasSendStopToggle(card)).toBe(true);
+});
+
+test("send_endpoint_stop toggle still renders for pulse mode when stored false", async () => {
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: pulseCfg({ send_endpoint_stop: false }),
+    activeTab: "device",
+  });
+  expect(hasSendStopToggle(card)).toBe(true);
+});
+
+test("send_endpoint_stop toggle does NOT render for switch mode", async () => {
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: switchCfg(),
+    activeTab: "device",
+  });
+  expect(hasSendStopToggle(card)).toBe(false);
+});
+
+test("send_endpoint_stop toggle does NOT render for toggle mode", async () => {
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: toggleCfg(),
+    activeTab: "device",
+  });
+  expect(hasSendStopToggle(card)).toBe(false);
+});
+
+test("send_endpoint_stop toggle does NOT render for wrapped mode", async () => {
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: wrappedCfg(),
+    activeTab: "device",
+  });
+  expect(hasSendStopToggle(card)).toBe(false);
+});
+
+// ---------------------------------------------------------------------------
+// Endpoint run-on row gating
+//   switch mode  → 5 rows (incl. endpoint_runon_time)
+//   pulse w/stop-on (default) → 5 rows (endpoint_runon_time shown)
+//   pulse w/stop-off → 4 rows (endpoint_runon_time hidden)
+//   toggle / wrapped → 4 rows (endpoint_runon_time hidden)
+// ---------------------------------------------------------------------------
+
+test("switch mode shows the endpoint run-on row (5 travel rows)", async () => {
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: switchCfg(),
+    activeTab: "timing",
+  });
+  expect(timingInputCount(card)).toBe(5);
+});
+
+test("pulse mode with stop on (default) shows the endpoint run-on row (5 travel rows)", async () => {
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: pulseCfg(),
+    activeTab: "timing",
+  });
+  expect(timingInputCount(card)).toBe(5);
+});
+
+test("pulse mode with stop OFF hides the endpoint run-on row (4 travel rows)", async () => {
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: pulseCfg({ send_endpoint_stop: false }),
+    activeTab: "timing",
+  });
+  expect(timingInputCount(card)).toBe(4);
+});
+
+test("toggle mode hides the endpoint run-on row (4 travel rows)", async () => {
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: toggleCfg(),
+    activeTab: "timing",
+  });
+  expect(timingInputCount(card)).toBe(4);
+});
+
+test("wrapped mode hides the endpoint run-on row (4 travel rows)", async () => {
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: wrappedCfg(),
+    activeTab: "timing",
+  });
+  expect(timingInputCount(card)).toBe(4);
+});

--- a/tests/test_send_endpoint_stop.py
+++ b/tests/test_send_endpoint_stop.py
@@ -19,7 +19,7 @@ import asyncio
 import pytest
 from unittest.mock import patch
 
-from homeassistant.const import SERVICE_CLOSE_COVER
+from homeassistant.const import SERVICE_CLOSE_COVER, SERVICE_OPEN_COVER
 
 from custom_components.cover_time_based.cover import (
     CONTROL_MODE_PULSE,
@@ -44,6 +44,15 @@ def _ha_calls(cover):
         c
         for c in cover.hass.services.async_call.call_args_list
         if c.args[0] == "homeassistant"
+    ]
+
+
+def _relay_turn_on(cover, entity_id):
+    """homeassistant.turn_on calls targeting a specific relay entity."""
+    return [
+        c
+        for c in _ha_calls(cover)
+        if c.args[1] == "turn_on" and c.args[2].get("entity_id") == entity_id
     ]
 
 
@@ -106,6 +115,28 @@ async def test_option_off_pulse_skips_endpoint_stop(make_cover):
 
 
 @pytest.mark.asyncio
+async def test_option_off_pulse_skips_endpoint_stop_at_open(make_cover):
+    """The #133 fix applies at the open (100%) endpoint too, not only close (0%) —
+    both 0/100 go through the same self-stop path."""
+    cover = _make_pulse(make_cover, send_endpoint_stop=False, endpoint_runon_time=2.0)
+    cover._self_initiated_movement = True
+    cover._last_command = SERVICE_OPEN_COVER
+    cover.travel_calc.set_position(100)
+
+    cover.hass.services.async_call.reset_mock()
+    with patch.object(cover, "async_write_ha_state"):
+        await cover.auto_stop_if_necessary()
+
+    assert _ha_calls(cover) == [], (
+        "option off must skip the open-endpoint stop too (#133)"
+    )
+    assert cover._delay_task is None, (
+        "option off must not schedule run-on at the open endpoint"
+    )
+    await _cancel_tasks(cover)
+
+
+@pytest.mark.asyncio
 async def test_option_off_pulse_mid_travel_still_stops(make_cover):
     """send_endpoint_stop=False only suppresses the stop AT an endpoint — a
     mid-travel stop (nothing self-stops there) must still pulse the stop relay."""
@@ -118,11 +149,7 @@ async def test_option_off_pulse_mid_travel_still_stops(make_cover):
     with patch.object(cover, "async_write_ha_state"):
         await cover.auto_stop_if_necessary()
 
-    stop_on = [
-        c
-        for c in _ha_calls(cover)
-        if c.args[1] == "turn_on" and c.args[2].get("entity_id") == "switch.stop"
-    ]
+    stop_on = _relay_turn_on(cover, "switch.stop")
     assert stop_on, "mid-travel stop must still pulse the stop relay"
     await _cancel_tasks(cover)
 
@@ -164,11 +191,7 @@ async def test_option_off_pulse_dual_motor_skips_tilt_endpoint_stop(make_cover):
 
     await _run_tilt_move(cover, 100)  # tilt to its open endpoint
 
-    tilt_stop_on = [
-        c
-        for c in _ha_calls(cover)
-        if c.args[1] == "turn_on" and c.args[2].get("entity_id") == "switch.tilt_stop"
-    ]
+    tilt_stop_on = _relay_turn_on(cover, "switch.tilt_stop")
     assert tilt_stop_on == [], "option off must skip the tilt endpoint stop (#133)"
     await _cancel_tasks(cover)
 
@@ -183,11 +206,7 @@ async def test_default_pulse_dual_motor_pulses_tilt_endpoint_stop(make_cover):
 
     await _run_tilt_move(cover, 100)  # tilt to its open endpoint
 
-    tilt_stop_on = [
-        c
-        for c in _ha_calls(cover)
-        if c.args[1] == "turn_on" and c.args[2].get("entity_id") == "switch.tilt_stop"
-    ]
+    tilt_stop_on = _relay_turn_on(cover, "switch.tilt_stop")
     assert tilt_stop_on, "default pulse must pulse the tilt endpoint stop (#129)"
     await _cancel_tasks(cover)
 
@@ -214,11 +233,7 @@ async def test_option_on_pulse_defers_endpoint_stop_by_runon(make_cover):
         "option on must defer the endpoint stop by the run-on time"
     )
     # The immediate stop relay must NOT have fired yet (it is deferred).
-    stop_on = [
-        c
-        for c in _ha_calls(cover)
-        if c.args[1] == "turn_on" and c.args[2].get("entity_id") == "switch.stop"
-    ]
+    stop_on = _relay_turn_on(cover, "switch.stop")
     assert stop_on == [], "the deferred stop must not fire immediately"
     await _cancel_tasks(cover)
 
@@ -232,7 +247,9 @@ async def test_option_on_pulse_defers_endpoint_stop_by_runon(make_cover):
 async def test_toggle_ignores_send_endpoint_stop(make_cover):
     """Toggle mode always self-stops at endpoints regardless of the option, which
     it does not even accept."""
-    cover = make_cover(control_mode=CONTROL_MODE_TOGGLE)
+    # Pass the option explicitly to prove non-pulse modes ignore it even when set
+    # (e.g. a stale value left in options after switching away from pulse mode).
+    cover = make_cover(control_mode=CONTROL_MODE_TOGGLE, send_endpoint_stop=False)
     assert cover._self_stops_at_endpoints() is True
 
 
@@ -240,7 +257,7 @@ async def test_toggle_ignores_send_endpoint_stop(make_cover):
 async def test_wrapped_ignores_send_endpoint_stop(make_cover):
     """A wrapped (non-native-position) cover self-stops at endpoints regardless
     of the option."""
-    cover = make_cover(cover_entity_id="cover.inner")
+    cover = make_cover(cover_entity_id="cover.inner", send_endpoint_stop=False)
     assert cover._self_stops_at_endpoints() is True
 
 
@@ -248,5 +265,5 @@ async def test_wrapped_ignores_send_endpoint_stop(make_cover):
 async def test_switch_ignores_send_endpoint_stop(make_cover):
     """Switch mode never self-stops at endpoints (latched relay) regardless of
     the option."""
-    cover = make_cover(control_mode=CONTROL_MODE_SWITCH)
+    cover = make_cover(control_mode=CONTROL_MODE_SWITCH, send_endpoint_stop=False)
     assert cover._self_stops_at_endpoints() is False

--- a/tests/test_send_endpoint_stop.py
+++ b/tests/test_send_endpoint_stop.py
@@ -1,0 +1,252 @@
+"""Configurable endpoint stop for pulse mode (issue #133).
+
+"Pulse mode" serves two physically opposite momentary controllers:
+
+- A **latching** controller (issue #129) keeps running until it receives a
+  dedicated stop pulse — it MUST get the endpoint stop or it stays stuck
+  "moving". This is the default (``send_endpoint_stop=True``).
+- An **auto-stop** controller (issue #133) halts itself at its 0%/100% limits;
+  a stop pulse received while already stopped is read as "go to favourite",
+  repositioning the cover. For this hardware the endpoint stop is harmful and
+  must be skipped (``send_endpoint_stop=False``).
+
+These tests pin the per-cover ``send_endpoint_stop`` option that selects
+between the two, mirroring the toggle-mode ``relay_reports_off`` option.
+"""
+
+import asyncio
+
+import pytest
+from unittest.mock import patch
+
+from homeassistant.const import SERVICE_CLOSE_COVER
+
+from custom_components.cover_time_based.cover import (
+    CONTROL_MODE_PULSE,
+    CONTROL_MODE_SWITCH,
+    CONTROL_MODE_TOGGLE,
+)
+
+
+async def _cancel_tasks(cover):
+    tasks = getattr(cover.hass, "_test_tasks", [])
+    for task in tasks:
+        if not task.done():
+            task.cancel()
+    if tasks:
+        await asyncio.gather(*tasks, return_exceptions=True)
+        tasks.clear()
+
+
+def _ha_calls(cover):
+    """Relay (homeassistant.turn_on/turn_off) service calls."""
+    return [
+        c
+        for c in cover.hass.services.async_call.call_args_list
+        if c.args[0] == "homeassistant"
+    ]
+
+
+def _make_pulse(make_cover, send_endpoint_stop=None, **kwargs):
+    """Build a pulse cover, optionally setting send_endpoint_stop."""
+    return make_cover(
+        control_mode=CONTROL_MODE_PULSE,
+        stop_switch="switch.stop",
+        send_endpoint_stop=send_endpoint_stop,
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Default sends the endpoint stop (deferred by run-on) — guards #129.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_default_pulse_sends_endpoint_stop(make_cover):
+    """Default (option unset) pulse cover at an endpoint still pulses its stop
+    relay (deferred by run-on) — the #129 behaviour, unchanged."""
+    cover = _make_pulse(make_cover, endpoint_runon_time=2.0)
+    assert cover._self_stops_at_endpoints() is False
+    cover._self_initiated_movement = True
+    cover._last_command = SERVICE_CLOSE_COVER
+    cover.travel_calc.set_position(0)
+
+    with patch.object(cover, "async_write_ha_state"):
+        await cover.auto_stop_if_necessary()
+
+    assert cover._delay_task is not None, (
+        "default pulse must defer the endpoint stop to the run-on timer (#129)"
+    )
+    await _cancel_tasks(cover)
+
+
+# ---------------------------------------------------------------------------
+# 2. Option off skips the endpoint stop, but a mid-travel stop still fires.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_option_off_pulse_skips_endpoint_stop(make_cover):
+    """With send_endpoint_stop=False the pulse cover behaves as self-stopping:
+    reaching an endpoint fires NO relay stop and schedules no run-on (#133)."""
+    cover = _make_pulse(make_cover, send_endpoint_stop=False, endpoint_runon_time=2.0)
+    assert cover._self_stops_at_endpoints() is True
+    cover._self_initiated_movement = True
+    cover._last_command = SERVICE_CLOSE_COVER
+    cover.travel_calc.set_position(0)
+
+    cover.hass.services.async_call.reset_mock()
+    with patch.object(cover, "async_write_ha_state"):
+        await cover.auto_stop_if_necessary()
+
+    assert _ha_calls(cover) == [], "option off must send no endpoint stop pulse (#133)"
+    assert cover._delay_task is None, "option off must not schedule run-on at endpoint"
+    await _cancel_tasks(cover)
+
+
+@pytest.mark.asyncio
+async def test_option_off_pulse_mid_travel_still_stops(make_cover):
+    """send_endpoint_stop=False only suppresses the stop AT an endpoint — a
+    mid-travel stop (nothing self-stops there) must still pulse the stop relay."""
+    cover = _make_pulse(make_cover, send_endpoint_stop=False, endpoint_runon_time=0)
+    cover._self_initiated_movement = True
+    cover._last_command = SERVICE_CLOSE_COVER
+    cover.travel_calc.set_position(50)  # mid-travel, not an endpoint
+
+    cover.hass.services.async_call.reset_mock()
+    with patch.object(cover, "async_write_ha_state"):
+        await cover.auto_stop_if_necessary()
+
+    stop_on = [
+        c
+        for c in _ha_calls(cover)
+        if c.args[1] == "turn_on" and c.args[2].get("entity_id") == "switch.stop"
+    ]
+    assert stop_on, "mid-travel stop must still pulse the stop relay"
+    await _cancel_tasks(cover)
+
+
+# ---------------------------------------------------------------------------
+# 3. Tilt endpoint follows the flag (dual-motor pulse).
+# ---------------------------------------------------------------------------
+
+
+def _make_pulse_dual_motor(make_cover, send_endpoint_stop=None):
+    return make_cover(
+        control_mode=CONTROL_MODE_PULSE,
+        stop_switch="switch.stop",
+        send_endpoint_stop=send_endpoint_stop,
+        tilt_time_close=2.0,
+        tilt_time_open=2.0,
+        tilt_mode="dual_motor",
+        tilt_open_switch="switch.tilt_open",
+        tilt_close_switch="switch.tilt_close",
+        tilt_stop_switch="switch.tilt_stop",
+    )
+
+
+async def _run_tilt_move(cover, target):
+    with patch.object(cover, "async_write_ha_state"):
+        await cover.set_tilt_position(target)
+        cover.hass.services.async_call.reset_mock()
+        cover.tilt_calc.set_position(target)
+        await cover.auto_stop_if_necessary()
+
+
+@pytest.mark.asyncio
+async def test_option_off_pulse_dual_motor_skips_tilt_endpoint_stop(make_cover):
+    """With the option off, a pulse dual-motor cover skips the tilt-stop relay at
+    a tilt endpoint (the same flag gates _tilt_settle)."""
+    cover = _make_pulse_dual_motor(make_cover, send_endpoint_stop=False)
+    cover.travel_calc.set_position(50)  # mid-travel: isolate tilt
+    cover.tilt_calc.set_position(0)
+
+    await _run_tilt_move(cover, 100)  # tilt to its open endpoint
+
+    tilt_stop_on = [
+        c
+        for c in _ha_calls(cover)
+        if c.args[1] == "turn_on" and c.args[2].get("entity_id") == "switch.tilt_stop"
+    ]
+    assert tilt_stop_on == [], "option off must skip the tilt endpoint stop (#133)"
+    await _cancel_tasks(cover)
+
+
+@pytest.mark.asyncio
+async def test_default_pulse_dual_motor_pulses_tilt_endpoint_stop(make_cover):
+    """With the option on (default), a pulse dual-motor cover still pulses its
+    tilt-stop relay at a tilt endpoint — the tilt twin of #129."""
+    cover = _make_pulse_dual_motor(make_cover)  # option unset → default on
+    cover.travel_calc.set_position(50)  # mid-travel: isolate tilt
+    cover.tilt_calc.set_position(0)
+
+    await _run_tilt_move(cover, 100)  # tilt to its open endpoint
+
+    tilt_stop_on = [
+        c
+        for c in _ha_calls(cover)
+        if c.args[1] == "turn_on" and c.args[2].get("entity_id") == "switch.tilt_stop"
+    ]
+    assert tilt_stop_on, "default pulse must pulse the tilt endpoint stop (#129)"
+    await _cancel_tasks(cover)
+
+
+# ---------------------------------------------------------------------------
+# 4. Run-on still applies when the option is on.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_option_on_pulse_defers_endpoint_stop_by_runon(make_cover):
+    """With the option on and a run-on time set, the endpoint stop is deferred by
+    that run-on, not fired immediately (a _delay_task is scheduled)."""
+    cover = _make_pulse(make_cover, send_endpoint_stop=True, endpoint_runon_time=2.0)
+    cover._self_initiated_movement = True
+    cover._last_command = SERVICE_CLOSE_COVER
+    cover.travel_calc.set_position(0)
+
+    cover.hass.services.async_call.reset_mock()
+    with patch.object(cover, "async_write_ha_state"):
+        await cover.auto_stop_if_necessary()
+
+    assert cover._delay_task is not None, (
+        "option on must defer the endpoint stop by the run-on time"
+    )
+    # The immediate stop relay must NOT have fired yet (it is deferred).
+    stop_on = [
+        c
+        for c in _ha_calls(cover)
+        if c.args[1] == "turn_on" and c.args[2].get("entity_id") == "switch.stop"
+    ]
+    assert stop_on == [], "the deferred stop must not fire immediately"
+    await _cancel_tasks(cover)
+
+
+# ---------------------------------------------------------------------------
+# 5. Other modes unchanged — toggle and wrapped ignore the option.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_toggle_ignores_send_endpoint_stop(make_cover):
+    """Toggle mode always self-stops at endpoints regardless of the option, which
+    it does not even accept."""
+    cover = make_cover(control_mode=CONTROL_MODE_TOGGLE)
+    assert cover._self_stops_at_endpoints() is True
+
+
+@pytest.mark.asyncio
+async def test_wrapped_ignores_send_endpoint_stop(make_cover):
+    """A wrapped (non-native-position) cover self-stops at endpoints regardless
+    of the option."""
+    cover = make_cover(cover_entity_id="cover.inner")
+    assert cover._self_stops_at_endpoints() is True
+
+
+@pytest.mark.asyncio
+async def test_switch_ignores_send_endpoint_stop(make_cover):
+    """Switch mode never self-stops at endpoints (latched relay) regardless of
+    the option."""
+    cover = make_cover(control_mode=CONTROL_MODE_SWITCH)
+    assert cover._self_stops_at_endpoints() is False

--- a/tests/test_websocket_api.py
+++ b/tests/test_websocket_api.py
@@ -12,6 +12,7 @@ from custom_components.cover_time_based.cover import (
     CONF_OPEN_SWITCH_ENTITY_ID,
     CONF_PULSE_TIME,
     CONF_RELAY_REPORTS_OFF,
+    CONF_SEND_ENDPOINT_STOP,
     CONF_STOP_SWITCH_ENTITY_ID,
     CONF_TILT_CLOSE_SWITCH,
     CONF_TILT_MODE,
@@ -532,6 +533,84 @@ class TestRelayReportsOffRoundTrip:
 
         new_options = hass.config_entries.async_update_entry.call_args[1]["options"]
         assert new_options[CONF_RELAY_REPORTS_OFF] is False
+
+
+class TestSendEndpointStopRoundTrip:
+    """send_endpoint_stop is returned in get_config and saved in update_config."""
+
+    @pytest.mark.asyncio
+    async def test_get_config_defaults_to_true(self):
+        hass, _, entity_reg = _make_hass(options={})
+        conn = _make_connection()
+
+        with patch(
+            "custom_components.cover_time_based.websocket_api.er.async_get",
+            return_value=entity_reg,
+        ):
+            await _ws_get_config(
+                hass,
+                conn,
+                {
+                    "id": 1,
+                    "type": "cover_time_based/get_config",
+                    "entity_id": ENTITY_ID,
+                },
+            )
+
+        result = conn.send_result.call_args[0][1]
+        assert result["send_endpoint_stop"] is True
+
+    @pytest.mark.asyncio
+    async def test_get_config_returns_stored_false(self):
+        hass, _, entity_reg = _make_hass(
+            options={
+                CONF_CONTROL_MODE: CONTROL_MODE_PULSE,
+                CONF_SEND_ENDPOINT_STOP: False,
+            }
+        )
+        conn = _make_connection()
+
+        with patch(
+            "custom_components.cover_time_based.websocket_api.er.async_get",
+            return_value=entity_reg,
+        ):
+            await _ws_get_config(
+                hass,
+                conn,
+                {
+                    "id": 1,
+                    "type": "cover_time_based/get_config",
+                    "entity_id": ENTITY_ID,
+                },
+            )
+
+        result = conn.send_result.call_args[0][1]
+        assert result["send_endpoint_stop"] is False
+
+    @pytest.mark.asyncio
+    async def test_update_config_saves_false(self):
+        hass, _, entity_reg = _make_hass(
+            options={CONF_CONTROL_MODE: CONTROL_MODE_PULSE}
+        )
+        conn = _make_connection()
+
+        with patch(
+            "custom_components.cover_time_based.websocket_api.er.async_get",
+            return_value=entity_reg,
+        ):
+            await _ws_update_config(
+                hass,
+                conn,
+                {
+                    "id": 1,
+                    "type": "cover_time_based/update_config",
+                    "entity_id": ENTITY_ID,
+                    "send_endpoint_stop": False,
+                },
+            )
+
+        new_options = hass.config_entries.async_update_entry.call_args[1]["options"]
+        assert new_options[CONF_SEND_ENDPOINT_STOP] is False
 
 
 class TestAssumedStateRoundTrip:


### PR DESCRIPTION
Fixes #133.

## Problem
"Pulse" mode serves two physically opposite momentary controllers, and v4.5.3 (#130) made the endpoint stop **unconditional** — right for one, wrong for the other:
- **#129 (latching controller):** keeps running until it receives a dedicated stop pulse → **needs** the endpoint stop.
- **#133 (auto-stop controller):** self-stops at its 0%/100% limits, and a stop pulse received *while already stopped* is read as "go to favourite/preset position" (Somfy *my* behaviour) → every limit hit **repositions** the cover.

Run-on timing can't fix this: the motor has already self-stopped, so *any* stop pulse arrives "while stopped". The fix is to make the endpoint stop a per-cover option.

## Change
New per-cover boolean **`send_endpoint_stop`** (default `True`), **pulse mode only**, wired exactly like the existing toggle-mode `relay_reports_off`:
- `PulseModeCover._self_stops_at_endpoints()` now returns `not self._send_endpoint_stop` (was hardcoded `False`).
- Default `True` → sends the endpoint stop (today's v4.5.3 behaviour, **#129 stays fixed out of the box**). Off → skips it (the **#133 fix**). The same flag governs a dedicated **tilt-stop** relay.
- Card toggle ("Send stop signal at endpoints", EN/PT/PL); the **Endpoint run-on time** row is now also shown for pulse covers that send the stop.
- Threaded through `const.py`, `cover.py` (schema + factory + YAML), `websocket_api.py`.

## Default
`True` preserves the v4.5.3 (now on "latest") behaviour — no currently-working cover changes; auto-stop users opt out.

## Tests & docs
- New backend suite (default sends / off skips at **both** 0% and 100% / mid-travel still stops / dual-motor tilt on+off / run-on still defers / switch+toggle+wrapped ignore the option) + websocket round-trip; frontend gating matrix for all 5 modes. Full suite green (ruff, pytest+coverage, vitest).
- README: new "Send stop signal at endpoints (Pulse mode)" subsection + YAML option row, and corrected the endpoint/run-on/tilt prose that still described pre-4.5.3 behaviour. CHANGELOG `## Unreleased` entry added.