### PR TITLE
feat: native tilt & position forwarding for wrapped covers

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ Because a command-echo cover has no endpoint feedback — and in practice drives
 
 **Tilt on a wrapped cover.** The **Inline** and **Sequential** tilt modes drive the wrapped cover's normal open / close commands, so they work on any wrapped cover regardless of whether it reports tilt support. Only the **Separate tilt motor** mode requires the wrapped cover to expose its own tilt commands, so it is offered only when the wrapped entity reports native tilt support.
 
+**Native tilt forwarding.** If the wrapped cover natively supports `set_cover_tilt_position` — for example a Z-Wave venetian shutter whose firmware positions its own slats — and you use the **Inline** tilt mode, the integration forwards the tilt commands (set-tilt, open-tilt, close-tilt) straight to the wrapped cover instead of simulating them by pulsing the main motor. The device positions its slats itself, precisely and at any travel position, and the integration snaps its tilt tracker to the angle the cover reports once it settles. On such a cover the integration also drives **position** natively (forwarding `set_cover_position`) even though tilt is configured, and animates the tilt display sweeping toward the direction endpoint during travel — venetian slats close on the way down, open on the way up — before syncing to the reported angle. This is auto-detected from the wrapped entity's supported features; no extra configuration is needed. A cover that does not advertise native tilt keeps the timed simulation described above, and the Sequential / Separate-tilt-motor modes always use their existing behaviour.
+
 ### Switch-based covers
 
 Control a cover using two relay switches (one for open, one for close), with an optional third stop switch (required in **Pulse** mode).

--- a/custom_components/cover_time_based/cover_wrapped.py
+++ b/custom_components/cover_time_based/cover_wrapped.py
@@ -147,17 +147,22 @@ class WrappedCoverTimeBased(CoverTimeBased):
         return self._wrapped_supports_set_tilt_position()
 
     async def _plan_tilt_for_travel(self, target, command, current_pos, current_tilt):
-        """Skip the physical tilt coupling for native-tilt covers.
+        """Sweep the tilt DISPLAY to the direction endpoint during native travel.
 
-        The wrapped device positions its own slats during travel, so the base
-        inline coupling (sweep tilt to the endpoint via the main motor, then
-        restore) would fight it. Skip it and let the settle-snap sync tilt to
-        the device's reported angle once travel completes. Non-native covers
-        keep the base coupling.
+        The wrapped device positions its own slats, so we drive no physical
+        tilt. But the slats visibly track travel on a venetian (close going
+        down, open going up), so animate tilt_calc to that endpoint for display;
+        the base feeds this coupled target to tilt_calc.start_travel(). No
+        restore is scheduled — the device owns the final angle, and the
+        settle-snap syncs tilt to the reported value once travel completes.
+        Non-native covers keep the base coupling (physical, main-motor).
         """
         if self._use_native_tilt():
             self._tilt_restore_target = None
-            return None, 0.0, False
+            if current_pos is None or current_tilt is None:
+                return None, 0.0, False
+            tilt_endpoint = 0 if target < current_pos else 100
+            return tilt_endpoint, 0.0, False
         return await super()._plan_tilt_for_travel(
             target, command, current_pos, current_tilt
         )

--- a/custom_components/cover_time_based/cover_wrapped.py
+++ b/custom_components/cover_time_based/cover_wrapped.py
@@ -173,15 +173,23 @@ class WrappedCoverTimeBased(CoverTimeBased):
             native position to it; this also keeps the command-echo
             reinterpretation in _handle_external_state_change from ever racing a
             self-driven native move), and
-          - a configured tilt strategy: native forwarding drives travel only and
-            can't express the tilt coupling/pre-steps the time-based path plans,
-            so tilt covers keep the full tilt-aware open/close/stop tracking.
+          - a configured *timed* tilt strategy: native forwarding drives travel
+            only and can't express the tilt coupling/pre-steps the time-based
+            path plans, so dual-motor/sequential tilt covers keep the full
+            tilt-aware open/close/stop tracking. A native-tilt cover
+            (_use_native_tilt()) already owns its slats independently of our
+            travel motor, so driving position natively too is coupling-safe.
         """
         if self._force_time_based_position:
             return False
         if self._reports_command_not_endpoint:
             return False
-        if self._tilt_strategy is not None:
+        # A configured tilt strategy normally keeps the timed path so the
+        # tilt coupling/pre-steps can run. But when tilt is itself forwarded
+        # natively (_use_native_tilt) the wrapped device owns its slats, so
+        # driving position natively is coupling-safe and gives device-accurate
+        # positioning. Dual-motor/sequential (timed tilt) keep the timed path.
+        if self._tilt_strategy is not None and not self._use_native_tilt():
             return False
         return self._wrapped_supports_set_position()
 

--- a/custom_components/cover_time_based/cover_wrapped.py
+++ b/custom_components/cover_time_based/cover_wrapped.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
 from homeassistant.helpers.event import async_track_state_change_event
 
 from .cover_base import CoverTimeBased
+from .drivers import NativePositionDriver, TimedPositionDriver
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -49,6 +50,8 @@ class WrappedCoverTimeBased(CoverTimeBased):
         self._force_time_based_position = force_time_based_position
         self._reports_command_not_endpoint = reports_command_not_endpoint
         self._last_self_command_time: float | None = None
+        self._native_position_driver = NativePositionDriver(self)
+        self._timed_position_driver = TimedPositionDriver(self)
 
     async def async_added_to_hass(self):
         """Register state listener for the wrapped cover entity."""
@@ -129,9 +132,19 @@ class WrappedCoverTimeBased(CoverTimeBased):
             return False
         return self._wrapped_supports_set_position()
 
+    def _position_driver(self):
+        """Select the position actuation driver from current capabilities.
+
+        Re-evaluated per call: the wrapped entity's supported_features can
+        change at runtime (e.g. it goes unavailable and back).
+        """
+        if self._use_native_set_position():
+            return self._native_position_driver
+        return self._timed_position_driver
+
     def _motor_stops_itself(self) -> bool:
         """Native covers drive to and hold the target position themselves."""
-        return self._use_native_set_position()
+        return self._position_driver().holds_itself
 
     def _self_stops_at_endpoints(self) -> bool:
         """Command-echo wrapped covers have no endstop and must be stopped.
@@ -320,25 +333,14 @@ class WrappedCoverTimeBased(CoverTimeBased):
         return None
 
     async def _command_position_move(self, target, command, already_moving_same_dir):
-        """Drive a mid-position move for the wrapped cover.
+        """Drive a mid-position move via the selected position driver.
 
-        When the wrapped entity supports native SET_POSITION, forward
-        ``cover.set_cover_position`` straight to it (including on a same-direction
-        retarget — the device changes course): the device drives to the target
-        and holds there itself, so we never depend on its ``stop_cover`` and
-        ``_motor_stops_itself`` keeps auto-stop from re-commanding it. Everything
-        else — direction handling, min-movement, startup delay, tracker
-        animation — is the base set_position ceremony. Without native support we
-        fall back to the base relay drive (latched open/close + timed stop).
+        Native covers forward set_cover_position and hold themselves; timed
+        covers run the base relay drive (latched open/close + timed stop).
         """
-        if not self._use_native_set_position():
-            await super()._command_position_move(
-                target, command, already_moving_same_dir
-            )
-            return
-        self._require_movement_target_available(self._cover_entity_id)
-        self._log("_command_position_move :: forwarding set_cover_position(%d)", target)
-        await self._call_set_cover_position(int(round(target)))
+        await self._position_driver().command_move(
+            target, command, already_moving_same_dir
+        )
 
     async def _call_set_cover_position(self, position: int) -> None:
         """Forward a set_cover_position command to the wrapped entity."""

