### PR TITLE
ci: drop the always-failing auto-bump job from release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,7 @@ name: Release
 # Publishes a GitHub Release when a v* tag is pushed (HACS reads GitHub
 # releases). Every release is published as a PRE-RELEASE (and off "latest") so a
 # new version is never served to the default / HACS channel before it has been
-# tested — promote it to a full release later (step 4). For final-version tags
-# (no -alpha/-beta/-rc suffix) it then rolls main forward to the next minor so
-# unreleased work no longer carries the just-released version.
+# tested — promote it to a full release later (step 4).
 #
 # Release flow:
 #   1. bin/release.sh <version>  -> opens the chore/release PR (bumps manifest)
@@ -13,10 +11,12 @@ name: Release
 #   3. git tag v<version> && git push <remote> v<version>  -> triggers this workflow
 #   4. test the pre-release, then promote it to the latest full release:
 #        gh release edit v<version> --prerelease=false --latest=true
+#   5. roll main forward to the next minor for development:
+#        bin/bump-dev.sh   (opens a PR; merge it)
 #
-# The next-minor bump is pushed directly to main with the default GITHUB_TOKEN;
-# where main is protected that push is rejected — run bin/bump-dev.sh to land the
-# same bump via a PR instead.
+# This workflow does NOT bump main itself. main is protected (PR-only + required
+# checks), so a direct push from the workflow is always rejected — the dev-cycle
+# bump is done as a normal PR via bin/bump-dev.sh (step 5) instead.
 
 on:
   push:
@@ -29,9 +29,6 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     name: Publish GitHub Release
-    outputs:
-      version: ${{ steps.version.outputs.version }}
-      prerelease: ${{ steps.version.outputs.prerelease }}
     steps:
       - uses: actions/checkout@v5
 
@@ -47,7 +44,8 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           # Whether the tag itself is a semver pre-release (-alpha/-beta/-rc).
           # The GitHub Release is always published as a pre-release regardless
-          # (see below); this output only gates the main-forward bump.
+          # (see below); this output only gates whether a missing CHANGELOG
+          # section is fatal (a -alpha/-beta/-rc tag may legitimately have none).
           if [[ "$VERSION" == *-* ]]; then
             echo "prerelease=true" >> "$GITHUB_OUTPUT"
           else
@@ -107,43 +105,3 @@ jobs:
           #   gh release edit v<version> --prerelease=false --latest=true
           prerelease: true
           make_latest: false
