### PR TITLE
fix: send stop for inline tilt at a travel endpoint in self-stopping modes (#142)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Fixes
+
+- **Inline tilt at a parked endpoint no longer rolls the cover fully open/closed** ([#142](https://github.com/Sese-Schneider/ha-cover-time-based/issues/142)): the companion to [#125](https://github.com/Sese-Schneider/ha-cover-time-based/issues/125). In **inline** tilt mode the slats are articulated by the main travel motor, so a tilt move adjusting the slats while the cover is parked at a travel endpoint (fully open or fully closed) drives the motor *off* its limit switch. #125 fixed the run-on overshoot for **Switch** mode, but the self-stopping modes (**Toggle**, **Pulse** and **wrapped** covers) took a different branch: at an endpoint they skip the stop entirely, assuming the motor is still seated against its physical limit and self-stops there. For a tilt move that assumption is wrong — the motor has just been driven off the limit — so the stop was never sent and the cover ran on to the full endpoint (e.g. tilting the slats open while fully closed rolled the blind all the way up). The stop is now sent for tilt moves at an endpoint in these modes (mirroring the run-on exclusion #125 added), so the motor stops at the requested tilt; real *travel* moves to an endpoint still skip the redundant stop as before.
+
 ## 4.7.0 (2026-06-29)
 
 ### Features

--- a/custom_components/cover_time_based/cover_base.py
+++ b/custom_components/cover_time_based/cover_base.py
@@ -1447,6 +1447,16 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
                 return
 
             current_travel = self.travel_calc.current_position()
+            # Endpoint handling (the self-stop skip and the run-on below) is a
+            # *travel* concept: it only applies when a travel move reaches a
+            # physical limit. A tilt move that merely finishes while the cover is
+            # parked at a travel endpoint has driven the motor *off* that limit
+            # to articulate the slats, so the motor will NOT self-stop there and
+            # must always be stopped explicitly — never given the self-stop skip
+            # (issue #142) or the run-on (issue #125).
+            endpoint_applies = (
+                self._at_endpoint(current_travel) and not self._moving_tilt
+            )
             if self._motor_stops_itself():
                 # The device drives to the target and holds there on its own
                 # (e.g. a wrapped cover commanded via set_cover_position). Any
@@ -1461,7 +1471,7 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
                 # travel stop below and re-pulse the travel relay off a stale
                 # _last_command.
                 await self._tilt_settle()
-            elif self._at_endpoint(current_travel) and self._self_stops_at_endpoints():
+            elif endpoint_applies and self._self_stops_at_endpoints():
                 # The motor self-stops at its physical limit switch. Sending a
                 # stop here is redundant (and for toggle re-pulses → restart),
                 # so skip the relay stop and any run-on; just settle the
@@ -1472,8 +1482,7 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
                     current_travel,
                 )
             elif (
-                self._at_endpoint(current_travel)
-                and not self._moving_tilt
+                endpoint_applies
                 and self._endpoint_runon_time is not None
                 and self._endpoint_runon_time > 0
             ):

--- a/tests/test_endpoint_self_stop.py
+++ b/tests/test_endpoint_self_stop.py
@@ -845,3 +845,84 @@ async def test_stop_during_tilt_then_travel_still_runs_on(make_cover):
         "travel run-on must fire after a tilt move was committed then stopped"
     )
     await _cancel_tasks(cover)
+
+
+# ===================================================================
+# Inline tilt at a travel endpoint, self-stopping modes (issue #142)
+#
+# #125 (above) fixed inline tilt at an endpoint for the *latched* modes
+# (switch), whose _self_stops_at_endpoints() is False — those hit the
+# run-on branch. The *self-stopping* modes (toggle/pulse/wrapped), whose
+# _self_stops_at_endpoints() is True, hit the earlier self-stop branch,
+# which skipped the stop on the assumption the motor sits against its
+# limit. But an inline tilt move drives the motor *off* the limit to
+# articulate the slats, so it does NOT self-stop — skipping the stop
+# lets it run on to the full endpoint (the cover rolls all the way
+# up/down instead of just tilting).
+# ===================================================================
+
+
+@pytest.mark.asyncio
+async def test_inline_tilt_at_closed_endpoint_self_stopping_mode_stops(make_cover):
+    """Toggle + inline: tilting open while parked fully closed drives the motor
+    off the bottom limit, so it won't self-stop — the stop must be sent (a
+    toggle re-pulse) or the cover rolls all the way up (issue #142)."""
+    cover = _make_inline(make_cover, CONTROL_MODE_TOGGLE)
+    cover.travel_calc.set_position(0)  # parked fully closed (a travel endpoint)
+    cover.tilt_calc.set_position(0)
+
+    with patch.object(cover, "async_write_ha_state"):
+        await cover.set_tilt_position(50)  # tilt open, off the closed endpoint
+        cover.hass.services.async_call.reset_mock()
+        cover.tilt_calc.set_position(50)  # tilt reaches its 50% target
+        await cover.auto_stop_if_necessary()
+
+    on_calls = [c for c in _ha_calls(cover) if c.args[1] == "turn_on"]
+    assert on_calls, (
+        "inline tilt at a travel endpoint must stop the motor — it was driven "
+        "off the limit and won't self-stop (issue #142)"
+    )
+    await _cancel_tasks(cover)
+
+
+@pytest.mark.asyncio
+async def test_inline_tilt_at_open_endpoint_self_stopping_mode_stops(make_cover):
+    """The same bug bites at the open endpoint: tilting closed while parked
+    fully open drives the motor off the top limit and must be stopped, or the
+    cover rolls all the way down (issue #142)."""
+    cover = _make_inline(make_cover, CONTROL_MODE_TOGGLE)
+    cover.travel_calc.set_position(100)  # parked fully open (a travel endpoint)
+    cover.tilt_calc.set_position(100)
+
+    with patch.object(cover, "async_write_ha_state"):
+        await cover.set_tilt_position(50)  # tilt closed, off the open endpoint
+        cover.hass.services.async_call.reset_mock()
+        cover.tilt_calc.set_position(50)
+        await cover.auto_stop_if_necessary()
+
+    on_calls = [c for c in _ha_calls(cover) if c.args[1] == "turn_on"]
+    assert on_calls, "inline tilt at the open endpoint must stop the motor (issue #142)"
+    await _cancel_tasks(cover)
+
+
+@pytest.mark.asyncio
+async def test_inline_travel_to_endpoint_self_stopping_mode_skips_stop(make_cover):
+    """The fix is tilt-move only: a real *travel* move to an endpoint in a
+    self-stopping mode must still skip the stop (the motor self-stops at its
+    limit; a toggle re-pulse would restart it — issue #105)."""
+    cover = _make_inline(make_cover, CONTROL_MODE_TOGGLE)
+    cover.travel_calc.set_position(50)
+    cover.tilt_calc.set_position(0)  # already at the closing tilt endpoint
+
+    with patch.object(cover, "async_write_ha_state"):
+        await cover.set_position(0)  # pure travel to fully closed
+        cover.hass.services.async_call.reset_mock()
+        cover.travel_calc.set_position(0)
+        cover.tilt_calc.set_position(0)
+        await cover.auto_stop_if_necessary()
+
+    assert _ha_calls(cover) == [], (
+        "a travel move to an endpoint must still self-stop (no re-pulse)"
+    )
+    assert cover._delay_task is None
+    await _cancel_tasks(cover)


### PR DESCRIPTION
## Summary

Fixes #142. In **inline** tilt mode the slats are articulated by the main travel motor, so a tilt move drives the travel relay. When the cover is parked at a travel endpoint (fully open/closed) — the usual case when adjusting slats — the tilt move drives the motor *off* its limit switch, so it will **not** self-stop there.

The self-stopping relay modes (**Toggle**, **Pulse**, **wrapped** — `_self_stops_at_endpoints()` True) took the endpoint **self-stop** branch in `auto_stop_if_necessary`, which skips the relay stop on the assumption the motor is seated against its physical limit. For a tilt move that assumption is wrong, so the stop was never sent and the cover ran on to the full endpoint — e.g. tilting the slats open while fully closed rolled the blind all the way up.

This is the direct companion to #125, which fixed the analogous overshoot for **Switch** mode in the adjacent **run-on** branch (by excluding tilt moves with `not self._moving_tilt`). #125 added that guard to the run-on branch only; the self-stop branch — the one the momentary/delegated modes take — never got it.

## The fix

Hoist the tilt-exclusion into a single shared predicate and gate both endpoint branches on it:

```python
endpoint_applies = self._at_endpoint(current_travel) and not self._moving_tilt
```

A tilt move at a travel endpoint now falls through to the explicit stop. Real **travel** moves to an endpoint still skip the redundant stop (a toggle re-pulse would restart the motor — #105). Dual-motor tilt is unaffected (handled by its own earlier `_moving_tilt_motor` branch). The change is behaviour-preserving for the run-on branch.

## Tests

- Inline tilt at the **closed** endpoint in a self-stopping mode must send the stop (issue #142).
- Inline tilt at the **open** endpoint must send the stop too (symmetric).
- Regression guard: a real **travel** move to an endpoint still skips the stop.

The reporter independently identified the same one-line condition; this PR generalises it (shared predicate, both branches) and adds the missing test coverage for inline tilt on self-stopping modes.

Full suite: 1096 passing; ruff format + check clean.