--- a/custom_components/cover_time_based/cover_wrapped.py
+++ b/custom_components/cover_time_based/cover_wrapped.py
@@ -3,7 +3,12 @@
 import logging
 import time
 
-from homeassistant.components.cover import ATTR_CURRENT_POSITION, CoverEntityFeature
+from homeassistant.components.cover import (
+    ATTR_CURRENT_POSITION,
+    ATTR_CURRENT_TILT_POSITION,
+    ATTR_TILT_POSITION,
+    CoverEntityFeature,
+)
 from homeassistant.const import (
     ATTR_SUPPORTED_FEATURES,
     STATE_CLOSED,
@@ -17,6 +22,7 @@ from homeassistant.helpers.event import async_track_state_change_event
 
 from .cover_base import CoverTimeBased
 from .drivers import NativePositionDriver, PositionDriver, TimedPositionDriver
+from .tilt_strategies.inline import InlineTilt
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -108,6 +114,31 @@ class WrappedCoverTimeBased(CoverTimeBased):
         """Return True if the wrapped cover advertises native STOP."""
         features = self._wrapped_features()
         return features is not None and bool(features & CoverEntityFeature.STOP)
+
+    def _wrapped_supports_set_tilt_position(self) -> bool:
+        """Return True if the wrapped cover advertises native SET_TILT_POSITION."""
+        features = self._wrapped_features()
+        return features is not None and bool(
+            features & CoverEntityFeature.SET_TILT_POSITION
+        )
+
+    def _use_native_tilt(self) -> bool:
+        """Return True if tilt commands should be forwarded to the wrapped
+        cover's own tilt instead of simulated with the main motor.
+
+        Restricted to InlineTilt: the device positions its own slats, so the
+        inline strategy's no-op snap_trackers_to_physical leaves our
+        natively-set tilt intact. Dual-motor/sequential strategies re-derive
+        tilt from travel and keep the timed path. Command-echo covers report
+        nothing trustworthy to snap back from, so they keep the timed path too.
+        """
+        if self._reports_command_not_endpoint:
+            return False
+        if not self._has_tilt_support():
+            return False
+        if not isinstance(self._tilt_strategy, InlineTilt):
+            return False
+        return self._wrapped_supports_set_tilt_position()
 
     def _use_native_set_position(self) -> bool:
         """Return True if set_cover_position should be forwarded natively.

--- a/custom_components/cover_time_based/cover_wrapped.py
+++ b/custom_components/cover_time_based/cover_wrapped.py
@@ -146,6 +146,22 @@ class WrappedCoverTimeBased(CoverTimeBased):
             return False
         return self._wrapped_supports_set_tilt_position()
 
+    async def _plan_tilt_for_travel(self, target, command, current_pos, current_tilt):
+        """Skip the physical tilt coupling for native-tilt covers.
+
+        The wrapped device positions its own slats during travel, so the base
+        inline coupling (sweep tilt to the endpoint via the main motor, then
+        restore) would fight it. Skip it and let the settle-snap sync tilt to
+        the device's reported angle once travel completes. Non-native covers
+        keep the base coupling.
+        """
+        if self._use_native_tilt():
+            self._tilt_restore_target = None
+            return None, 0.0, False
+        return await super()._plan_tilt_for_travel(
+            target, command, current_pos, current_tilt
+        )
+
     def _use_native_set_position(self) -> bool:
         """Return True if set_cover_position should be forwarded natively.
 

--- a/custom_components/cover_time_based/cover_wrapped.py
+++ b/custom_components/cover_time_based/cover_wrapped.py
@@ -180,10 +180,12 @@ class WrappedCoverTimeBased(CoverTimeBased):
             self-driven native move), and
           - a configured *timed* tilt strategy: native forwarding drives travel
             only and can't express the tilt coupling/pre-steps the time-based
-            path plans, so dual-motor/sequential tilt covers keep the full
-            tilt-aware open/close/stop tracking. A native-tilt cover
-            (_use_native_tilt()) already owns its slats independently of our
-            travel motor, so driving position natively too is coupling-safe.
+            path plans, so a *timed* tilt strategy keeps the timed path
+            (dual-motor/sequential, and inline covers whose wrapped entity
+            can't forward tilt); native-tilt covers drive position natively
+            too. A native-tilt cover (_use_native_tilt()) already owns its
+            slats independently of our travel motor, so driving position
+            natively is coupling-safe there.
         """
         if self._force_time_based_position:
             return False

--- a/custom_components/cover_time_based/cover_wrapped.py
+++ b/custom_components/cover_time_based/cover_wrapped.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
 from homeassistant.helpers.event import async_track_state_change_event
 
 from .cover_base import CoverTimeBased
-from .drivers import NativePositionDriver, TimedPositionDriver
+from .drivers import NativePositionDriver, PositionDriver, TimedPositionDriver
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -132,7 +132,7 @@ class WrappedCoverTimeBased(CoverTimeBased):
             return False
         return self._wrapped_supports_set_position()
 
-    def _position_driver(self):
+    def _position_driver(self) -> PositionDriver:
         """Select the position actuation driver from current capabilities.
 
         Re-evaluated per call: the wrapped entity's supported_features can

--- a/custom_components/cover_time_based/cover_wrapped.py
+++ b/custom_components/cover_time_based/cover_wrapped.py
@@ -21,7 +21,12 @@ from homeassistant.const import (
 from homeassistant.helpers.event import async_track_state_change_event
 
 from .cover_base import CoverTimeBased
-from .drivers import NativePositionDriver, PositionDriver, TimedPositionDriver
+from .drivers import (
+    NativePositionDriver,
+    NativeTiltDriver,
+    PositionDriver,
+    TimedPositionDriver,
+)
 from .tilt_strategies.inline import InlineTilt
 
 _LOGGER = logging.getLogger(__name__)
@@ -58,6 +63,7 @@ class WrappedCoverTimeBased(CoverTimeBased):
         self._last_self_command_time: float | None = None
         self._native_position_driver = NativePositionDriver(self)
         self._timed_position_driver = TimedPositionDriver(self)
+        self._native_tilt_driver = NativeTiltDriver(self)
 
     async def async_added_to_hass(self):
         """Register state listener for the wrapped cover entity."""
@@ -174,7 +180,15 @@ class WrappedCoverTimeBased(CoverTimeBased):
         return self._timed_position_driver
 
     def _motor_stops_itself(self) -> bool:
-        """Native covers drive to and hold the target position themselves."""
+        """The device holds the target itself — the auto-updater must not send
+        a relay stop.
+
+        True during a native tilt move (the wrapped cover positions its own
+        slats), and for native set_position covers (Plan 1). Timed covers on
+        either axis must be told to stop, so False otherwise.
+        """
+        if self._moving_tilt and self._use_native_tilt():
+            return True
         return self._position_driver().holds_itself
 
     def _self_stops_at_endpoints(self) -> bool:
@@ -464,6 +478,46 @@ class WrappedCoverTimeBased(CoverTimeBased):
             self._cover_entity_id,
             service,
         )
+
+    async def _call_set_cover_tilt_position(self, position: int) -> None:
+        """Forward a set_cover_tilt_position command to the wrapped entity."""
+        self._start_bounce_grace_window()
+        await self.hass.services.async_call(
+            "cover",
+            "set_cover_tilt_position",
+            {"entity_id": self._cover_entity_id, ATTR_TILT_POSITION: position},
+            False,
+        )
+
+    async def _prepare_native_tilt(self) -> None:
+        """Stop any in-flight move before forwarding a native tilt.
+
+        The base tilt entry points abandon the active lifecycle and stop an
+        in-flight travel before tilting. _abandon_active_lifecycle early-returns
+        without stopping a plain (non-restore, non-pre-step) timed travel, so
+        stop that here explicitly — including its physical relay — otherwise a
+        tilt issued mid-travel leaves the wrapped cover's position motor running.
+        """
+        await self._abandon_active_lifecycle()
+        if self.travel_calc.is_traveling():
+            self.travel_calc.stop()
+            self.stop_auto_updater()
+            if not self._triggered_externally:
+                await self._send_stop()
+
+    async def async_set_cover_tilt_position(self, **kwargs):
+        """Forward tilt-to-position natively when the wrapped cover can."""
+        if ATTR_TILT_POSITION in kwargs and self._use_native_tilt():
+            await self._native_tilt_driver.move_to(int(kwargs[ATTR_TILT_POSITION]))
+            return
+        await super().async_set_cover_tilt_position(**kwargs)
+
+    async def _async_move_tilt_to_endpoint(self, target):
+        """Route open/close-tilt through native forwarding when available."""
+        if self._use_native_tilt():
+            await self._native_tilt_driver.move_to(target)
+            return
+        await super()._async_move_tilt_to_endpoint(target)
 
     async def _send_tilt_open(self) -> None:
         if not self._wrapped_supports_tilt():

--- a/custom_components/cover_time_based/cover_wrapped.py
+++ b/custom_components/cover_time_based/cover_wrapped.py
@@ -288,6 +288,7 @@ class WrappedCoverTimeBased(CoverTimeBased):
                     " no position info"
                 )
                 await self.async_stop_cover()
