### PR TITLE
feat: prompt a hard refresh after first-time card install

### DIFF
--- a/custom_components/cover_time_based/card_resources.py
+++ b/custom_components/cover_time_based/card_resources.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import logging
 
-from homeassistant.components import frontend
+from homeassistant.components import frontend, persistent_notification
 from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
@@ -26,11 +26,50 @@ from .const import DOMAIN
 _LOGGER = logging.getLogger(__name__)
 # Key under hass.data[DOMAIN] holding the registered resource's id.
 _RESOURCE_ID_KEY = "card_resource_id"
+# Stable id so repeated (re)registrations replace the notice rather than stack.
+_REFRESH_NOTIFICATION_ID = f"{DOMAIN}_card_refresh"
 
 
 def _get_lovelace_resources(hass: HomeAssistant):
     """The Lovelace resource collection, or None if unavailable (YAML mode)."""
     return getattr(hass.data.get("lovelace"), "resources", None)
+
+
+def _record_resource_id(hass: HomeAssistant, resource_id: str) -> None:
+    """Remember the resource's id (hass.data is empty after a restart) so a
+    later full uninstall can delete it."""
+    hass.data.setdefault(DOMAIN, {})[_RESOURCE_ID_KEY] = resource_id
+
+
+def _notify_card_refresh(hass: HomeAssistant) -> None:
+    """Tell the user to hard-refresh so the browser loads the newly added card.
+
+    HA loads its Lovelace resource list once, at page load, and does not
+    hot-inject a newly registered resource into already-open browser sessions.
+    So a fresh install leaves the card missing (or showing a "custom element
+    doesn't exist" error) until the page is reloaded — and, because HA's service
+    worker serves the app through a cache, often only a *hard* refresh picks it
+    up. Since the card is registered from Python rather than installed as a
+    standalone HACS plugin, the user otherwise gets no prompt to reload at all.
+
+    Fired only when the resource is newly created — a first install (or a
+    re-create after a full uninstall / upgrade from a pre-resource version),
+    all cases where open sessions lack the card. A version update instead leaves
+    the card already present (running the previous code) with the new JS at a
+    fresh, uncached URL, so a normal reload picks it up — nagging on every
+    release would be spam.
+    """
+    persistent_notification.async_create(
+        hass,
+        (
+            "The Cover Time Based dashboard card was installed. "
+            "Do a hard refresh of your browser (Ctrl+Shift+R, or ⌘+Shift+R "
+            "on Mac) to load it. If the card still shows a configuration error, "
+            "clear your browser cache and reload."
+        ),
+        title="Cover Time Based card installed",
+        notification_id=_REFRESH_NOTIFICATION_ID,
+    )
 
 
 async def async_register_card_resource(
@@ -45,37 +84,60 @@ async def async_register_card_resource(
     place; ``card_url`` is the current, content-hashed URL. Falls back to
     ``add_extra_js_url`` if the Lovelace resource store isn't available.
     """
+    # Set only when the resource is created for the first time — the sole case
+    # that warrants a refresh prompt (see _notify_card_refresh for why).
+    installed = False
     try:
         resources = _get_lovelace_resources(hass)
-        if resources is not None and hasattr(resources, "async_create_item"):
-            if not resources.loaded:
-                await resources.async_load()
-                resources.loaded = True
-            for item in resources.async_items():
-                url = item.get("url", "")
-                if url == card_url:
-                    # Already current — record the id (hass.data is empty after
-                    # a restart) so a later full uninstall can delete it.
-                    hass.data.setdefault(DOMAIN, {})[_RESOURCE_ID_KEY] = item["id"]
-                    return
-                if url.startswith(base_url):
-                    # Old version → cache-bust in place.
-                    await resources.async_update_item(item["id"], {"url": card_url})
-                    hass.data.setdefault(DOMAIN, {})[_RESOURCE_ID_KEY] = item["id"]
-                    return
+        if resources is None or not hasattr(resources, "async_create_item"):
+            frontend.add_extra_js_url(hass, card_url)
+            return
+
+        if not resources.loaded:
+            await resources.async_load()
+            resources.loaded = True
+
+        stale = None
+        for item in resources.async_items():
+            url = item.get("url", "")
+            if url == card_url:
+                # Already current — record the id so a later uninstall can
+                # delete it. No change, so no refresh notification.
+                _record_resource_id(hass, item["id"])
+                return
+            if url.startswith(base_url):
+                stale = item
+                break
+
+        if stale is not None:
+            # Old version → cache-bust in place. The card is already present in
+            # open sessions (running the old code) and the new JS is at a fresh,
+            # uncached URL, so a normal reload picks it up — done silently.
+            await resources.async_update_item(stale["id"], {"url": card_url})
+            _record_resource_id(hass, stale["id"])
+        else:
             item = await resources.async_create_item(
                 {"res_type": "module", "url": card_url}
             )
-            hass.data.setdefault(DOMAIN, {})[_RESOURCE_ID_KEY] = item["id"]
-            return
+            _record_resource_id(hass, item["id"])
+            installed = True
     except Exception:  # pylint: disable=broad-exception-caught
         _LOGGER.debug(
             "Could not register card as a Lovelace resource; "
             "falling back to add_extra_js_url",
             exc_info=True,
         )
+        frontend.add_extra_js_url(hass, card_url)
+        return
 
-    frontend.add_extra_js_url(hass, card_url)
+    # Notify outside the try so a notification failure can't trigger the
+    # fallback path and double-register the card; guard it separately so that
+    # failure also can't abort integration setup.
+    if installed:
+        try:
+            _notify_card_refresh(hass)
+        except Exception:  # pylint: disable=broad-exception-caught
+            _LOGGER.debug("Could not create card refresh notification", exc_info=True)
 
 
 async def async_unregister_card_resource(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -16,7 +16,10 @@ from custom_components.cover_time_based import (
     async_unload_entry,
     async_update_options,
 )
-from custom_components.cover_time_based.card_resources import _RESOURCE_ID_KEY
+from custom_components.cover_time_based.card_resources import (
+    _REFRESH_NOTIFICATION_ID,
+    _RESOURCE_ID_KEY,
+)
 from custom_components.cover_time_based.const import DOMAIN
 
 
@@ -244,6 +247,136 @@ class TestCardResourceRegistration:
         mock_add_js.assert_called_once()
         _, js_url = mock_add_js.call_args.args
         assert js_url == _CARD_JS_URL
+
+
+class TestCardRefreshNotification:
+    """HA does not hot-load a newly registered Lovelace resource into
+    already-open browser sessions, so a fresh install leaves the card missing
+    until the page is reloaded. Surface a persistent notification guiding the
+    user to hard-refresh — but only on a first install. A version update leaves
+    the card already present (running the old code) at a fresh, uncached URL, so
+    a normal reload suffices and a per-release nag would be spam. Never notify
+    on an unchanged restart or the YAML-mode add_extra_js_url fallback."""
+
+    _NOTIFY = "homeassistant.components.persistent_notification.async_create"
+
+    @pytest.mark.asyncio
+    async def test_fresh_install_notifies_to_refresh(self):
+        resources = FakeResources()
+        hass = _make_setup_hass(resources)
+
+        with (
+            patch("homeassistant.components.frontend.add_extra_js_url"),
+            patch(self._NOTIFY) as mock_notify,
+        ):
+            await async_setup(hass, {})
+
+        mock_notify.assert_called_once()
+        _, message = mock_notify.call_args.args
+        assert "refresh" in message.lower()
+        assert (
+            mock_notify.call_args.kwargs["notification_id"] == _REFRESH_NOTIFICATION_ID
+        )
+
+    @pytest.mark.asyncio
+    async def test_version_update_does_not_notify(self):
+        """On update the card is already present (running the old code) and the
+        new JS lives at a fresh, uncached URL, so a normal reload picks it up.
+        The resource is still cache-busted, but silently — no per-release nag."""
+        stale_url = f"{_CARD_BASE_URL}deadbeef/cover-time-based-card.js"
+        resources = FakeResources(items=[{"id": "old", "url": stale_url}], loaded=True)
+        hass = _make_setup_hass(resources)
+
+        with (
+            patch("homeassistant.components.frontend.add_extra_js_url"),
+            patch(self._NOTIFY) as mock_notify,
+        ):
+            await async_setup(hass, {})
+
+        # The cache-bust still happens...
+        assert resources.updated == [("old", {"url": _CARD_JS_URL})]
+        # ...but the user is not nagged.
+        mock_notify.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_unchanged_resource_does_not_notify(self):
+        resources = FakeResources(items=[{"id": "x", "url": _CARD_JS_URL}], loaded=True)
+        hass = _make_setup_hass(resources)
+
+        with (
+            patch("homeassistant.components.frontend.add_extra_js_url"),
+            patch(self._NOTIFY) as mock_notify,
+        ):
+            await async_setup(hass, {})
+
+        mock_notify.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_yaml_mode_fallback_does_not_notify(self):
+        hass = _make_setup_hass(None)
+
+        with (
+            patch("homeassistant.components.frontend.add_extra_js_url"),
+            patch(self._NOTIFY) as mock_notify,
+        ):
+            await async_setup(hass, {})
+
+        mock_notify.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_setup_then_entry_notifies_once(self):
+        """async_setup creates the resource (one notification); the per-entry
+        registration then finds it already current and must not notify again."""
+        resources = FakeResources()
+        hass = _make_setup_hass(resources)
+        hass.config_entries.async_forward_entry_setups = AsyncMock()
+        entry = MagicMock()
+        entry.async_on_unload = MagicMock()
+        entry.add_update_listener = MagicMock()
+
+        with (
+            patch("homeassistant.components.frontend.add_extra_js_url"),
+            patch(self._NOTIFY) as mock_notify,
+        ):
+            await async_setup(hass, {})
+            await async_setup_entry(hass, entry)
+
+        mock_notify.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_notification_failure_neither_aborts_setup_nor_falls_back(self):
+        """The notify runs outside the try so it can't cascade into the
+        double-registering fallback; it is also guarded so a notification
+        failure can't abort integration setup."""
+        resources = FakeResources()
+        hass = _make_setup_hass(resources)
+
+        with (
+            patch("homeassistant.components.frontend.add_extra_js_url") as mock_add_js,
+            patch(self._NOTIFY, side_effect=RuntimeError("boom")),
+        ):
+            result = await async_setup(hass, {})
+
+        assert result is True  # setup not aborted
+        assert len(resources.created) == 1  # resource registered exactly once
+        mock_add_js.assert_not_called()  # not double-registered via fallback
+
+    @pytest.mark.asyncio
+    async def test_resource_error_falls_back_and_does_not_notify(self):
+        """If registering the resource raises, we fall back to add_extra_js_url
+        and must not notify (no resource was created)."""
+        resources = FakeResources()
+        resources.async_create_item = AsyncMock(side_effect=RuntimeError("boom"))
+        hass = _make_setup_hass(resources)
+
+        with (
+            patch("homeassistant.components.frontend.add_extra_js_url") as mock_add_js,
+            patch(self._NOTIFY) as mock_notify,
+        ):
+            await async_setup(hass, {})
+
+        mock_add_js.assert_called_once()
+        mock_notify.assert_not_called()
 
 
 class TestManifest:


### PR DESCRIPTION
## Problem

After installing the integration, the dashboard card is **missing until the user does a hard refresh**. This is inherent to how HA loads frontend resources: HA reads its Lovelace resource list **once, at page load**, and does not hot-inject a newly registered resource into already-open browser sessions. So a fresh install leaves the card missing (or showing a "custom element doesn't exist" error) until the page is reloaded — and because HA's service worker serves the app through a cache, often only a **hard** refresh picks it up.

Because this card is registered from Python (not installed as a standalone HACS Lovelace plugin), the user gets **no** prompt to reload — unlike a HACS plugin, which tells you to refresh. Hence the confusion.

## Fix

Create a `persistent_notification` when the card resource is **newly created**, guiding the user to hard-refresh. It does not eliminate the one-time reload (HA gives us no way to hot-load into open sessions), but it removes the "why is my card missing?" surprise.

### When it fires

| Scenario | Notifies? |
|---|---|
| Fresh install (card missing until reload) | ✅ |
| Re-create after full uninstall / upgrade from a pre-resource version | ✅ (genuinely a new resource) |
| Version update (card already present; new JS at a fresh, uncached URL → normal reload suffices) | ❌ |
| Unchanged restart | ❌ |
| YAML-mode `add_extra_js_url` fallback | ❌ |

Deliberately **install-only**: on a version update the old card keeps rendering and a normal reload picks up the new code, so nagging on every release (this repo ships frequently) would be spam.

### Safety

The notify runs **outside** the resource-registration `try` so a notification failure can't cascade into the double-registering `add_extra_js_url` fallback, and is **separately guarded** so a notification failure can't abort integration setup.

## Testing

- 7 new unit tests in `TestCardRefreshNotification` covering: notify-on-create, no-notify on update/unchanged/YAML-fallback, notify-once across `async_setup` + `async_setup_entry`, notify-failure neither aborts setup nor falls back, and resource-error → fallback without notify.
- Full suite: **1201 passed**; ruff check + format clean (pre-push gate green).

## Open question for review

The message/title are **hardcoded English**. This repo localises user-facing strings (`strings.json` + `pl`/`pt`), and the analogous repair notice uses a `translation_key`. But `persistent_notification.async_create` has **no** translation-key mechanism — localising would mean switching to a **sticky** `issue_registry` repair issue, which we deliberately avoided (a persistent notification is dismissible and self-limiting). Happy to switch if pl/pt parity is preferred over the lighter primitive.