### PR TITLE
feat: remember the card's last-selected device across reloads

### DIFF
--- a/custom_components/cover_time_based/frontend/card-render.js
+++ b/custom_components/cover_time_based/frontend/card-render.js
@@ -58,7 +58,7 @@ export function renderEntityPicker(card) {
               card._onStopCalibration(true);
             }
           }
-          card._selectedEntity = newEntity;
+          card._setSelectedEntity(newEntity);
           card._config = null;
           card._loadError = null;
           card._knownPosition = "unknown";

--- a/custom_components/cover_time_based/frontend/cover-time-based-card.js
+++ b/custom_components/cover_time_based/frontend/cover-time-based-card.js
@@ -54,6 +54,7 @@ class CoverTimeBasedCard extends LitElement {
     this._helpersLoaded = false;
     this._openHelp = null;
     this._selectionRestoreAttempted = false;
+    this._configLoadToken = 0;
   }
 
   // --- Translation support ---
@@ -223,6 +224,7 @@ class CoverTimeBasedCard extends LitElement {
   async _loadConfig() {
     const entityId = this._selectedEntity;
     if (!entityId || !this.hass) return;
+    const token = ++this._configLoadToken;
     this._loading = true;
     this._loadError = null;
     try {
@@ -233,8 +235,7 @@ class CoverTimeBasedCard extends LitElement {
       // The selection can change while this is in flight (the user picks
       // another device, or a restored selection races their pick). Applying a
       // stale response would bind one device's config to another — and the next
-      // autosave would then write those settings onto the wrong device. The
-      // newer load owns _loading and will clear it.
+      // autosave would then write those settings onto the wrong device.
       if (this._selectedEntity !== entityId) return;
       this._config = config;
     } catch (err) {
@@ -242,8 +243,13 @@ class CoverTimeBasedCard extends LitElement {
       console.error("Failed to load config:", err);
       this._config = null;
       this._loadError = this._t("yaml_warning");
+    } finally {
+      // Only the newest request owns the spinner: an older one must not clear
+      // it while a newer load is still running, but a request that was merely
+      // abandoned (the user cleared the picker, so nothing newer started) still
+      // has to, or the card spins forever.
+      if (token === this._configLoadToken) this._loading = false;
     }
-    this._loading = false;
   }
 
   _updateLocal(updates) {

--- a/custom_components/cover_time_based/frontend/cover-time-based-card.js
+++ b/custom_components/cover_time_based/frontend/cover-time-based-card.js
@@ -21,6 +21,7 @@ import {
   coverConfirmedWithoutTilt,
 } from "./entity-filter.js";
 import { DOMAIN, ATTRIBUTE_TO_CONFIG } from "./constants.js";
+import { loadSelectedEntity, saveSelectedEntity } from "./selection-storage.js";
 import { translate } from "./translations.js";
 import { cardStyles } from "./card-styles.js";
 import { renderCard } from "./card-render.js";
@@ -127,8 +128,35 @@ class CoverTimeBasedCard extends LitElement {
       this.requestUpdate();
     }
 
-    // Load entity list from full registry (includes config_entry_id)
-    this._loadEntityList();
+    // Load entity list from full registry (includes config_entry_id), then
+    // restore the device this browser last had selected. Restoring afterwards
+    // lets the remembered id be validated against the live list.
+    this._entityListReady = this._loadEntityList().then(() =>
+      this._restoreSelection()
+    );
+  }
+
+  /**
+   * Re-select the device remembered from a previous session, if it is still a
+   * live cover_time_based entity. A device that has since been deleted is
+   * dropped silently rather than left in the picker with a failing config load
+   * beneath it.
+   */
+  _restoreSelection() {
+    // The user may have picked a device while the registry lookup was in
+    // flight; never override a live selection.
+    if (this._selectedEntity) return;
+    const remembered = loadSelectedEntity();
+    if (!remembered) return;
+    if (!(this._configEntryEntities || []).includes(remembered)) return;
+    this._selectedEntity = remembered;
+    this._loadConfig();
+  }
+
+  /** Sets the selected device and remembers it for the next page load. */
+  _setSelectedEntity(entityId) {
+    this._selectedEntity = entityId;
+    saveSelectedEntity(entityId);
   }
 
   updated(changedProperties) {
@@ -284,7 +312,7 @@ class CoverTimeBasedCard extends LitElement {
 
   _onEntityChange(e) {
     const newValue = e.detail?.value || e.target?.value || "";
-    this._selectedEntity = newValue;
+    this._setSelectedEntity(newValue);
     this._config = null;
     if (this._selectedEntity) {
       this._loadConfig();

--- a/custom_components/cover_time_based/frontend/cover-time-based-card.js
+++ b/custom_components/cover_time_based/frontend/cover-time-based-card.js
@@ -53,6 +53,7 @@ class CoverTimeBasedCard extends LitElement {
     this._knownPosition = "unknown";
     this._helpersLoaded = false;
     this._openHelp = null;
+    this._selectionRestoreAttempted = false;
   }
 
   // --- Translation support ---
@@ -128,21 +129,30 @@ class CoverTimeBasedCard extends LitElement {
       this.requestUpdate();
     }
 
-    // Load entity list from full registry (includes config_entry_id), then
-    // restore the device this browser last had selected. Restoring afterwards
-    // lets the remembered id be validated against the live list.
-    this._entityListReady = this._loadEntityList().then(() =>
-      this._restoreSelection()
-    );
+    // Load entity list from full registry (includes config_entry_id). This also
+    // restores the device this browser last had selected, once the list is
+    // available to validate it against.
+    this._entityListReady = this._loadEntityList();
   }
 
   /**
    * Re-select the device remembered from a previous session, if it is still a
    * live cover_time_based entity. A device that has since been deleted is
-   * dropped silently rather than left in the picker with a failing config load
-   * beneath it.
+   * dropped silently rather than left in the picker (the entity may still fail
+   * to load for other reasons — an unloaded config entry, say — which surfaces
+   * as the usual load error). Called from _loadEntityList, which supplies the
+   * live list this validates against.
    */
   _restoreSelection() {
+    // The registry lookup may have outlived the element; a detached card must
+    // not mutate state or issue further calls. No attempt is recorded, so a
+    // later re-connect can still restore.
+    if (!this.isConnected) return;
+    // Restore only on the card's first load. connectedCallback runs again every
+    // time HA re-parents the element, and restoring then would pull a selection
+    // made in another card or browser tab into a picker the user had cleared.
+    if (this._selectionRestoreAttempted) return;
+    this._selectionRestoreAttempted = true;
     // The user may have picked a device while the registry lookup was in
     // flight; never override a live selection.
     if (this._selectedEntity) return;
@@ -175,6 +185,9 @@ class CoverTimeBasedCard extends LitElement {
         validEntryIds,
         DOMAIN
       );
+      // Restore before requesting the update so the populated picker and the
+      // restored selection render together, rather than in two passes.
+      this._restoreSelection();
       this.requestUpdate();
     } catch (err) {
       console.error(
@@ -208,15 +221,24 @@ class CoverTimeBasedCard extends LitElement {
   // --- Data fetching ---
 
   async _loadConfig() {
-    if (!this._selectedEntity || !this.hass) return;
+    const entityId = this._selectedEntity;
+    if (!entityId || !this.hass) return;
     this._loading = true;
     this._loadError = null;
     try {
-      this._config = await this.hass.callWS({
+      const config = await this.hass.callWS({
         type: "cover_time_based/get_config",
-        entity_id: this._selectedEntity,
+        entity_id: entityId,
       });
+      // The selection can change while this is in flight (the user picks
+      // another device, or a restored selection races their pick). Applying a
+      // stale response would bind one device's config to another — and the next
+      // autosave would then write those settings onto the wrong device. The
+      // newer load owns _loading and will clear it.
+      if (this._selectedEntity !== entityId) return;
+      this._config = config;
     } catch (err) {
+      if (this._selectedEntity !== entityId) return;
       console.error("Failed to load config:", err);
       this._config = null;
       this._loadError = this._t("yaml_warning");

--- a/custom_components/cover_time_based/frontend/selection-storage.js
+++ b/custom_components/cover_time_based/frontend/selection-storage.js
@@ -7,6 +7,11 @@
  * selection is restored without a websocket round-trip and the picker never
  * renders empty and then jumps.
  *
+ * The key is per-origin, not per-card: several config cards on one dashboard
+ * (or several browser tabs) share one memory, so they all restore whichever
+ * device was selected last. That suits a single config card, which is the
+ * expected usage.
+ *
  * Every access is guarded: Safari private mode and storage-disabled browsers
  * throw on localStorage access, and a forgotten selection is far better than a
  * broken picker.

--- a/custom_components/cover_time_based/frontend/selection-storage.js
+++ b/custom_components/cover_time_based/frontend/selection-storage.js
@@ -1,0 +1,37 @@
+/**
+ * Persistence for the config card's selected device.
+ *
+ * The card resets its picker on every load, so the last-selected device is
+ * remembered in localStorage and restored on connect. This is per-browser
+ * rather than per-HA-user by design: reading it is synchronous, so the
+ * selection is restored without a websocket round-trip and the picker never
+ * renders empty and then jumps.
+ *
+ * Every access is guarded: Safari private mode and storage-disabled browsers
+ * throw on localStorage access, and a forgotten selection is far better than a
+ * broken picker.
+ */
+
+export const SELECTION_STORAGE_KEY = "cover_time_based_card.selected_entity";
+
+/** Returns the remembered entity id, or "" if absent or unreadable. */
+export function loadSelectedEntity() {
+  try {
+    return window.localStorage.getItem(SELECTION_STORAGE_KEY) || "";
+  } catch (_) {
+    return "";
+  }
+}
+
+/** Remembers `entityId`, or forgets the selection when it is falsy. */
+export function saveSelectedEntity(entityId) {
+  try {
+    if (entityId) {
+      window.localStorage.setItem(SELECTION_STORAGE_KEY, entityId);
+    } else {
+      window.localStorage.removeItem(SELECTION_STORAGE_KEY);
+    }
+  } catch (_) {
+    // storage unavailable — the selection simply isn't remembered
+  }
+}

--- a/tests/frontend/card_selection_memory.test.mjs
+++ b/tests/frontend/card_selection_memory.test.mjs
@@ -7,7 +7,7 @@
  * Run: npm run test:fe -- tests/frontend/card_selection_memory.test.mjs
  */
 
-import { test, expect, afterEach, vi } from "vitest";
+import { test, expect, afterEach } from "vitest";
 import { makeHass } from "./helpers/hass.mjs";
 import { mountCard, defineHaStubs } from "./helpers/mount.mjs";
 import {
@@ -19,21 +19,30 @@ defineHaStubs();
 
 let card;
 afterEach(() => {
-  vi.restoreAllMocks();
   card?.remove();
   card = null;
 });
 
-/** hass whose registry exposes `entityIds` as live cover_time_based entities. */
-function hassWithEntities(entityIds) {
+/**
+ * hass whose registry exposes `entityIds` as live cover_time_based entities.
+ *
+ * `delayRegistry` makes the registry lookup resolve on a macrotask instead of
+ * synchronously, so a test can act while _loadEntityList is genuinely in
+ * flight. Without it the restore has already finished by the time mountCard
+ * returns, and any "mid-flight" assertion passes vacuously.
+ */
+function hassWithEntities(entityIds, { delayRegistry = false } = {}) {
+  const registry = () =>
+    entityIds.map((id) => ({
+      entity_id: id,
+      platform: "cover_time_based",
+      config_entry_id: "e1",
+    }));
   return makeHass({
     ws: {
-      "config/entity_registry/list": () =>
-        entityIds.map((id) => ({
-          entity_id: id,
-          platform: "cover_time_based",
-          config_entry_id: "e1",
-        })),
+      "config/entity_registry/list": delayRegistry
+        ? () => new Promise((r) => setTimeout(() => r(registry()), 0))
+        : registry,
       "config_entries/get": () => [{ entry_id: "e1" }],
     },
   });
@@ -80,13 +89,84 @@ test("with nothing remembered the picker stays empty", async () => {
   expect(card._selectedEntity).toBe("");
 });
 
-test("a selection made before the entity list resolves is not clobbered", async () => {
+test("a selection made while the entity list is in flight is not clobbered", async () => {
   saveSelectedEntity("cover.remembered");
-  card = await mountCard(hassWithEntities(["cover.remembered", "cover.chosen"]));
-  // User picks a device while the registry lookup is still in flight.
+  // Registry resolves on a macrotask, so the pick below genuinely lands
+  // mid-flight rather than after the restore has already run.
+  const hass = hassWithEntities(["cover.remembered", "cover.chosen"], {
+    delayRegistry: true,
+  });
+  card = await mountCard(hass);
+  expect(card._selectedEntity).toBe(""); // restore has not run yet
   card._setSelectedEntity("cover.chosen");
   await card._entityListReady;
+
   expect(card._selectedEntity).toBe("cover.chosen");
+  // Asserting the selection alone proves nothing here: the pick also rewrote
+  // storage, so a restore that ignored the guard would land on the same id.
+  // What distinguishes them is that the guarded restore bows out entirely and
+  // never drives a config load of its own — loading is the picker's job.
+  expect(hass.callWS).not.toHaveBeenCalledWith(
+    expect.objectContaining({ type: "cover_time_based/get_config" })
+  );
+});
+
+test("a card detached mid-lookup does not restore or call out", async () => {
+  saveSelectedEntity("cover.remembered");
+  const hass = hassWithEntities(["cover.remembered"], { delayRegistry: true });
+  card = await mountCard(hass);
+  card.remove(); // HA tears the card down before the registry lands
+  await card._entityListReady;
+
+  expect(card._selectedEntity).toBe("");
+  expect(hass.callWS).not.toHaveBeenCalledWith(
+    expect.objectContaining({ type: "cover_time_based/get_config" })
+  );
+});
+
+test("re-connecting does not adopt a selection the user cleared in this card", async () => {
+  // A second tab (or another card) remembers a device this card didn't choose.
+  card = await mountCard(hassWithEntities(["cover.elsewhere"]));
+  await card._entityListReady;
+  expect(card._selectedEntity).toBe("");
+  saveSelectedEntity("cover.elsewhere");
+
+  // HA re-parents the card (view re-render / DOM move).
+  card.remove();
+  document.body.appendChild(card);
+  await card._entityListReady;
+
+  expect(card._selectedEntity).toBe("");
+});
+
+test("a config response arriving after the device changed is discarded", async () => {
+  let releaseFirst;
+  const hass = makeHass({
+    ws: {
+      "config/entity_registry/list": () => [],
+      "config_entries/get": () => [],
+      "cover_time_based/get_config": ({ entity_id }) =>
+        entity_id === "cover.slow"
+          ? new Promise((r) => {
+              releaseFirst = () => r({ control_mode: "switch", marker: "slow" });
+            })
+          : { control_mode: "switch", marker: "fast" },
+    },
+  });
+  card = await mountCard(hass);
+  await card._entityListReady;
+
+  card._setSelectedEntity("cover.slow");
+  const slowLoad = card._loadConfig();
+  card._setSelectedEntity("cover.fast");
+  await card._loadConfig();
+  releaseFirst();
+  await slowLoad;
+
+  // The late response for cover.slow must not overwrite cover.fast's config,
+  // or the next autosave writes one device's settings onto another.
+  expect(card._selectedEntity).toBe("cover.fast");
+  expect(card._config?.marker).toBe("fast");
 });
 
 // ---------------------------------------------------------------------------
@@ -112,11 +192,4 @@ test("clearing the selection through the picker forgets it", async () => {
     new CustomEvent("value-changed", { detail: { value: "" } })
   );
   expect(loadSelectedEntity()).toBe("");
-});
-
-test("_onEntityChange remembers the newly selected device", async () => {
-  card = await mountCard(hassWithEntities(["cover.via_handler"]));
-  await card._entityListReady;
-  card._onEntityChange({ detail: { value: "cover.via_handler" } });
-  expect(loadSelectedEntity()).toBe("cover.via_handler");
 });

--- a/tests/frontend/card_selection_memory.test.mjs
+++ b/tests/frontend/card_selection_memory.test.mjs
@@ -139,6 +139,63 @@ test("re-connecting does not adopt a selection the user cleared in this card", a
   expect(card._selectedEntity).toBe("");
 });
 
+test("clearing the device mid-load does not leave the card spinning", async () => {
+  let release;
+  const hass = makeHass({
+    ws: {
+      "config/entity_registry/list": () => [],
+      "config_entries/get": () => [],
+      "cover_time_based/get_config": () =>
+        new Promise((r) => {
+          release = () => r({ control_mode: "switch" });
+        }),
+    },
+  });
+  card = await mountCard(hass);
+  await card._entityListReady;
+
+  card._setSelectedEntity("cover.slow");
+  const load = card._loadConfig();
+  expect(card._loading).toBe(true);
+  // User clears the picker before the response lands. Nothing starts a newer
+  // load, so this request is the only one that can clear the spinner.
+  card._setSelectedEntity("");
+  release();
+  await load;
+
+  expect(card._loading).toBe(false);
+  expect(card._config).toBe(null);
+});
+
+test("a superseded load does not clear the spinner for the newer one", async () => {
+  const release = {};
+  const hass = makeHass({
+    ws: {
+      "config/entity_registry/list": () => [],
+      "config_entries/get": () => [],
+      "cover_time_based/get_config": ({ entity_id }) =>
+        new Promise((r) => {
+          release[entity_id] = () => r({ control_mode: "switch" });
+        }),
+    },
+  });
+  card = await mountCard(hass);
+  await card._entityListReady;
+
+  card._setSelectedEntity("cover.a");
+  const loadA = card._loadConfig();
+  card._setSelectedEntity("cover.b");
+  const loadB = card._loadConfig();
+
+  release["cover.a"]();
+  await loadA;
+  expect(card._loading).toBe(true); // cover.b is still loading
+
+  release["cover.b"]();
+  await loadB;
+  expect(card._loading).toBe(false);
+});
+
 test("a config response arriving after the device changed is discarded", async () => {
   let releaseFirst;
   const hass = makeHass({

--- a/tests/frontend/card_selection_memory.test.mjs
+++ b/tests/frontend/card_selection_memory.test.mjs
@@ -1,0 +1,122 @@
+/**
+ * The card remembers its last-selected device across reloads.
+ *
+ * Restore happens after _loadEntityList resolves, so the remembered id can be
+ * validated against the live entity list; tests await card._entityListReady.
+ *
+ * Run: npm run test:fe -- tests/frontend/card_selection_memory.test.mjs
+ */
+
+import { test, expect, afterEach, vi } from "vitest";
+import { makeHass } from "./helpers/hass.mjs";
+import { mountCard, defineHaStubs } from "./helpers/mount.mjs";
+import {
+  saveSelectedEntity,
+  loadSelectedEntity,
+} from "../../custom_components/cover_time_based/frontend/selection-storage.js";
+
+defineHaStubs();
+
+let card;
+afterEach(() => {
+  vi.restoreAllMocks();
+  card?.remove();
+  card = null;
+});
+
+/** hass whose registry exposes `entityIds` as live cover_time_based entities. */
+function hassWithEntities(entityIds) {
+  return makeHass({
+    ws: {
+      "config/entity_registry/list": () =>
+        entityIds.map((id) => ({
+          entity_id: id,
+          platform: "cover_time_based",
+          config_entry_id: "e1",
+        })),
+      "config_entries/get": () => [{ entry_id: "e1" }],
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Restore
+// ---------------------------------------------------------------------------
+
+test("a remembered device that still exists is restored on connect", async () => {
+  saveSelectedEntity("cover.remembered");
+  card = await mountCard(hassWithEntities(["cover.remembered", "cover.other"]));
+  await card._entityListReady;
+  expect(card._selectedEntity).toBe("cover.remembered");
+});
+
+test("restoring a remembered device loads its config", async () => {
+  saveSelectedEntity("cover.remembered");
+  const hass = hassWithEntities(["cover.remembered"]);
+  card = await mountCard(hass);
+  await card._entityListReady;
+  expect(hass.callWS).toHaveBeenCalledWith(
+    expect.objectContaining({
+      type: "cover_time_based/get_config",
+      entity_id: "cover.remembered",
+    })
+  );
+});
+
+test("a remembered device that no longer exists is not restored", async () => {
+  saveSelectedEntity("cover.deleted");
+  const hass = hassWithEntities(["cover.still_here"]);
+  card = await mountCard(hass);
+  await card._entityListReady;
+  expect(card._selectedEntity).toBe("");
+  expect(hass.callWS).not.toHaveBeenCalledWith(
+    expect.objectContaining({ type: "cover_time_based/get_config" })
+  );
+});
+
+test("with nothing remembered the picker stays empty", async () => {
+  card = await mountCard(hassWithEntities(["cover.a"]));
+  await card._entityListReady;
+  expect(card._selectedEntity).toBe("");
+});
+
+test("a selection made before the entity list resolves is not clobbered", async () => {
+  saveSelectedEntity("cover.remembered");
+  card = await mountCard(hassWithEntities(["cover.remembered", "cover.chosen"]));
+  // User picks a device while the registry lookup is still in flight.
+  card._setSelectedEntity("cover.chosen");
+  await card._entityListReady;
+  expect(card._selectedEntity).toBe("cover.chosen");
+});
+
+// ---------------------------------------------------------------------------
+// Persist
+// ---------------------------------------------------------------------------
+
+test("selecting a device through the picker remembers it", async () => {
+  card = await mountCard(hassWithEntities(["cover.picked"]));
+  await card._entityListReady;
+  const picker = card.shadowRoot.querySelector("ha-entity-picker");
+  picker.dispatchEvent(
+    new CustomEvent("value-changed", { detail: { value: "cover.picked" } })
+  );
+  expect(loadSelectedEntity()).toBe("cover.picked");
+});
+
+test("clearing the selection through the picker forgets it", async () => {
+  saveSelectedEntity("cover.picked");
+  card = await mountCard(hassWithEntities(["cover.picked"]));
+  await card._entityListReady;
+  const picker = card.shadowRoot.querySelector("ha-entity-picker");
+  picker.dispatchEvent(
+    new CustomEvent("value-changed", { detail: { value: "" } })
+  );
+  expect(loadSelectedEntity()).toBe("");
+});
+
+test("_onEntityChange remembers the newly selected device", async () => {
+  card = await mountCard(hassWithEntities(["cover.via_handler"]));
+  await card._entityListReady;
+  card._onEntityChange({ detail: { value: "cover.via_handler" } });
+  expect(loadSelectedEntity()).toBe("cover.via_handler");
+});

--- a/tests/frontend/helpers/setup.mjs
+++ b/tests/frontend/helpers/setup.mjs
@@ -17,5 +17,13 @@ beforeEach(() => {
   }));
   window.confirm = vi.fn(() => true);
   window.alert = vi.fn();
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
+  // happy-dom under vitest exposes sessionStorage but leaves window.localStorage
+  // undefined, so install a fresh Storage per test. Fresh (rather than cleared)
+  // also drops any spies a previous test installed on it.
+  Object.defineProperty(window, "localStorage", {
+    value: new Storage(),
+    configurable: true,
+    writable: true,
+  });
 });

--- a/tests/frontend/selection_storage.test.mjs
+++ b/tests/frontend/selection_storage.test.mjs
@@ -1,0 +1,54 @@
+/**
+ * Tests for selection-storage.js — persisting the card's last-selected device.
+ *
+ * Run: npm run test:fe -- tests/frontend/selection_storage.test.mjs
+ */
+
+import { test, expect, afterEach, vi } from "vitest";
+import {
+  loadSelectedEntity,
+  saveSelectedEntity,
+  SELECTION_STORAGE_KEY,
+} from "../../custom_components/cover_time_based/frontend/selection-storage.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test("saveSelectedEntity then loadSelectedEntity round-trips an entity id", () => {
+  saveSelectedEntity("cover.living_room");
+  expect(loadSelectedEntity()).toBe("cover.living_room");
+});
+
+test("loadSelectedEntity returns empty string when nothing was saved", () => {
+  expect(loadSelectedEntity()).toBe("");
+});
+
+test("saveSelectedEntity with an empty id removes the stored key", () => {
+  saveSelectedEntity("cover.living_room");
+  saveSelectedEntity("");
+  expect(window.localStorage.getItem(SELECTION_STORAGE_KEY)).toBe(null);
+  expect(loadSelectedEntity()).toBe("");
+});
+
+test("loadSelectedEntity returns empty string when storage access throws", () => {
+  // Safari private mode / storage-disabled browsers throw on access.
+  vi.spyOn(window.localStorage, "getItem").mockImplementation(() => {
+    throw new Error("storage disabled");
+  });
+  expect(loadSelectedEntity()).toBe("");
+});
+
+test("saveSelectedEntity is a silent no-op when storage access throws", () => {
+  vi.spyOn(window.localStorage, "setItem").mockImplementation(() => {
+    throw new Error("storage disabled");
+  });
+  expect(() => saveSelectedEntity("cover.living_room")).not.toThrow();
+});
+
+test("saveSelectedEntity is a silent no-op when clearing and storage throws", () => {
+  vi.spyOn(window.localStorage, "removeItem").mockImplementation(() => {
+    throw new Error("storage disabled");
+  });
+  expect(() => saveSelectedEntity("")).not.toThrow();
+});


### PR DESCRIPTION
## What

The config card's device picker reset to empty on every page load, so reloading the dashboard meant re-picking the cover you were configuring. It now remembers the last-selected device and restores it on connect.

## How

New `frontend/selection-storage.js` wraps `localStorage` behind `loadSelectedEntity()` / `saveSelectedEntity()`, with every access guarded — Safari private mode and storage-disabled browsers throw, and a forgotten selection beats a broken picker.

Chosen over HA per-user frontend storage (`frontend/get_user_data`) because reading it is synchronous: the selection is restored without a websocket round-trip, so the picker never renders empty and then jumps. The tradeoff is per-browser rather than per-HA-user memory, which suits a session convenience. The key is per-origin, so several cards or tabs share one memory and all restore whichever device was touched last — fine for the expected single-config-card usage, and documented in the module.

Restore happens inside `_loadEntityList`, once the live entity list is available to validate the remembered id against, so a device deleted since last session is dropped rather than left in the picker over a failing config load. Persistence goes through a single `_setSelectedEntity()` so no selection path can forget to record.

## Hardening (second commit)

Reviewing the first commit turned up three real defects, each now covered by a test that fails when its guard is removed:

- **Restore fired on every `connectedCallback`**, which HA runs again whenever it re-parents the card. A picker the user had deliberately cleared would silently adopt a device selected in another card or browser tab. Restore is now attempted only on a card's first load.
- **`_loadConfig` applied stale responses.** It read `_selectedEntity`, awaited the websocket, then assigned `_config` without re-checking — so a response arriving after the device changed bound one device's config to another, and the next autosave would have written those settings onto the wrong device. The race predates this branch (two quick picks could trigger it), but auto-restore added a second actor firing exactly when the picker becomes usable.
- **Restore ran on detached elements**, mutating state and issuing a websocket call for a card HA had already torn down.

## Testing

14 new frontend tests. The guard test in the first commit was **vacuous** — with synchronous websocket mocks the restore had already completed before the test made its "mid-flight" pick, and deleting the guard left every test green. Tests now delay the registry response to interleave genuinely. Asserting the resulting selection still isn't enough (the pick rewrites storage, so an unguarded restore lands on the same id), so the test asserts the guarded restore drives no config load of its own. Every new guard was mutation-tested.

Full suite 291 passing; coverage 97.98% lines / 95.53% branches, above the 90% gates, with the new module at 100%. Verified in a live HA instance that both files serve under the content-hashed prefix (`_compute_frontend_hash` globs `*.js`, so the new module is cache-busted automatically).

## Notes for review

- `tests/frontend/helpers/setup.mjs` installs a `localStorage` per test: vitest's happy-dom env exposes `sessionStorage` but leaves `window.localStorage` undefined. The same hunk swaps `document.body.innerHTML = ""` for `replaceChildren()`, which also fixes happy-dom firing `disconnectedCallback` for only one of two leftover elements.
- Not addressed here: `_onEntityChange` is dead production code (the picker uses the inline handler in `card-render.js`), reachable only from tests. It predates this branch and is already upstream, so removing it belongs in its own PR.