+            await self._maybe_snap_to_reported_tilt()
 
     async def _handle_command_state(self, new_val: str) -> None:
         """Reinterpret the wrapped entity's state as a command echo.
@@ -343,6 +344,7 @@ class WrappedCoverTimeBased(CoverTimeBased):
         target = self._wrapped_reported_position()
         if target is not None:
             await self._snap_to_position(target)
+        await self._maybe_snap_to_reported_tilt()
 
     async def _snap_to_position(self, target: int) -> None:
         """Snap our tracker to a known position.
@@ -376,6 +378,42 @@ class WrappedCoverTimeBased(CoverTimeBased):
         if state.state == STATE_CLOSED:
             return 0
         return None
+
+    def _wrapped_reported_tilt_position(self) -> int | None:
+        """Return the wrapped cover's reported tilt position, or None.
+
+        Honors ignore_reported_position — a device whose reported values are
+        untrustworthy is untrustworthy on both axes. Unlike
+        _wrapped_reported_position there is no closed-state fallback: a closed
+        cover implies nothing unambiguous about its slat angle.
+        """
+        if self._ignore_reported_position:
+            return None
+        state = self.hass.states.get(self._cover_entity_id)
+        if state is None:
+            return None
+        attr_tilt = state.attributes.get(ATTR_CURRENT_TILT_POSITION)
+        if isinstance(attr_tilt, (int, float)) and 0 <= attr_tilt <= 100:
+            return int(attr_tilt)
+        return None
+
+    async def _maybe_snap_to_reported_tilt(self) -> None:
+        """Snap tilt_calc to the wrapped cover's reported tilt once it settles.
+
+        Gated on _use_native_tilt(): only covers whose tilt we forward natively
+        treat the reported tilt as source of truth. For dual-motor/sequential
+        the coupling model owns the tilt tracker, so we must not clobber it.
+        Skipped while our own tilt animation is still in flight.
+        """
+        if not self._use_native_tilt():
+            return
+        if self.tilt_calc.is_traveling():
+            return
+        target = self._wrapped_reported_tilt_position()
+        if target is None or self.tilt_calc.current_position() == target:
+            return
+        self._log("_maybe_snap_to_reported_tilt :: snapping tilt to %d", target)
+        await self.set_known_tilt_position(tilt_position=target)
 
     async def _command_position_move(self, target, command, already_moving_same_dir):
         """Drive a mid-position move via the selected position driver.

--- a/custom_components/cover_time_based/cover_wrapped.py
+++ b/custom_components/cover_time_based/cover_wrapped.py
@@ -252,6 +252,8 @@ class WrappedCoverTimeBased(CoverTimeBased):
         direction changes. When the wrapped cover settles into a stopped
         state we snap to its reported position; for covers without a
         current_position attribute we fall back to stopping the tracker.
+        On settle we also snap tilt to the wrapped cover's reported tilt
+        (native-tilt covers only, via _maybe_snap_to_reported_tilt).
         """
         if self._in_bounce_grace_window():
             self._log(
@@ -284,6 +286,22 @@ class WrappedCoverTimeBased(CoverTimeBased):
             self._log(
                 "_handle_external_state_change :: ignoring self-driven %s"
                 " during native set_position move",
+                new_val,
+            )
+            return
+
+        # Same for a self-driven native tilt move: the wrapped cover's own
+        # opening/closing while its slats run is a side effect of the tilt we
+        # forwarded, not an external travel. tilt_calc is traveling for the
+        # duration of our animation; mirror the native set_position guard above.
+        if (
+            new_val in _MOVING_STATES
+            and self._use_native_tilt()
+            and self.tilt_calc.is_traveling()
+        ):
+            self._log(
+                "_handle_external_state_change :: ignoring self-driven %s"
+                " during native tilt move",
                 new_val,
             )
             return
@@ -347,6 +365,9 @@ class WrappedCoverTimeBased(CoverTimeBased):
         _handle_external_state_change. Without this, an attribute update while
         the device sits in 'closed' would snap us to 0% via the
         state==closed -> 0 shortcut, the very snap this option exists to avoid.
+        After handling position, we also snap tilt to the wrapped cover's
+        reported tilt (native-tilt covers only, via
+        _maybe_snap_to_reported_tilt).
         """
         if event.data.get("entity_id") != self._cover_entity_id:
             return

--- a/custom_components/cover_time_based/cover_wrapped.py
+++ b/custom_components/cover_time_based/cover_wrapped.py
@@ -570,8 +570,13 @@ class WrappedCoverTimeBased(CoverTimeBased):
         )
 
     async def _call_set_cover_tilt_position(self, position: int) -> None:
-        """Forward a set_cover_tilt_position command to the wrapped entity."""
-        self._start_bounce_grace_window()
+        """Forward a set_cover_tilt_position command to the wrapped entity.
+
+        No bounce-grace window here (unlike the position forward): the
+        self-driven-tilt guard already suppresses the wrapped cover's own
+        opening/closing echo, and a bounce window would swallow a fast settle
+        report that the tilt settle-snap needs.
+        """
         await self.hass.services.async_call(
             "cover",
             "set_cover_tilt_position",

--- a/custom_components/cover_time_based/drivers.py
+++ b/custom_components/cover_time_based/drivers.py
@@ -1,0 +1,52 @@
+"""Actuation drivers for wrapped covers.
+
+A driver encapsulates the one thing that differs between a natively-driven
+wrapped cover and a time-based one: how a position move is actuated, and
+whether the device drives to the target and holds there itself. Everything
+else — display animation, settle-snap, stop, coupling — stays on the cover.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from .cover_base import CoverTimeBased
+
+
+class PositionDriver(ABC):
+    """Actuates a position move for a wrapped cover's position axis."""
+
+    #: Whether the device drives to the target and holds there on its own.
+    holds_itself: bool = False
+
+    def __init__(self, cover) -> None:
+        self._cover = cover
+
+    @abstractmethod
+    async def command_move(self, target, command, already_moving_same_dir) -> None:
+        """Actuate a mid-position move toward ``target``."""
+
+
+class TimedPositionDriver(PositionDriver):
+    """Relay-driven position: latched open/close + timed stop (base behaviour)."""
+
+    holds_itself = False
+
+    async def command_move(self, target, command, already_moving_same_dir) -> None:
+        await CoverTimeBased._command_position_move(
+            self._cover, target, command, already_moving_same_dir
+        )
+
+
+class NativePositionDriver(PositionDriver):
+    """Native position: forward set_cover_position; the device holds itself."""
+
+    holds_itself = True
+
+    async def command_move(self, target, command, already_moving_same_dir) -> None:
+        cover = self._cover
+        cover._require_movement_target_available(cover._cover_entity_id)
+        cover._log(
+            "_command_position_move :: forwarding set_cover_position(%d)", target
+        )
+        await cover._call_set_cover_position(int(round(target)))

--- a/custom_components/cover_time_based/drivers.py
+++ b/custom_components/cover_time_based/drivers.py
@@ -39,7 +39,12 @@ class TimedPositionDriver(PositionDriver):
 
 
 class NativePositionDriver(PositionDriver):
-    """Native position: forward set_cover_position; the device holds itself."""
+    """Native position: forward set_cover_position; the device holds itself.
+
+    Forwarding fires unconditionally, including on a same-direction retarget
+    (the device changes course to the new target) — which is why
+    ``already_moving_same_dir`` is ignored here, unlike the timed path.
+    """
 
     holds_itself = True
 

--- a/custom_components/cover_time_based/drivers.py
+++ b/custom_components/cover_time_based/drivers.py
@@ -84,10 +84,10 @@ class NativeTiltDriver(TiltDriver):
 
     async def move_to(self, target) -> None:
         cover = self._cover
-        await cover._prepare_native_tilt()
         current = cover.tilt_calc.current_position()
         if current is not None and int(current) == target:
             return
+        await cover._prepare_native_tilt()
         cover._self_initiated_movement = not cover._triggered_externally
         cover._moving_tilt = True
         cover._log("NativeTiltDriver :: forwarding set_cover_tilt_position(%d)", target)

--- a/custom_components/cover_time_based/drivers.py
+++ b/custom_components/cover_time_based/drivers.py
@@ -51,10 +51,11 @@ class NativePositionDriver(PositionDriver):
     async def command_move(self, target, command, already_moving_same_dir) -> None:
         cover = self._cover
         cover._require_movement_target_available(cover._cover_entity_id)
+        position = int(round(target))
         cover._log(
-            "_command_position_move :: forwarding set_cover_position(%d)", target
+            "_command_position_move :: forwarding set_cover_position(%d)", position
         )
-        await cover._call_set_cover_position(int(round(target)))
+        await cover._call_set_cover_position(position)
 
 
 class TiltDriver(ABC):
@@ -87,8 +88,9 @@ class NativeTiltDriver(TiltDriver):
         current = cover.tilt_calc.current_position()
         if current is not None and int(current) == target:
             return
-        await cover._prepare_native_tilt()
         cover._self_initiated_movement = not cover._triggered_externally
+        cover._require_movement_target_available(cover._cover_entity_id)
+        await cover._prepare_native_tilt()
         cover._moving_tilt = True
         cover._log("NativeTiltDriver :: forwarding set_cover_tilt_position(%d)", target)
         await cover._call_set_cover_tilt_position(target)

--- a/custom_components/cover_time_based/drivers.py
+++ b/custom_components/cover_time_based/drivers.py
@@ -55,3 +55,44 @@ class NativePositionDriver(PositionDriver):
             "_command_position_move :: forwarding set_cover_position(%d)", target
         )
         await cover._call_set_cover_position(int(round(target)))