-
-  bump:
-    needs: publish
-    # Only final-version tags (no pre-release suffix) roll main forward; an
-    # -alpha/-beta/-rc tag leaves the version alone.
-    if: needs.publish.outputs.prerelease == 'false'
-    runs-on: ubuntu-latest
-    name: Bump main to next minor
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          ref: main
-
-      - name: Compute next minor and bump version files
-        id: bump
-        env:
-          VERSION: ${{ needs.publish.outputs.version }}
-        run: |
-          NEXT=$(python3 -c "import os; mj, mn, _ = os.environ['VERSION'].split('-')[0].split('.'); print(f'{mj}.{int(mn)+1}.0')")
-          echo "next=$NEXT" >> "$GITHUB_OUTPUT"
-          # Same verified bump bin/release.sh uses, so the two can't drift.
-          bin/bump-version.sh "$NEXT"
-
-      - name: Commit and push the bump directly to main
-        env:
-          NEXT: ${{ steps.bump.outputs.next }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -A
-          # No-op guard: if the manifest is already at $NEXT (e.g. a re-run, or
-          # main was hand-bumped), there's nothing to commit — exit cleanly
-          # rather than letting `git commit` fail the job under `set -e`.
-          if git diff --cached --quiet; then
-            echo "manifest already at $NEXT — nothing to bump; skipping commit/push."
-            exit 0
-          fi
-          git commit -m "chore: bump version to $NEXT for development"
-          # main is unprotected, so the default GITHUB_TOKEN can push directly.
-          git push origin HEAD:main

--- a/bin/bump-dev.sh
+++ b/bin/bump-dev.sh
@@ -3,14 +3,13 @@
 #
 # Usage: bin/bump-dev.sh [--no-push]
 #
-# Run this AFTER a release tag is pushed. release.yml normally pushes the
-# next-minor bump straight to main, but this repo's main is protected (PR-only
-# + required status checks), so that direct push is rejected. This helper does
-# the same bump as a PR instead — run it as yourself so CI triggers and the PR
-# is mergeable.
+# Run this AFTER a release tag is pushed. This repo's main is protected (PR-only
+# + required status checks), so the release workflow can't push the next-minor
+# bump itself — this helper lands the same bump as a PR instead. Run it as
+# yourself so CI triggers and the PR is mergeable, then merge it.
 #
-# It mirrors bin/release.sh's preflight and the next-minor formula in
-# .github/workflows/release.yml, so the three can't drift. The branch is
+# It mirrors bin/release.sh's preflight and uses the same verified bump
+# (bin/bump-version.sh), so they can't drift. The branch is
 # deliberately version-less: HACS scans every branch and complains about
 # version numbers in branch names.
 

--- a/bin/bump-version.sh
+++ b/bin/bump-version.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # Bumps the integration version in the manifest, verified.
 #
-# Single source of truth for the version bump, shared by bin/release.sh (local
-# release prep) and .github/workflows/release.yml (post-release next-minor
-# bump), so the two can never drift.
+# Single source of truth for the version bump, shared by bin/release.sh (release
+# prep) and bin/bump-dev.sh (post-release next-minor dev bump), so they can
+# never drift.
 #
 # Usage: bin/bump-version.sh <version>             bump manifest to <version>
 #        bin/bump-version.sh --validate <version>  semver-check only, no writes

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -20,8 +20,9 @@
 #
 # After the PR merges, push the v<version> tag to publish the GitHub Release:
 #   git tag v<version> && git push origin v<version>
-# The release workflow then publishes the release and, for final releases,
-# pushes a follow-up commit bumping main to the next minor (main is unprotected).
+# The release workflow then publishes the release. Roll main forward to the next
+# minor for development separately, via bin/bump-dev.sh (the workflow can't push
+# the bump itself — main is protected).
 #
 # The release branch is deliberately version-less: HACS scans every branch and
 # complains about version numbers in branch names.
@@ -133,8 +134,8 @@ git tag $TAG
 git push origin $TAG
 \`\`\`
 
-The release workflow publishes the GitHub Release and, for final releases,
-rolls \`main\` forward to the next minor.
+The release workflow publishes the GitHub Release. Roll \`main\` forward to the
+next minor for development separately, via bin/bump-dev.sh.
 "
 
 echo "Release $TAG branch pushed and PR opened."

--- a/tests/test_bump_dev_script.py
+++ b/tests/test_bump_dev_script.py
@@ -1,7 +1,7 @@
 """Tests for bin/bump-dev.sh.
 
 Post-release helper that opens a PR rolling main forward to the next minor
-(the dev-cycle bump release.yml can't push directly on a protected main).
+(the dev-cycle bump — main is protected, so the release workflow can't push it).
 
 Invokes the real bash script inside a throwaway git repo in tmp_path. All GIT_*
 env vars are scrubbed so the subprocess git calls operate on the fixture repo


### PR DESCRIPTION
The release workflow's `bump` job pushes the next-minor dev bump **directly to main**, which is **always rejected** on this repo because main is protected (PR-only + required status checks, `GH013`). Every final release published fine, but the workflow run was marked **failed** on the bump job — pure noise.

The dev-cycle bump is already done manually as a PR via `bin/bump-dev.sh` (and self-merged), which is what actually works here. This makes that the documented standard process and removes the failing job.

### Changes
- Remove the `bump` job (and the now-orphaned `publish` job outputs) from `release.yml`.
- Document `bin/bump-dev.sh` as step 5 of the release flow.
- Refresh now-stale comments in `bin/release.sh`, `bin/bump-dev.sh`, `bin/bump-version.sh`, and the `test_bump_dev_script.py` docstring.

No script behaviour changes; release/bump tests still pass (24).