### PR TITLE
feat: use a translated repair issue for the card-refresh prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Fixes
+
+- **A Repairs prompt now guides you to hard-refresh after installing the card** ([#164](https://github.com/Sese-Schneider/ha-cover-time-based/issues/164)): Home Assistant loads dashboard resources only when the page first loads, so immediately after installing the integration the **Cover Time Based** card is missing from already-open browser sessions until the page is reloaded — and because HA's service worker caches the app, often only a *hard* refresh brings it in. Since the card is registered by the integration itself rather than installed as a standalone HACS plugin, nothing prompted you to reload. A dismissible **Settings → Repairs** notice (translated EN/PL/PT) now appears to prompt the hard refresh. It is raised only when the card resource is newly created — a first install (or a re-create after a full uninstall) — never on a version update (the card is already present and a normal reload picks up the new code) or an ordinary restart, and it clears itself on the next restart once a fresh session would load the card anyway.
+
 ## 4.8.0 (2026-07-06)
 
 ### Features

--- a/custom_components/cover_time_based/card_resources.py
+++ b/custom_components/cover_time_based/card_resources.py
@@ -18,16 +18,18 @@ from __future__ import annotations
 
 import logging
 
-from homeassistant.components import frontend, persistent_notification
+from homeassistant.components import frontend
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 # Key under hass.data[DOMAIN] holding the registered resource's id.
 _RESOURCE_ID_KEY = "card_resource_id"
-# Stable id so repeated (re)registrations replace the notice rather than stack.
-_REFRESH_NOTIFICATION_ID = f"{DOMAIN}_card_refresh"
+# issue_id (scoped to DOMAIN) and translation_key for the "card installed —
+# hard-refresh to load it" repair issue.
+_CARD_INSTALLED_ISSUE = "card_installed"
 
 
 def _get_lovelace_resources(hass: HomeAssistant):
@@ -41,34 +43,31 @@ def _record_resource_id(hass: HomeAssistant, resource_id: str) -> None:
     hass.data.setdefault(DOMAIN, {})[_RESOURCE_ID_KEY] = resource_id
 
 
-def _notify_card_refresh(hass: HomeAssistant) -> None:
-    """Tell the user to hard-refresh so the browser loads the newly added card.
+def _create_refresh_issue(hass: HomeAssistant) -> None:
+    """Raise a repair issue telling the user to hard-refresh for the new card.
 
-    HA loads its Lovelace resource list once, at page load, and does not
-    hot-inject a newly registered resource into already-open browser sessions.
-    So a fresh install leaves the card missing (or showing a "custom element
-    doesn't exist" error) until the page is reloaded — and, because HA's service
-    worker serves the app through a cache, often only a *hard* refresh picks it
-    up. Since the card is registered from Python rather than installed as a
-    standalone HACS plugin, the user otherwise gets no prompt to reload at all.
+    The module docstring explains the custom-element timing issue that makes a
+    reload necessary; the user-facing title/description are translated via
+    ``translation_key`` (strings.json + translations/).
 
-    Fired only when the resource is newly created — a first install (or a
+    Raised only when the resource is newly created — a first install (or a
     re-create after a full uninstall / upgrade from a pre-resource version),
     all cases where open sessions lack the card. A version update instead leaves
     the card already present (running the previous code) with the new JS at a
     fresh, uncached URL, so a normal reload picks it up — nagging on every
     release would be spam.
+
+    Non-fixable and non-persistent (the HA default): the user dismisses it once
+    the card appears, and it clears on the next restart — by then any fresh
+    session loads the card anyway, and we only re-raise it on a real new create.
     """
-    persistent_notification.async_create(
+    async_create_issue(
         hass,
-        (
-            "The Cover Time Based dashboard card was installed. "
-            "Do a hard refresh of your browser (Ctrl+Shift+R, or ⌘+Shift+R "
-            "on Mac) to load it. If the card still shows a configuration error, "
-            "clear your browser cache and reload."
-        ),
-        title="Cover Time Based card installed",
-        notification_id=_REFRESH_NOTIFICATION_ID,
+        DOMAIN,
+        _CARD_INSTALLED_ISSUE,
+        is_fixable=False,
+        severity=IssueSeverity.WARNING,
+        translation_key=_CARD_INSTALLED_ISSUE,
     )
 
 
@@ -85,7 +84,7 @@ async def async_register_card_resource(
     ``add_extra_js_url`` if the Lovelace resource store isn't available.
     """
     # Set only when the resource is created for the first time — the sole case
-    # that warrants a refresh prompt (see _notify_card_refresh for why).
+    # that warrants a refresh prompt (see _create_refresh_issue for why).
     installed = False
     try:
         resources = _get_lovelace_resources(hass)
@@ -102,7 +101,7 @@ async def async_register_card_resource(
             url = item.get("url", "")
             if url == card_url:
                 # Already current — record the id so a later uninstall can
-                # delete it. No change, so no refresh notification.
+                # delete it. No change, so no refresh issue.
                 _record_resource_id(hass, item["id"])
                 return
             if url.startswith(base_url):
@@ -130,14 +129,14 @@ async def async_register_card_resource(
         frontend.add_extra_js_url(hass, card_url)
         return
 
-    # Notify outside the try so a notification failure can't trigger the
-    # fallback path and double-register the card; guard it separately so that
-    # failure also can't abort integration setup.
+    # Raise the issue outside the try so a failure can't trigger the fallback
+    # path and double-register the card; guard it separately so that failure
+    # also can't abort integration setup.
     if installed:
         try:
-            _notify_card_refresh(hass)
+            _create_refresh_issue(hass)
         except Exception:  # pylint: disable=broad-exception-caught
-            _LOGGER.debug("Could not create card refresh notification", exc_info=True)
+            _LOGGER.debug("Could not create card refresh repair issue", exc_info=True)
 
 
 async def async_unregister_card_resource(

--- a/custom_components/cover_time_based/strings.json
+++ b/custom_components/cover_time_based/strings.json
@@ -11,6 +11,10 @@
     }
   },
   "issues": {
+    "card_installed": {
+      "title": "Refresh your browser to show the Cover Time Based card",
+      "description": "The Cover Time Based dashboard card was installed. Home Assistant only loads dashboard resources when the page loads, so in already-open browser sessions the card stays missing until you reload — and often only a **hard refresh** works. Do a hard refresh (**Ctrl+Shift+R**, or **⌘+Shift+R** on macOS) to load the card; if it still shows a configuration error, clear your browser cache and reload. You can dismiss this issue once the card appears."
+    },
     "deprecated_yaml": {
       "title": "YAML configuration is deprecated",
       "description": "Configuring Cover Time Based using YAML is deprecated and will be removed in a future version.\n\nPlease remove the YAML configuration and recreate your covers using the UI: **Settings > Devices & Services > Helpers > Create Helper > Cover Time Based**."

--- a/custom_components/cover_time_based/translations/en.json
+++ b/custom_components/cover_time_based/translations/en.json
@@ -11,6 +11,10 @@
     }
   },
   "issues": {
+    "card_installed": {
+      "title": "Refresh your browser to show the Cover Time Based card",
+      "description": "The Cover Time Based dashboard card was installed. Home Assistant only loads dashboard resources when the page loads, so in already-open browser sessions the card stays missing until you reload — and often only a **hard refresh** works. Do a hard refresh (**Ctrl+Shift+R**, or **⌘+Shift+R** on macOS) to load the card; if it still shows a configuration error, clear your browser cache and reload. You can dismiss this issue once the card appears."
+    },
     "deprecated_yaml": {
       "title": "YAML configuration is deprecated",
       "description": "Configuring Cover Time Based using YAML is deprecated and will be removed in a future version.\n\nPlease remove the YAML configuration and recreate your covers using the UI: **Settings > Devices & Services > Helpers > Create Helper > Cover Time Based**."

--- a/custom_components/cover_time_based/translations/pl.json
+++ b/custom_components/cover_time_based/translations/pl.json
@@ -11,6 +11,10 @@
     }
   },
   "issues": {
+    "card_installed": {
+      "title": "Odśwież przeglądarkę, aby wyświetlić kartę Cover Time Based",
+      "description": "Karta Cover Time Based została zainstalowana. Home Assistant ładuje zasoby panelu tylko podczas wczytywania strony, więc w już otwartych sesjach przeglądarki karta pozostaje niewidoczna do czasu ponownego załadowania — i często pomaga dopiero **twarde odświeżenie**. Wykonaj twarde odświeżenie (**Ctrl+Shift+R** lub **⌘+Shift+R** w systemie macOS), aby załadować kartę; jeśli nadal wyświetla się błąd konfiguracji, wyczyść pamięć podręczną przeglądarki i załaduj ponownie. Możesz zignorować to ostrzeżenie, gdy karta się pojawi."
+    },
     "deprecated_yaml": {
       "title": "Konfiguracja YAML jest przestarzała",
       "description": "Konfiguracja Cover Time Based za pomocą YAML jest przestarzała i zostanie usunięta w przyszłej wersji.\n\nProszę usunąć konfigurację YAML i odtworzyć rolety za pomocą interfejsu: **Ustawienia > Urządzenia i usługi > Pomocniki > Utwórz pomocnik > Cover Time Based**."

--- a/custom_components/cover_time_based/translations/pt.json
+++ b/custom_components/cover_time_based/translations/pt.json
@@ -11,6 +11,10 @@
     }
   },
   "issues": {
+    "card_installed": {
+      "title": "Atualize o navegador para mostrar o cartão Cover Time Based",
+      "description": "O cartão Cover Time Based foi instalado. O Home Assistant só carrega os recursos do painel ao carregar a página, por isso nas sessões do navegador já abertas o cartão permanece ausente até recarregar — e muitas vezes só um **recarregamento forçado** funciona. Faça um recarregamento forçado (**Ctrl+Shift+R**, ou **⌘+Shift+R** no macOS) para carregar o cartão; se ainda mostrar um erro de configuração, limpe a cache do navegador e recarregue. Pode dispensar este aviso assim que o cartão aparecer."
+    },
     "deprecated_yaml": {
       "title": "A configuração YAML está obsoleta",
       "description": "A configuração do Cover Time Based usando YAML está obsoleta e será removida numa versão futura.\n\nPor favor, remova a configuração YAML e recrie os seus estores usando a interface: **Definições > Dispositivos e Serviços > Auxiliares > Criar Auxiliar > Cover Time Based**."

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -5,6 +5,8 @@ import re
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from homeassistant.helpers.issue_registry import IssueSeverity
+
 from custom_components.cover_time_based import (
     _CARD_BASE_URL,
     _CARD_JS_URL,
@@ -17,7 +19,7 @@ from custom_components.cover_time_based import (
     async_update_options,
 )
 from custom_components.cover_time_based.card_resources import (
-    _REFRESH_NOTIFICATION_ID,
+    _CARD_INSTALLED_ISSUE,
     _RESOURCE_ID_KEY,
 )
 from custom_components.cover_time_based.const import DOMAIN
@@ -249,37 +251,43 @@ class TestCardResourceRegistration:
         assert js_url == _CARD_JS_URL
 
 
-class TestCardRefreshNotification:
+class TestCardRefreshRepairIssue:
     """HA does not hot-load a newly registered Lovelace resource into
     already-open browser sessions, so a fresh install leaves the card missing
-    until the page is reloaded. Surface a persistent notification guiding the
-    user to hard-refresh — but only on a first install. A version update leaves
-    the card already present (running the old code) at a fresh, uncached URL, so
-    a normal reload suffices and a per-release nag would be spam. Never notify
-    on an unchanged restart or the YAML-mode add_extra_js_url fallback."""
+    until the page is reloaded. Raise a translated repair issue guiding the
+    user to hard-refresh — but only on a first install (resource newly
+    created). A version update leaves the card already present at a fresh,
+    uncached URL, so a normal reload suffices and a per-release nag would be
+    spam. Never raise it on an unchanged restart or the YAML-mode
+    add_extra_js_url fallback."""
 
-    _NOTIFY = "homeassistant.components.persistent_notification.async_create"
+    _CREATE_ISSUE = (
+        "custom_components.cover_time_based.card_resources.async_create_issue"
+    )
 
     @pytest.mark.asyncio
-    async def test_fresh_install_notifies_to_refresh(self):
+    async def test_fresh_install_raises_refresh_issue(self):
         resources = FakeResources()
         hass = _make_setup_hass(resources)
 
         with (
             patch("homeassistant.components.frontend.add_extra_js_url"),
-            patch(self._NOTIFY) as mock_notify,
+            patch(self._CREATE_ISSUE) as mock_issue,
         ):
             await async_setup(hass, {})
 
-        mock_notify.assert_called_once()
-        _, message = mock_notify.call_args.args
-        assert "refresh" in message.lower()
-        assert (
-            mock_notify.call_args.kwargs["notification_id"] == _REFRESH_NOTIFICATION_ID
-        )
+        mock_issue.assert_called_once()
+        # async_create_issue(hass, DOMAIN, issue_id, ...)
+        _, domain, issue_id = mock_issue.call_args.args
+        assert domain == DOMAIN
+        assert issue_id == _CARD_INSTALLED_ISSUE
+        kwargs = mock_issue.call_args.kwargs
+        assert kwargs["translation_key"] == _CARD_INSTALLED_ISSUE
+        assert kwargs["is_fixable"] is False
+        assert kwargs["severity"] == IssueSeverity.WARNING
 
     @pytest.mark.asyncio
-    async def test_version_update_does_not_notify(self):
+    async def test_version_update_does_not_raise_issue(self):
         """On update the card is already present (running the old code) and the
         new JS lives at a fresh, uncached URL, so a normal reload picks it up.
         The resource is still cache-busted, but silently — no per-release nag."""
@@ -289,44 +297,44 @@ class TestCardRefreshNotification:
 
         with (
             patch("homeassistant.components.frontend.add_extra_js_url"),
-            patch(self._NOTIFY) as mock_notify,
+            patch(self._CREATE_ISSUE) as mock_issue,
         ):
             await async_setup(hass, {})
 
         # The cache-bust still happens...
         assert resources.updated == [("old", {"url": _CARD_JS_URL})]
         # ...but the user is not nagged.
-        mock_notify.assert_not_called()
+        mock_issue.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_unchanged_resource_does_not_notify(self):
+    async def test_unchanged_resource_does_not_raise_issue(self):
         resources = FakeResources(items=[{"id": "x", "url": _CARD_JS_URL}], loaded=True)
         hass = _make_setup_hass(resources)
 
         with (
             patch("homeassistant.components.frontend.add_extra_js_url"),
-            patch(self._NOTIFY) as mock_notify,
+            patch(self._CREATE_ISSUE) as mock_issue,
         ):
             await async_setup(hass, {})
 
-        mock_notify.assert_not_called()
+        mock_issue.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_yaml_mode_fallback_does_not_notify(self):
+    async def test_yaml_mode_fallback_does_not_raise_issue(self):
         hass = _make_setup_hass(None)
 
         with (
             patch("homeassistant.components.frontend.add_extra_js_url"),
-            patch(self._NOTIFY) as mock_notify,
+            patch(self._CREATE_ISSUE) as mock_issue,
         ):
             await async_setup(hass, {})
 
-        mock_notify.assert_not_called()
+        mock_issue.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_setup_then_entry_notifies_once(self):
-        """async_setup creates the resource (one notification); the per-entry
-        registration then finds it already current and must not notify again."""
+    async def test_setup_then_entry_raises_issue_once(self):
+        """async_setup creates the resource (one issue); the per-entry
+        registration then finds it already current and must not raise again."""
         resources = FakeResources()
         hass = _make_setup_hass(resources)
         hass.config_entries.async_forward_entry_setups = AsyncMock()
@@ -336,24 +344,24 @@ class TestCardRefreshNotification:
 
         with (
             patch("homeassistant.components.frontend.add_extra_js_url"),
-            patch(self._NOTIFY) as mock_notify,
+            patch(self._CREATE_ISSUE) as mock_issue,
         ):
             await async_setup(hass, {})
             await async_setup_entry(hass, entry)
 
-        mock_notify.assert_called_once()
+        mock_issue.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_notification_failure_neither_aborts_setup_nor_falls_back(self):
-        """The notify runs outside the try so it can't cascade into the
-        double-registering fallback; it is also guarded so a notification
-        failure can't abort integration setup."""
+    async def test_issue_failure_neither_aborts_setup_nor_falls_back(self):
+        """The issue is raised outside the try so a failure can't cascade into
+        the double-registering fallback; it is also guarded so a failure can't
+        abort integration setup."""
         resources = FakeResources()
         hass = _make_setup_hass(resources)
 
         with (
             patch("homeassistant.components.frontend.add_extra_js_url") as mock_add_js,
-            patch(self._NOTIFY, side_effect=RuntimeError("boom")),
+            patch(self._CREATE_ISSUE, side_effect=RuntimeError("boom")),
         ):
             result = await async_setup(hass, {})
 
@@ -362,21 +370,21 @@ class TestCardRefreshNotification:
         mock_add_js.assert_not_called()  # not double-registered via fallback
 
     @pytest.mark.asyncio
-    async def test_resource_error_falls_back_and_does_not_notify(self):
+    async def test_resource_error_falls_back_and_does_not_raise_issue(self):
         """If registering the resource raises, we fall back to add_extra_js_url
-        and must not notify (no resource was created)."""
+        and must not raise the issue (no resource was created)."""
         resources = FakeResources()
         resources.async_create_item = AsyncMock(side_effect=RuntimeError("boom"))
         hass = _make_setup_hass(resources)
 
         with (
             patch("homeassistant.components.frontend.add_extra_js_url") as mock_add_js,
-            patch(self._NOTIFY) as mock_notify,
+            patch(self._CREATE_ISSUE) as mock_issue,
         ):
             await async_setup(hass, {})
 
         mock_add_js.assert_called_once()
-        mock_notify.assert_not_called()
+        mock_issue.assert_not_called()
 
 
 class TestManifest:


### PR DESCRIPTION
Follow-up to #163. Replaces the hardcoded-English persistent notification with a **translated `issue_registry` repair issue**, so the "hard-refresh to load the new card" prompt is localised.

## Why
#163 added a persistent notification, but its text was hardcoded English while this integration localises all user-facing strings (`strings.json` + `pl`/`pt`). `persistent_notification.async_create` has no `translation_key`, so localising means moving to a repair issue — which is also the mechanism the integration already uses for `deprecated_yaml`.

## What
- `card_resources.py`: `async_create_issue(hass, DOMAIN, "card_installed", is_fixable=False, severity=WARNING, translation_key="card_installed")`, mirroring the existing `deprecated_yaml` call.
- `issues.card_installed` (title + description) added to `strings.json` and `translations/en.json` + `pl.json` + `pt.json`.

## Behaviour (unchanged from #163)
Raised **only** when the Lovelace resource is newly created (first install / re-create) — never on a version update, unchanged restart, or the `add_extra_js_url` fallback. **Non-fixable, non-persistent**: the user dismisses it, and it self-clears on the next restart (by then any fresh session loads the card anyway). Raising it stays outside the registration `try` (no fallback cascade) and is separately guarded (can't abort setup).

## Testing
- `TestCardRefreshRepairIssue` (7 tests) rewritten to assert on `async_create_issue` (domain, issue_id, `translation_key`, `is_fixable`, `severity`), plus the no-raise cases.
- Full suite **1201 passed**; ruff + i18n-drift + hassfest (CI) clean.

## Note on translations
The `pl`/`pt` strings were reviewed for accuracy, naturalness, and consistency with the existing `deprecated_yaml` entries — a native-speaker glance is still welcome, but they're assessed as ship-quality.