+
+
+class TiltDriver(ABC):
+    """Actuates a tilt move for a wrapped cover's tilt axis."""
+
+    #: Whether the device drives to the tilt target and holds there on its own.
+    holds_itself: bool = False
+
+    def __init__(self, cover) -> None:
+        self._cover = cover
+
+    @abstractmethod
+    async def move_to(self, target) -> None:
+        """Actuate a tilt move toward ``target`` (0-100)."""
+
+
+class NativeTiltDriver(TiltDriver):
+    """Native tilt: forward set_cover_tilt_position; the device holds itself.
+
+    Forwards the command, then animates ``tilt_calc`` toward the target so the
+    integration reports live motion; the auto-updater issues no relay stop
+    (the cover's ``_motor_stops_itself`` is tilt-aware), and the settle-snap
+    corrects ``tilt_calc`` to the device's reported tilt once it stops.
+    """
+
+    holds_itself = True
+
+    async def move_to(self, target) -> None:
+        cover = self._cover
+        await cover._prepare_native_tilt()
+        current = cover.tilt_calc.current_position()
+        if current is not None and int(current) == target:
+            return
+        cover._self_initiated_movement = not cover._triggered_externally
+        cover._moving_tilt = True
+        cover._log("NativeTiltDriver :: forwarding set_cover_tilt_position(%d)", target)
+        await cover._call_set_cover_tilt_position(target)
+        if current is None:
+            cover.tilt_calc.update_position(100 if target <= 50 else 0)
+        cover.tilt_calc.start_travel(target)
+        cover.start_auto_updater()

--- a/tests/test_cover_wrapped.py
+++ b/tests/test_cover_wrapped.py
@@ -913,6 +913,23 @@ class TestNativeCouplingNeutralized:
         assert started is False
         assert cover._tilt_restore_target == 60  # base scheduled a restore
 
+    @pytest.mark.asyncio
+    async def test_move_to_rejects_unavailable_target(self):
+        from custom_components.cover_time_based.drivers import NativeTiltDriver
+        from homeassistant.exceptions import HomeAssistantError
+
+        cover = _make_wrapped_cover(
+            tilt_time_close=5, tilt_time_open=5, tilt_mode="inline"
+        )
+        _set_wrapped_features(
+            cover, _F_OPEN | _F_CLOSE | self._F_SET_TILT, state="unavailable"
+        )
+        cover.tilt_calc.set_position(80)
+        cover._triggered_externally = False
+
+        with pytest.raises(HomeAssistantError):
+            await NativeTiltDriver(cover).move_to(30)
+
 
 class TestNativePositionWithNativeTilt:
     """A native-both-inline cover drives position natively too (symmetry);

--- a/tests/test_cover_wrapped.py
+++ b/tests/test_cover_wrapped.py
@@ -687,12 +687,16 @@ class TestUseNativeTilt:
     _F_SET_TILT = 128  # CoverEntityFeature.SET_TILT_POSITION
 
     def test_native_tilt_when_inline_and_set_tilt_supported(self):
-        cover = _make_wrapped_cover(tilt_time_close=5, tilt_time_open=5, tilt_mode="inline")
+        cover = _make_wrapped_cover(
+            tilt_time_close=5, tilt_time_open=5, tilt_mode="inline"
+        )
         _set_wrapped_features(cover, _F_OPEN | _F_CLOSE | self._F_SET_TILT)
         assert cover._use_native_tilt() is True
 
     def test_not_native_without_set_tilt_position(self):
-        cover = _make_wrapped_cover(tilt_time_close=5, tilt_time_open=5, tilt_mode="inline")
+        cover = _make_wrapped_cover(
+            tilt_time_close=5, tilt_time_open=5, tilt_mode="inline"
+        )
         _set_wrapped_features(cover, _F_OPEN | _F_CLOSE)  # no SET_TILT_POSITION
         assert cover._use_native_tilt() is False
 
@@ -705,7 +709,9 @@ class TestUseNativeTilt:
 
     def test_not_native_for_command_echo(self):
         cover = _make_wrapped_cover(
-            tilt_time_close=5, tilt_time_open=5, tilt_mode="inline",
+            tilt_time_close=5,
+            tilt_time_open=5,
+            tilt_mode="inline",
             reports_command_not_endpoint=True,
         )
         _set_wrapped_features(cover, _F_OPEN | _F_CLOSE | self._F_SET_TILT)
@@ -804,7 +810,9 @@ class TestTiltSettleSnap:
 
     @pytest.mark.asyncio
     async def test_snaps_tilt_to_reported_on_settle(self):
-        cover = _make_wrapped_cover(tilt_time_close=5, tilt_time_open=5, tilt_mode="inline")
+        cover = _make_wrapped_cover(
+            tilt_time_close=5, tilt_time_open=5, tilt_mode="inline"
+        )
         st = _set_wrapped_features(
             cover, _F_OPEN | _F_CLOSE | self._F_SET_TILT, state="open"
         )
@@ -850,7 +858,9 @@ class TestNativeCouplingNeutralized:
 
     @pytest.mark.asyncio
     async def test_no_tilt_restore_scheduled_for_native(self):
-        cover = _make_wrapped_cover(tilt_time_close=5, tilt_time_open=5, tilt_mode="inline")
+        cover = _make_wrapped_cover(
+            tilt_time_close=5, tilt_time_open=5, tilt_mode="inline"
+        )
         _set_wrapped_features(cover, _F_OPEN | _F_CLOSE | self._F_SET_TILT)
         cover._tilt_restore_target = 77  # pretend something set it
 
@@ -865,7 +875,9 @@ class TestNativeCouplingNeutralized:
     async def test_coupling_preserved_for_non_native(self):
         # A non-native inline cover (no SET_TILT_POSITION) keeps the base plan,
         # which for an inline mid-position move schedules a tilt restore.
-        cover = _make_wrapped_cover(tilt_time_close=5, tilt_time_open=5, tilt_mode="inline")
+        cover = _make_wrapped_cover(
+            tilt_time_close=5, tilt_time_open=5, tilt_mode="inline"
+        )
         _set_wrapped_features(cover, _F_OPEN | _F_CLOSE)  # no SET_TILT_POSITION
         cover.tilt_calc.set_position(60)
 

--- a/tests/test_cover_wrapped.py
+++ b/tests/test_cover_wrapped.py
@@ -29,16 +29,32 @@ def _make_wrapped_cover(
     cover_entity_id="cover.inner",
     force_time_based_position=False,
     reports_command_not_endpoint=False,
+    tilt_time_close=None,
+    tilt_time_open=None,
+    tilt_mode="none",
 ):
     """Create a WrappedCoverTimeBased wired to a mock hass."""
+    tilt_strategy = None
+    if tilt_time_close is not None and tilt_time_open is not None:
+        # Map tilt_mode to strategy
+        from custom_components.cover_time_based.tilt_strategies import (
+            InlineTilt,
+            SequentialCloseTilt,
+        )
+
+        if tilt_mode == "inline":
+            tilt_strategy = InlineTilt()
+        elif tilt_mode in ("sequential_close", "sequential"):
+            tilt_strategy = SequentialCloseTilt()
+
     cover = WrappedCoverTimeBased(
         device_id="test_wrapped",
         name="Test Wrapped",
-        tilt_strategy=None,
+        tilt_strategy=tilt_strategy,
         travel_time_close=30,
         travel_time_open=30,
-        tilt_time_close=None,
-        tilt_time_open=None,
+        tilt_time_close=tilt_time_close,
+        tilt_time_open=tilt_time_open,
         travel_startup_delay=None,
         tilt_startup_delay=None,
         endpoint_runon_time=None,
@@ -662,3 +678,40 @@ class TestWrappedCommandEchoMode:
         with patch.object(cover, "_snap_to_position", new=AsyncMock()) as snap_mock:
             await cover._handle_external_state_change("cover.inner", "open", "closed")
         snap_mock.assert_awaited_once_with(0)
+
+
+class TestUseNativeTilt:
+    """_use_native_tilt() requires InlineTilt + wrapped SET_TILT_POSITION,
+    and is off for command-echo covers and non-inline strategies."""
+
+    _F_SET_TILT = 128  # CoverEntityFeature.SET_TILT_POSITION
+
+    def test_native_tilt_when_inline_and_set_tilt_supported(self):
+        cover = _make_wrapped_cover(tilt_time_close=5, tilt_time_open=5, tilt_mode="inline")
+        _set_wrapped_features(cover, _F_OPEN | _F_CLOSE | self._F_SET_TILT)
+        assert cover._use_native_tilt() is True
+
+    def test_not_native_without_set_tilt_position(self):
+        cover = _make_wrapped_cover(tilt_time_close=5, tilt_time_open=5, tilt_mode="inline")
+        _set_wrapped_features(cover, _F_OPEN | _F_CLOSE)  # no SET_TILT_POSITION
+        assert cover._use_native_tilt() is False
+
+    def test_not_native_for_non_inline_strategy(self):
+        cover = _make_wrapped_cover(
+            tilt_time_close=5, tilt_time_open=5, tilt_mode="sequential_close"
+        )
+        _set_wrapped_features(cover, _F_OPEN | _F_CLOSE | self._F_SET_TILT)
+        assert cover._use_native_tilt() is False
+
+    def test_not_native_for_command_echo(self):
+        cover = _make_wrapped_cover(
+            tilt_time_close=5, tilt_time_open=5, tilt_mode="inline",
+            reports_command_not_endpoint=True,
+        )
+        _set_wrapped_features(cover, _F_OPEN | _F_CLOSE | self._F_SET_TILT)
+        assert cover._use_native_tilt() is False
+
+    def test_not_native_without_tilt_configured(self):
+        cover = _make_wrapped_cover()  # no tilt times → no tilt strategy
+        _set_wrapped_features(cover, _F_OPEN | _F_CLOSE | self._F_SET_TILT)
+        assert cover._use_native_tilt() is False

--- a/tests/test_cover_wrapped.py
+++ b/tests/test_cover_wrapped.py
@@ -893,7 +893,7 @@ class TestNativeCouplingNeutralized:
             50, "close", current_pos=100, current_tilt=60
         )
 
-        assert (tilt_target, pre_step_delay, started) == (None, 0.0, False)
+        assert (tilt_target, pre_step_delay, started) == (0, 0.0, False)
         assert cover._tilt_restore_target is None
 
     @pytest.mark.asyncio
@@ -969,3 +969,68 @@ class TestNativePositionWithNativeTilt:
         services = [c.args[1] for c in _calls(cover.hass.services.async_call)]
         assert "set_cover_position" in services
         assert "close_cover" not in services and "open_cover" not in services
+
+
+class TestNativeTiltSweep:
+    """During a position travel, a native cover's tilt display sweeps to the
+    direction endpoint (0 closing, 100 opening); no physical tilt command."""
+
+    _F_SET_TILT = 128
+
+    def _prep(self, cover):
+        cover.start_auto_updater = MagicMock()
+        cover.async_write_ha_state = MagicMock()
+        cover.async_schedule_update_ha_state = MagicMock()
+
+    def _native_cover(self):
+        cover = _make_wrapped_cover(
+            tilt_time_close=5, tilt_time_open=5, tilt_mode="inline"
+        )
+        _set_wrapped_features(
+            cover, _F_OPEN | _F_CLOSE | _F_SET_POSITION | self._F_SET_TILT
+        )
+        self._prep(cover)
+        return cover
+
+    @pytest.mark.asyncio
+    async def test_plan_returns_zero_endpoint_when_closing(self):
+        cover = self._native_cover()
+        tilt_target, pre_step_delay, started = await cover._plan_tilt_for_travel(
+            30, "close", current_pos=100, current_tilt=80
+        )
+        assert (tilt_target, pre_step_delay, started) == (0, 0.0, False)
+        assert cover._tilt_restore_target is None
+
+    @pytest.mark.asyncio
+    async def test_plan_returns_100_endpoint_when_opening(self):
+        cover = self._native_cover()
+        tilt_target, _, started = await cover._plan_tilt_for_travel(
+            90, "open", current_pos=20, current_tilt=10
+        )
+        assert tilt_target == 100
+        assert started is False
+
+    @pytest.mark.asyncio
+    async def test_plan_returns_none_when_position_unknown(self):
+        cover = self._native_cover()
+        result = await cover._plan_tilt_for_travel(
+            50, "open", current_pos=None, current_tilt=40
+        )
+        assert result == (None, 0.0, False)
+
+    @pytest.mark.asyncio
+    async def test_position_move_sweeps_tilt_display_no_tilt_command(self):
+        cover = self._native_cover()
+        cover.travel_calc.set_position(100)
+        cover.tilt_calc.set_position(80)
+
+        await cover.set_position(30)  # closing
+
+        # Tilt display is animating toward the closed endpoint (0)...
+        assert cover.tilt_calc.is_traveling()
+        assert cover.tilt_calc._travel_to_position == 0
+        # ...and no physical tilt command was sent (device owns its slats).
+        services = [c.args[1] for c in _calls(cover.hass.services.async_call)]
+        assert "set_cover_tilt_position" not in services
+        assert "close_cover_tilt" not in services
+        assert "open_cover_tilt" not in services

--- a/tests/test_cover_wrapped.py
+++ b/tests/test_cover_wrapped.py
@@ -840,3 +840,38 @@ class TestTiltSettleSnap:
         await cover._handle_external_state_change("cover.inner", "opening", "open")
 
         assert cover.tilt_calc.current_position() == 100  # unchanged; not native
+
+
+class TestNativeCouplingNeutralized:
+    """A position move on a native-tilt cover schedules no main-motor tilt
+    restore — the device manages its own slats."""
+
+    _F_SET_TILT = 128
+
+    @pytest.mark.asyncio
+    async def test_no_tilt_restore_scheduled_for_native(self):
+        cover = _make_wrapped_cover(tilt_time_close=5, tilt_time_open=5, tilt_mode="inline")
+        _set_wrapped_features(cover, _F_OPEN | _F_CLOSE | self._F_SET_TILT)
+        cover._tilt_restore_target = 77  # pretend something set it
+
+        tilt_target, pre_step_delay, started = await cover._plan_tilt_for_travel(
+            50, "close", current_pos=100, current_tilt=60
+        )
+
+        assert (tilt_target, pre_step_delay, started) == (None, 0.0, False)
+        assert cover._tilt_restore_target is None
+
+    @pytest.mark.asyncio
+    async def test_coupling_preserved_for_non_native(self):
+        # A non-native inline cover (no SET_TILT_POSITION) keeps the base plan,
+        # which for an inline mid-position move schedules a tilt restore.
+        cover = _make_wrapped_cover(tilt_time_close=5, tilt_time_open=5, tilt_mode="inline")
+        _set_wrapped_features(cover, _F_OPEN | _F_CLOSE)  # no SET_TILT_POSITION
+        cover.tilt_calc.set_position(60)
+
+        _, _, started = await cover._plan_tilt_for_travel(
+            50, "close", current_pos=100, current_tilt=60
+        )
+
+        assert started is False
+        assert cover._tilt_restore_target == 60  # base scheduled a restore

--- a/tests/test_cover_wrapped.py
+++ b/tests/test_cover_wrapped.py
@@ -715,3 +715,77 @@ class TestUseNativeTilt:
         cover = _make_wrapped_cover()  # no tilt times → no tilt strategy
         _set_wrapped_features(cover, _F_OPEN | _F_CLOSE | self._F_SET_TILT)
         assert cover._use_native_tilt() is False
+
+
+class TestNativeTiltForwarding:
+    """Native tilt covers forward set_cover_tilt_position and animate tilt_calc,
+    and the auto-updater issues no relay stop when the tilt move completes."""
+
+    _F_SET_TILT = 128
+
+    def _prep(self, cover):
+        cover.start_auto_updater = MagicMock()
+        cover.async_write_ha_state = MagicMock()
+        cover.async_schedule_update_ha_state = MagicMock()
+
+    def _native_tilt_cover(self):
+        cover = _make_wrapped_cover(
+            tilt_time_close=5, tilt_time_open=5, tilt_mode="inline"
+        )
+        _set_wrapped_features(cover, _F_OPEN | _F_CLOSE | self._F_SET_TILT)
+        self._prep(cover)
+        return cover
+
+    @pytest.mark.asyncio
+    async def test_set_tilt_position_forwards_natively(self):
+        cover = self._native_tilt_cover()
+        cover.tilt_calc.set_position(100)
+
+        await cover.async_set_cover_tilt_position(tilt_position=30)
+
+        services = [
+            (c.args[1], c.args[2]) for c in _calls(cover.hass.services.async_call)
+        ]
+        assert (
+            "set_cover_tilt_position",
+            {"entity_id": "cover.inner", "tilt_position": 30},
+        ) in services
+        assert all(svc != "close_cover" and svc != "open_cover" for svc, _ in services)
+        assert cover.tilt_calc.is_traveling()
+        assert cover.tilt_calc._travel_to_position == 30
+
+    @pytest.mark.asyncio
+    async def test_open_close_tilt_forward_natively(self):
+        cover = self._native_tilt_cover()
+        cover.tilt_calc.set_position(0)
+
+        await cover.async_open_cover_tilt()
+
+        services = [c.args[1] for c in _calls(cover.hass.services.async_call)]
+        assert "set_cover_tilt_position" in services
+        assert "open_cover_tilt" not in services  # not the dual-motor relay path
+
+    @pytest.mark.asyncio
+    async def test_tilt_already_at_target_is_noop(self):
+        cover = self._native_tilt_cover()
+        cover.tilt_calc.set_position(30)
+
+        await cover.async_set_cover_tilt_position(tilt_position=30)
+
+        assert _calls(cover.hass.services.async_call) == []
+
+    @pytest.mark.asyncio
+    async def test_auto_stop_sends_no_relay_stop_for_native_tilt(self):
+        cover = self._native_tilt_cover()
+        cover.tilt_calc.set_position(100)
+        await cover.async_set_cover_tilt_position(tilt_position=30)
+        cover.hass.services.async_call.reset_mock()
+
+        # Simulate the tilt animation having reached the target, then let the
+        # auto-updater's stop check run: a native tilt device holds itself.
+        cover.tilt_calc.set_position(30)
+        await cover.auto_stop_if_necessary()
+
+        services = [c.args[1] for c in _calls(cover.hass.services.async_call)]
+        assert "stop_cover" not in services
+        assert "close_cover" not in services

--- a/tests/test_cover_wrapped.py
+++ b/tests/test_cover_wrapped.py
@@ -771,6 +771,13 @@ class TestNativeTiltForwarding:
         assert "set_cover_tilt_position" in services
         assert "open_cover_tilt" not in services  # not the dual-motor relay path
 
+        tilt_call = next(
+            c
+            for c in _calls(cover.hass.services.async_call)
+            if c.args[1] == "set_cover_tilt_position"
+        )
+        assert tilt_call.args[2] == {"entity_id": "cover.inner", "tilt_position": 100}
+
     @pytest.mark.asyncio
     async def test_tilt_already_at_target_is_noop(self):
         cover = self._native_tilt_cover()
@@ -848,6 +855,24 @@ class TestTiltSettleSnap:
         await cover._handle_external_state_change("cover.inner", "opening", "open")
 
         assert cover.tilt_calc.current_position() == 100  # unchanged; not native
+
+    @pytest.mark.asyncio
+    async def test_snaps_tilt_to_zero_on_settle(self):
+        cover = _make_wrapped_cover(
+            tilt_time_close=5, tilt_time_open=5, tilt_mode="inline"
+        )
+        st = _set_wrapped_features(
+            cover, _F_OPEN | _F_CLOSE | self._F_SET_TILT, state="open"
+        )
+        st.attributes["current_position"] = 100
+        st.attributes["current_tilt_position"] = 0
+        self._prep(cover)
+        cover.travel_calc.set_position(100)
+        cover.tilt_calc.set_position(50)
+
+        await cover._handle_external_state_change("cover.inner", "opening", "open")
+
+        assert cover.tilt_calc.current_position() == 0
 
 
 class TestNativeCouplingNeutralized:

--- a/tests/test_cover_wrapped.py
+++ b/tests/test_cover_wrapped.py
@@ -789,3 +789,54 @@ class TestNativeTiltForwarding:
         services = [c.args[1] for c in _calls(cover.hass.services.async_call)]
         assert "stop_cover" not in services
         assert "close_cover" not in services
+
+
+class TestTiltSettleSnap:
+    """On settle, a native-tilt cover snaps tilt_calc to the device's reported
+    current_tilt_position; non-native strategies do not."""
+
+    _F_SET_TILT = 128
+
+    def _prep(self, cover):
+        cover.start_auto_updater = MagicMock()
+        cover.async_write_ha_state = MagicMock()
+        cover.async_schedule_update_ha_state = MagicMock()
+
+    @pytest.mark.asyncio
+    async def test_snaps_tilt_to_reported_on_settle(self):
+        cover = _make_wrapped_cover(tilt_time_close=5, tilt_time_open=5, tilt_mode="inline")
+        st = _set_wrapped_features(
+            cover, _F_OPEN | _F_CLOSE | self._F_SET_TILT, state="open"
+        )
+        st.attributes["current_position"] = 100
+        st.attributes["current_tilt_position"] = 45
+        self._prep(cover)
+        cover.travel_calc.set_position(100)
+        cover.tilt_calc.set_position(60)  # optimistic/stale
+
+        await cover._handle_external_state_change("cover.inner", "opening", "open")
+
+        assert cover.tilt_calc.current_position() == 45
+
+    @pytest.mark.asyncio
+    async def test_no_tilt_snap_for_non_native_strategy(self):
+        cover = _make_wrapped_cover(
+            tilt_time_close=5, tilt_time_open=5, tilt_mode="sequential_close"
+        )
+        st = _set_wrapped_features(
+            cover, _F_OPEN | _F_CLOSE | self._F_SET_TILT, state="open"
+        )
+        st.attributes["current_position"] = 100
+        st.attributes["current_tilt_position"] = 45
+        self._prep(cover)
+        cover.travel_calc.set_position(100)
+        # SequentialCloseTilt's own (pre-existing, unrelated) snap_trackers_to_
+        # physical forces tilt to 100 whenever travel is not at 0 — set tilt to
+        # 100 up front so that mechanism is a no-op here, isolating the
+        # assertion to whether _maybe_snap_to_reported_tilt (this task) pulls
+        # tilt from the wrapped device's reported current_tilt_position (45).
+        cover.tilt_calc.set_position(100)
+
+        await cover._handle_external_state_change("cover.inner", "opening", "open")
+
+        assert cover.tilt_calc.current_position() == 100  # unchanged; not native

--- a/tests/test_cover_wrapped.py
+++ b/tests/test_cover_wrapped.py
@@ -1034,3 +1034,28 @@ class TestNativeTiltSweep:
         assert "set_cover_tilt_position" not in services
         assert "close_cover_tilt" not in services
         assert "open_cover_tilt" not in services
+
+    @pytest.mark.asyncio
+    async def test_native_both_position_move_settles_both_axes(self):
+        cover = _make_wrapped_cover(
+            tilt_time_close=5, tilt_time_open=5, tilt_mode="inline"
+        )
+        st = _set_wrapped_features(
+            cover, _F_OPEN | _F_CLOSE | _F_SET_POSITION | self._F_SET_TILT
+        )
+        self._prep(cover)
+        cover.travel_calc.set_position(100)
+        cover.tilt_calc.set_position(80)
+
+        await cover.set_position(30)  # native position forward; tilt sweeps toward 0
+
+        # Device settles and reports its real position + slat angle.
+        cover._last_self_command_time = None  # bypass the bounce grace window
+        st.state = "open"
+        st.attributes["current_position"] = 30
+        st.attributes["current_tilt_position"] = 25
+
+        await cover._handle_external_state_change("cover.inner", "closing", "open")
+
+        assert cover.travel_calc.current_position() == 30
+        assert cover.tilt_calc.current_position() == 25

--- a/tests/test_cover_wrapped.py
+++ b/tests/test_cover_wrapped.py
@@ -538,6 +538,23 @@ class TestWrappedNativeInheritsBaseCeremony:
         assert cover._motor_stops_itself() is False
 
     @pytest.mark.asyncio
+    async def test_position_driver_selection_matches_native_flag(self):
+        from custom_components.cover_time_based.drivers import (
+            NativePositionDriver,
+            TimedPositionDriver,
+        )
+
+        cover = _make_wrapped_cover()
+
+        _set_wrapped_features(cover, 7)  # OPEN|CLOSE|SET_POSITION -> native
+        assert isinstance(cover._position_driver(), NativePositionDriver)
+        assert cover._motor_stops_itself() is True
+
+        _set_wrapped_features(cover, _F_OPEN | _F_CLOSE | _F_STOP)  # no SET_POSITION
+        assert isinstance(cover._position_driver(), TimedPositionDriver)
+        assert cover._motor_stops_itself() is False
+
+    @pytest.mark.asyncio
     async def test_auto_stop_sends_no_relay_stop_for_native(self):
         cover = _make_wrapped_cover()
         _set_wrapped_features(cover, 7)

--- a/tests/test_cover_wrapped.py
+++ b/tests/test_cover_wrapped.py
@@ -912,3 +912,60 @@ class TestNativeCouplingNeutralized:
 
         assert started is False
         assert cover._tilt_restore_target == 60  # base scheduled a restore
+
+
+class TestNativePositionWithNativeTilt:
+    """A native-both-inline cover drives position natively too (symmetry);
+    timed-tilt strategies keep the timed position path."""
+
+    _F_SET_TILT = 128
+
+    def _prep(self, cover):
+        cover.start_auto_updater = MagicMock()
+        cover.async_write_ha_state = MagicMock()
+        cover.async_schedule_update_ha_state = MagicMock()
+
+    def test_native_position_enabled_for_native_both_inline(self):
+        cover = _make_wrapped_cover(
+            tilt_time_close=5, tilt_time_open=5, tilt_mode="inline"
+        )
+        _set_wrapped_features(
+            cover, _F_OPEN | _F_CLOSE | _F_SET_POSITION | self._F_SET_TILT
+        )
+        assert cover._use_native_set_position() is True
+
+    def test_timed_position_kept_for_sequential_even_with_set_position(self):
+        cover = _make_wrapped_cover(
+            tilt_time_close=5, tilt_time_open=5, tilt_mode="sequential_close"
+        )
+        _set_wrapped_features(
+            cover, _F_OPEN | _F_CLOSE | _F_SET_POSITION | self._F_SET_TILT
+        )
+        assert cover._use_native_set_position() is False
+
+    def test_timed_position_kept_for_inline_without_set_tilt(self):
+        cover = _make_wrapped_cover(
+            tilt_time_close=5, tilt_time_open=5, tilt_mode="inline"
+        )
+        _set_wrapped_features(
+            cover, _F_OPEN | _F_CLOSE | _F_SET_POSITION
+        )  # no SET_TILT
+        assert cover._use_native_set_position() is False
+
+    @pytest.mark.asyncio
+    async def test_position_move_forwards_natively_for_native_both(self):
+        cover = _make_wrapped_cover(
+            tilt_time_close=5, tilt_time_open=5, tilt_mode="inline"
+        )
+        _set_wrapped_features(
+            cover, _F_OPEN | _F_CLOSE | _F_SET_POSITION | self._F_SET_TILT
+        )
+        self._prep(cover)
+        cover.travel_calc.set_position(100)
+        cover.tilt_calc.set_position(50)
+
+        await cover.set_position(60)
+
+        services = [c.args[1] for c in _calls(cover.hass.services.async_call)]
+        assert "set_cover_position" in services
+        assert "close_cover" not in services and "open_cover" not in services

--- a/tests/test_drivers.py
+++ b/tests/test_drivers.py
@@ -1,0 +1,52 @@
+"""Unit tests for the wrapped-cover actuation drivers."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.cover_time_based.drivers import (
+    NativePositionDriver,
+    TimedPositionDriver,
+)
+
+
+def test_holds_itself_flags():
+    assert NativePositionDriver(MagicMock()).holds_itself is True
+    assert TimedPositionDriver(MagicMock()).holds_itself is False
+
+
+@pytest.mark.asyncio
+async def test_native_command_move_forwards_rounded_set_position():
+    cover = MagicMock()
+    cover._cover_entity_id = "cover.inner"
+    cover._call_set_cover_position = AsyncMock()
+    cover._require_movement_target_available = MagicMock()
+
+    driver = NativePositionDriver(cover)
+    await driver.command_move(59.6, "open", False)
+
+    cover._require_movement_target_available.assert_called_once_with("cover.inner")
+    cover._call_set_cover_position.assert_awaited_once_with(60)
+
+
+@pytest.mark.asyncio
+async def test_timed_command_move_delegates_to_base():
+    # The timed driver runs the base CoverTimeBased._command_position_move
+    # against the cover. We assert it calls through to that exact unbound
+    # method with the same args (full behaviour is covered by the existing
+    # wrapped-cover integration tests).
+    from custom_components.cover_time_based import drivers as drivers_mod
+
+    cover = MagicMock()
+    called = {}
+
+    async def fake_base(self, target, command, already):
+        called["args"] = (self, target, command, already)
+
+    drivers_mod.CoverTimeBased._command_position_move = fake_base
+    try:
+        driver = TimedPositionDriver(cover)
+        await driver.command_move(40, "close", True)
+    finally:
+        del drivers_mod.CoverTimeBased._command_position_move
+
+    assert called["args"] == (cover, 40, "close", True)

--- a/tests/test_drivers.py
+++ b/tests/test_drivers.py
@@ -26,27 +26,3 @@ async def test_native_command_move_forwards_rounded_set_position():
 
     cover._require_movement_target_available.assert_called_once_with("cover.inner")
     cover._call_set_cover_position.assert_awaited_once_with(60)
-
-
-@pytest.mark.asyncio
-async def test_timed_command_move_delegates_to_base():
-    # The timed driver runs the base CoverTimeBased._command_position_move
-    # against the cover. We assert it calls through to that exact unbound
-    # method with the same args (full behaviour is covered by the existing
-    # wrapped-cover integration tests).
-    from custom_components.cover_time_based import drivers as drivers_mod
-
-    cover = MagicMock()
-    called = {}
-
-    async def fake_base(self, target, command, already):
-        called["args"] = (self, target, command, already)
-
-    drivers_mod.CoverTimeBased._command_position_move = fake_base
-    try:
-        driver = TimedPositionDriver(cover)
-        await driver.command_move(40, "close", True)
-    finally:
-        del drivers_mod.CoverTimeBased._command_position_move
-
-    assert called["args"] == (cover, 40, "close", True)


### PR DESCRIPTION
## Native tilt & position forwarding for wrapped covers

Supersedes #154. Reworks wrapped-cover handling so a cover that natively positions its own slats is driven by **forwarding native commands**, with the time-based tracker used only as a live **display overlay**.

### Motivation

The existing wrapped-cover tilt support (#87) simulates tilt by pulsing the main motor for a timed burst. That is correct for covers that fake tilt that way, but wrong for a cover whose firmware positions its own slats (e.g. a Shelly Wave Shutter EU LR driving a venetian blind over Z-Wave): a tilt-close at the travel endpoint becomes a no-op, intermediate tilt angles can't be reached, and the tracker drifts because nothing reads back the angle the cover reports. Such covers also report position/tilt only once they stop moving, so their native slider is stale during travel — which is what makes wrapping them (for a smooth live display) worthwhile in the first place.

### What it does

For an **Inline**-tilt wrapped cover whose underlying entity advertises `set_cover_tilt_position` (and `set_cover_position`):

- **Native tilt** — set-tilt / open-tilt / close-tilt are forwarded straight to the wrapped cover; the tilt display animates during the move and snaps to the cover's reported angle on settle.
- **Native position** — `set_cover_position` is forwarded too (previously a configured tilt strategy forced timed positioning), giving device-accurate positioning.
- **Display sweep** — during a position travel the tilt display sweeps to the direction endpoint (venetian slats close going down, open going up) before syncing to the reported angle.
- **No relay stop** — the device holds itself at the target, so the auto-updater issues no stop command.

All of this is **auto-detected** from the wrapped entity's supported features — no new configuration. The existing opt-outs (`force_time_based_position`, `ignore_reported_position`, `reports_command_not_endpoint`) still force the timed path. Covers without native support, and the Sequential / Separate-tilt-motor strategies, keep their existing timed behaviour unchanged.

### Design

Implemented as a small **driver seam**: a `PositionDriver` / `TiltDriver` abstraction (Timed vs Native) selected per axis from the wrapped entity's capabilities, plus a shared tracker (display animation + settle-snap). The native path never relay-drives or timed-stops the cover, which removes the "is this state change mine or external?" guessing that time-window hacks otherwise need. **`cover_base.py` is not modified** — every change is an override on `WrappedCoverTimeBased` or a new class in `drivers.py`.

### Tests

Python suite extended for the driver seam, native tilt/position forwarding, the settle-snap gating (never clobbers dual-motor/sequential coupling), coupling neutralization, the self-driven-move guards, and the display sweep. Full suite green, `ruff check` + `ruff format` clean.
