### PR TITLE
feat: nudge users on untranslated languages to request a translation

### DIFF
--- a/TRANSLATING.md
+++ b/TRANSLATING.md
@@ -9,7 +9,7 @@ Cover Time Based has strings in two places, each with its own file layout. Both 
 | Surface | Files | Used for |
 |---|---|---|
 | Home Assistant backend | [`strings.json`](custom_components/cover_time_based/strings.json) and [`translations/<lang>.json`](custom_components/cover_time_based/translations/) | Config-flow titles and fields, Repairs issues, service descriptions — anything Home Assistant's own UI renders for us. |
-| Lovelace configuration card | [`frontend/cover-time-based-card.js`](custom_components/cover_time_based/frontend/cover-time-based-card.js) — the `EN` object near the top, and the `TRANSLATIONS = { en: EN, pt: {...}, pl: {...} }` block below it | Every string the card itself draws. |
+| Lovelace configuration card | [`frontend/translations.js`](custom_components/cover_time_based/frontend/translations.js) — the `EN` object at the top, and the `TRANSLATIONS = { en: EN, pt: {...}, pl: {...} }` block below it | Every string the card itself draws. |
 
 Currently supported languages: English (`en`), Portuguese (`pt`), Polish (`pl`).
 
@@ -26,7 +26,7 @@ Don't touch `strings.json` — it stays in English and is the developer source o
 
 ### Card
 
-In [`custom_components/cover_time_based/frontend/cover-time-based-card.js`](custom_components/cover_time_based/frontend/cover-time-based-card.js):
+In [`custom_components/cover_time_based/frontend/translations.js`](custom_components/cover_time_based/frontend/translations.js):
 
 1. Find the `TRANSLATIONS` object:
 
@@ -42,6 +42,10 @@ In [`custom_components/cover_time_based/frontend/cover-time-based-card.js`](cust
 
 The card falls back to English for any key you miss, so a partial translation will work — but the [audit below](#verifying-translations-are-in-sync) will flag what's missing.
 
+The card resolves a locale by trying the exact code first, then its base language, then English — so a `pt-BR` user reads the `pt` catalogue, and adding `de` also covers `de-AT` and `de-CH`. Add a region-specific key (`pt-BR`) only when that variant needs wording of its own.
+
+The `language_request.*` keys are deliberately **English-only**. They are the "your language isn't translated yet" banner, which by construction is only ever shown to users whose language has no catalogue — a translated copy would be unreachable.
+
 ## Adding a new translatable string
 
 When you add a new feature that introduces a new user-facing string:
@@ -54,7 +58,7 @@ When you add a new feature that introduces a new user-facing string:
 
 ### Card
 
-1. Add the key + English value to the `EN` object near the top of `cover-time-based-card.js`.
+1. Add the key + English value to the `EN` object at the top of `translations.js`.
 2. Add the same key with a translated value to **every other** language block inside the `TRANSLATIONS` object (`pt`, `pl`, …).
 3. Render the string with `this._t("your.key")`. It reads `hass.language` and falls back to English if a key or language is missing.
 
@@ -90,7 +94,7 @@ for path in sorted((base / "translations").glob("*.json")):
     other = all_keys(json.loads(path.read_text()))
     print(f"backend {path.stem}: missing={sorted(en_keys - other) or 'none'}  extra={sorted(other - en_keys) or 'none'}")
 
-card = (base / "frontend/cover-time-based-card.js").read_text()
+card = (base / "frontend/translations.js").read_text()
 def block(text, start):
     m = re.search(start, text)
     if not m: return ""
@@ -105,10 +109,13 @@ def keys_of(t): return set(re.findall(r'"([^"]+)":\s*"', t))
 
 en_card = keys_of(block(card, r"const EN\s*=\s*\{"))
 trans   = block(card, r"const TRANSLATIONS\s*=\s*\{")
+# The translation-request banner is English-only by design — see above.
+IGNORE = {k for k in en_card if k.startswith("language_request.")}
 for lang in re.findall(r"^\s{2}(\w+):\s*\{", trans, re.M):
     if lang == "en": continue
     other = keys_of(block(trans, rf"{lang}:\s*\{{"))
-    print(f"card    {lang}: missing={sorted(en_card - other) or 'none'}  extra={sorted(other - en_card) or 'none'}")
+    missing = sorted((en_card - IGNORE) - other)
+    print(f"card    {lang}: missing={missing or 'none'}  extra={sorted(other - en_card) or 'none'}")
 PY
 ```
 

--- a/TRANSLATING.md
+++ b/TRANSLATING.md
@@ -44,7 +44,7 @@ The card falls back to English for any key you miss, so a partial translation wi
 
 The card resolves a locale by trying the exact code first, then its base language, then English — so a `pt-BR` user reads the `pt` catalogue, and adding `de` also covers `de-AT` and `de-CH`. Add a region-specific key (`pt-BR`) only when that variant needs wording of its own.
 
-The `language_request.*` keys are deliberately **English-only**. They are the "your language isn't translated yet" banner, which by construction is only ever shown to users whose language has no catalogue — a translated copy would be unreachable.
+The "your language isn't translated yet" banner is not in this table at all — its copy lives in `frontend/language-banner.js`, because it is only ever shown to users whose language has no catalogue, so a translated copy could never be displayed.
 
 ## Adding a new translatable string
 
@@ -109,13 +109,10 @@ def keys_of(t): return set(re.findall(r'"([^"]+)":\s*"', t))
 
 en_card = keys_of(block(card, r"const EN\s*=\s*\{"))
 trans   = block(card, r"const TRANSLATIONS\s*=\s*\{")
-# The translation-request banner is English-only by design — see above.
-IGNORE = {k for k in en_card if k.startswith("language_request.")}
 for lang in re.findall(r"^\s{2}(\w+):\s*\{", trans, re.M):
     if lang == "en": continue
     other = keys_of(block(trans, rf"{lang}:\s*\{{"))
-    missing = sorted((en_card - IGNORE) - other)
-    print(f"card    {lang}: missing={missing or 'none'}  extra={sorted(other - en_card) or 'none'}")
+    print(f"card    {lang}: missing={sorted(en_card - other) or 'none'}  extra={sorted(other - en_card) or 'none'}")
 PY
 ```
 

--- a/custom_components/cover_time_based/frontend/card-render.js
+++ b/custom_components/cover_time_based/frontend/card-render.js
@@ -2,6 +2,7 @@ import { html } from "https://unpkg.com/lit-element@2.4.0/lit-element.js?module"
 import { renderTextfield } from "./textfield-render.js";
 import { switchPickerDomains, showsPulseTime } from "./entity-filter.js";
 import { TIMING_ATTRIBUTES } from "./constants.js";
+import { renderLanguageBanner } from "./language-banner.js";
 
 export function renderCard(card) {
   if (!card.hass) return html``;
@@ -9,6 +10,7 @@ export function renderCard(card) {
     <ha-card>
       <div class="card-header">${card._t("header")}</div>
       <div class="card-content">
+        ${renderLanguageBanner(card)}
         ${renderEntityPicker(card)}
         ${card._selectedEntity && card._config
           ? renderConfigSections(card)

--- a/custom_components/cover_time_based/frontend/card-styles.js
+++ b/custom_components/cover_time_based/frontend/card-styles.js
@@ -454,6 +454,46 @@ export const cardStyles = css`
         color: var(--secondary-text-color);
       }
 
+      .lang-banner {
+        display: flex;
+        align-items: flex-start;
+        gap: 12px;
+        padding: 12px 16px;
+        margin: 0 0 16px;
+        background: var(--secondary-background-color, #f5f5f5);
+        border-radius: 8px;
+        font-size: 14px;
+        line-height: 1.4;
+      }
+
+      .lang-banner ha-icon {
+        color: var(--secondary-text-color, #727272);
+        flex: 0 0 auto;
+      }
+
+      .lang-banner-body {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        flex: 1 1 auto;
+        color: var(--primary-text-color, #212121);
+      }
+
+      .lang-banner-body a {
+        color: var(--primary-color, #03a9f4);
+        text-decoration: none;
+        font-weight: 500;
+      }
+
+      .lang-banner-body a:hover {
+        text-decoration: underline;
+      }
+
+      .lang-banner ha-icon-button {
+        flex: 0 0 auto;
+        cursor: pointer;
+      }
+
       .yaml-warning {
         padding: 16px;
         margin: 8px 0;

--- a/custom_components/cover_time_based/frontend/cover-time-based-card.js
+++ b/custom_components/cover_time_based/frontend/cover-time-based-card.js
@@ -23,6 +23,7 @@ import {
 import { DOMAIN, ATTRIBUTE_TO_CONFIG } from "./constants.js";
 import { loadSelectedEntity, saveSelectedEntity } from "./selection-storage.js";
 import { translate } from "./translations.js";
+import { persistLangDismissed } from "./language-banner.js";
 import { cardStyles } from "./card-styles.js";
 import { renderCard } from "./card-render.js";
 
@@ -55,6 +56,9 @@ class CoverTimeBasedCard extends LitElement {
     this._openHelp = null;
     this._selectionRestoreAttempted = false;
     this._configLoadToken = 0;
+    // Locales dismissed this session. Mirrors the persisted list so a dismissal
+    // still sticks when localStorage is unavailable and persistence no-ops.
+    this._dismissedLangs = new Set();
   }
 
   // --- Translation support ---
@@ -65,6 +69,12 @@ class CoverTimeBasedCard extends LitElement {
 
   _switchLabel(baseKey, controlMode) {
     return this._t(switchLabelKey(baseKey, controlMode));
+  }
+
+  _dismissLanguageBanner(code) {
+    this._dismissedLangs.add(code);
+    persistLangDismissed(code);
+    this.requestUpdate();
   }
 
   // --- Lifecycle ---

--- a/custom_components/cover_time_based/frontend/cover-time-based-card.js
+++ b/custom_components/cover_time_based/frontend/cover-time-based-card.js
@@ -23,7 +23,7 @@ import {
 import { DOMAIN, ATTRIBUTE_TO_CONFIG } from "./constants.js";
 import { loadSelectedEntity, saveSelectedEntity } from "./selection-storage.js";
 import { translate } from "./translations.js";
-import { persistLangDismissed } from "./language-banner.js";
+import { loadDismissedLangs, persistLangDismissed } from "./language-banner.js";
 import { cardStyles } from "./card-styles.js";
 import { renderCard } from "./card-render.js";
 
@@ -56,9 +56,11 @@ class CoverTimeBasedCard extends LitElement {
     this._openHelp = null;
     this._selectionRestoreAttempted = false;
     this._configLoadToken = 0;
-    // Locales dismissed this session. Mirrors the persisted list so a dismissal
-    // still sticks when localStorage is unavailable and persistence no-ops.
-    this._dismissedLangs = new Set();
+    // The single answer to "has the translation nudge been dismissed?", seeded
+    // from storage once here rather than re-read on every render. Holding it in
+    // memory also means a dismissal sticks for the session when localStorage is
+    // unavailable and the write silently no-ops.
+    this._dismissedLangs = new Set(loadDismissedLangs());
   }
 
   // --- Translation support ---

--- a/custom_components/cover_time_based/frontend/language-banner.js
+++ b/custom_components/cover_time_based/frontend/language-banner.js
@@ -24,6 +24,22 @@ export const LANG_DISMISSED_STORAGE_KEY =
   "cover_time_based_card.dismissed_lang_requests";
 
 /**
+ * The banner's copy, deliberately NOT in the translation table.
+ *
+ * These strings are unreachable in any language but English: the banner renders
+ * only when no catalogue covers the user's locale, so a translated copy could
+ * never be displayed. Keeping them out of `EN` also keeps them out of the
+ * language-parity gate, which correctly requires every English key to be
+ * translated — a rule these strings would otherwise have to be excepted from.
+ */
+const COPY = {
+  message: (language) =>
+    `Your Home Assistant language is ${language}, but Cover Time Based isn't translated into it yet.`,
+  action: "Request a translation →",
+  dismiss: "Dismiss",
+};
+
+/**
  * A prefilled "new issue" URL requesting a translation for `code`.
  *
  * Uses `?body=` rather than `?template=`: a template link resolves against the
@@ -116,9 +132,8 @@ export function persistLangDismissed(code) {
 /**
  * The nudge, or "" when the language is covered or already dismissed.
  *
- * The copy always renders in English: by construction the banner only appears
- * to users whose language has no catalogue, so `_t` falls back to EN anyway —
- * which is why `language_request.*` exists in EN only.
+ * The copy always renders in English — see {@link COPY} for why it is not
+ * translated.
  */
 export function renderLanguageBanner(card) {
   const code = normaliseLocale(card.hass?.language);
@@ -126,7 +141,7 @@ export function renderLanguageBanner(card) {
   if (card._dismissedLangs.has(code)) return "";
 
   const displayName = languageDisplayName(code);
-  const message = card._t("language_request.message", { language: displayName });
+  const message = COPY.message(displayName);
   return html`
     <div class="lang-banner">
       <ha-icon icon="mdi:translate"></ha-icon>
@@ -136,11 +151,11 @@ export function renderLanguageBanner(card) {
           href=${buildTranslationRequestUrl(code, displayName)}
           target="_blank"
           rel="noopener noreferrer"
-          >${card._t("language_request.action")}</a
+          >${COPY.action}</a
         >
       </div>
       <ha-icon-button
-        .label=${card._t("language_request.dismiss")}
+        .label=${COPY.dismiss}
         @click=${() => card._dismissLanguageBanner(code)}
       >
         <ha-icon icon="mdi:close"></ha-icon>

--- a/custom_components/cover_time_based/frontend/language-banner.js
+++ b/custom_components/cover_time_based/frontend/language-banner.js
@@ -13,6 +13,9 @@
  * dismissal is far better than a card that fails to render.
  */
 
+import { html } from "https://unpkg.com/lit-element@2.4.0/lit-element.js?module";
+import { isLanguageSupported } from "./translations.js";
+
 /** Upstream repository — the issue link must not point at a fork. */
 export const GITHUB_REPO_URL =
   "https://github.com/Sese-Schneider/ha-cover-time-based";
@@ -95,4 +98,40 @@ export function persistLangDismissed(code) {
   } catch (_) {
     // storage unavailable — the dismissal simply isn't remembered
   }
+}
+
+/**
+ * The nudge, or "" when the language is covered or already dismissed.
+ *
+ * The copy always renders in English: by construction the banner only appears
+ * to users whose language has no catalogue, so `_t` falls back to EN anyway —
+ * which is why `language_request.*` exists in EN only.
+ */
+export function renderLanguageBanner(card) {
+  const code = (card.hass?.language || "").replace(/_/g, "-");
+  if (isLanguageSupported(code)) return "";
+  if (card._dismissedLangs?.has(code) || isLangDismissed(code)) return "";
+
+  const displayName = languageDisplayName(code);
+  const message = card._t("language_request.message", { language: displayName });
+  return html`
+    <div class="lang-banner">
+      <ha-icon icon="mdi:translate"></ha-icon>
+      <div class="lang-banner-body">
+        <span>${message}</span>
+        <a
+          href=${buildTranslationRequestUrl(code, displayName)}
+          target="_blank"
+          rel="noopener noreferrer"
+          >${card._t("language_request.action")}</a
+        >
+      </div>
+      <ha-icon-button
+        .label=${card._t("language_request.dismiss")}
+        @click=${() => card._dismissLanguageBanner(code)}
+      >
+        <ha-icon icon="mdi:close"></ha-icon>
+      </ha-icon-button>
+    </div>
+  `;
 }

--- a/custom_components/cover_time_based/frontend/language-banner.js
+++ b/custom_components/cover_time_based/frontend/language-banner.js
@@ -14,7 +14,7 @@
  */
 
 import { html } from "https://unpkg.com/lit-element@2.4.0/lit-element.js?module";
-import { isLanguageSupported } from "./translations.js";
+import { isLanguageSupported, normaliseLocale } from "./translations.js";
 
 /** Upstream repository — the issue link must not point at a fork. */
 export const GITHUB_REPO_URL =
@@ -32,15 +32,27 @@ export const LANG_DISMISSED_STORAGE_KEY =
  * Title and body are deliberately English rather than localised — they land in
  * the project's issue tracker, which the maintainers read in English. No
  * `labels=` parameter: the repo has no `translation` label to request.
+ *
+ * For a region variant the body also names the base language, because one
+ * catalogue serves the whole family: `de-AT`, `de-DE` and `de` users would
+ * otherwise file three differently-titled issues for the single `de` catalogue
+ * that would satisfy all of them.
  */
 export function buildTranslationRequestUrl(code, displayName) {
+  const base = code.split("-")[0].toLowerCase();
+  const body = [
+    `I'd like Cover Time Based to be translated into: **${displayName}** (\`${code}\`).`,
+  ];
+  if (base !== code) {
+    body.push(
+      ``,
+      `A \`${base}\` catalogue would cover this — the card falls back to the base language.`
+    );
+  }
+  body.push(``, `- [ ] I'm happy to review the translation`);
   const params = new URLSearchParams({
     title: `Translation request: ${displayName} (${code})`,
-    body: [
-      `I'd like Cover Time Based to be translated into: **${displayName}** (\`${code}\`).`,
-      ``,
-      `- [ ] I'm happy to review the translation`,
-    ].join("\n"),
+    body: body.join("\n"),
   });
   return `${GITHUB_REPO_URL}/issues/new?${params.toString()}`;
 }
@@ -70,8 +82,14 @@ export function languageDisplayName(code) {
   return code;
 }
 
-/** The dismissed locales, or [] when absent, unreadable or corrupt. */
-function dismissedLocales() {
+/**
+ * The dismissed locales, or [] when absent, unreadable or corrupt.
+ *
+ * Read once when a card is constructed rather than on every render: the card
+ * holds the result in a Set, which is then the single answer to "was this
+ * dismissed?" — including when localStorage throws and the write below no-ops.
+ */
+export function loadDismissedLangs() {
   try {
     const raw = window.localStorage.getItem(LANG_DISMISSED_STORAGE_KEY);
     const parsed = raw ? JSON.parse(raw) : [];
@@ -81,15 +99,10 @@ function dismissedLocales() {
   }
 }
 
-/** Whether the nudge was already dismissed for `code`. */
-export function isLangDismissed(code) {
-  return dismissedLocales().includes(code);
-}
-
 /** Record a dismissal for `code` (append + de-dup). */
 export function persistLangDismissed(code) {
   try {
-    const current = dismissedLocales();
+    const current = loadDismissedLangs();
     if (current.includes(code)) return;
     window.localStorage.setItem(
       LANG_DISMISSED_STORAGE_KEY,
@@ -108,9 +121,9 @@ export function persistLangDismissed(code) {
  * which is why `language_request.*` exists in EN only.
  */
 export function renderLanguageBanner(card) {
-  const code = (card.hass?.language || "").replace(/_/g, "-");
+  const code = normaliseLocale(card.hass?.language);
   if (isLanguageSupported(code)) return "";
-  if (card._dismissedLangs?.has(code) || isLangDismissed(code)) return "";
+  if (card._dismissedLangs.has(code)) return "";
 
   const displayName = languageDisplayName(code);
   const message = card._t("language_request.message", { language: displayName });

--- a/custom_components/cover_time_based/frontend/language-banner.js
+++ b/custom_components/cover_time_based/frontend/language-banner.js
@@ -1,0 +1,98 @@
+/**
+ * The "your language isn't translated yet" nudge shown in the config card.
+ *
+ * Cover Time Based ships card strings in English, Portuguese and Polish. A user
+ * on any other language silently reads English with no hint that asking for a
+ * translation is welcome. This module builds a one-time, per-locale dismissable
+ * banner inviting them to open a prefilled GitHub issue.
+ *
+ * Dismissals are stored per-locale rather than as a single flag: dismiss `de`,
+ * switch HA to `fr`, then switch back, and a scalar store would have forgotten
+ * the original dismissal and re-nagged. Storage is per-browser, and every access
+ * is guarded — Safari private mode throws on localStorage, and a forgotten
+ * dismissal is far better than a card that fails to render.
+ */
+
+/** Upstream repository — the issue link must not point at a fork. */
+export const GITHUB_REPO_URL =
+  "https://github.com/Sese-Schneider/ha-cover-time-based";
+
+export const LANG_DISMISSED_STORAGE_KEY =
+  "cover_time_based_card.dismissed_lang_requests";
+
+/**
+ * A prefilled "new issue" URL requesting a translation for `code`.
+ *
+ * Uses `?body=` rather than `?template=`: a template link resolves against the
+ * repo's default branch, so it would prefill nothing until the template merged.
+ *
+ * Title and body are deliberately English rather than localised — they land in
+ * the project's issue tracker, which the maintainers read in English. No
+ * `labels=` parameter: the repo has no `translation` label to request.
+ */
+export function buildTranslationRequestUrl(code, displayName) {
+  const params = new URLSearchParams({
+    title: `Translation request: ${displayName} (${code})`,
+    body: [
+      `I'd like Cover Time Based to be translated into: **${displayName}** (\`${code}\`).`,
+      ``,
+      `- [ ] I'm happy to review the translation`,
+    ].join("\n"),
+  });
+  return `${GITHUB_REPO_URL}/issues/new?${params.toString()}`;
+}
+
+/**
+ * Native display name for a BCP-47 code ("fr" -> "français"), falling back to
+ * the English name and then the raw code, with every Intl call guarded.
+ *
+ * Intl.DisplayNames defaults to fallback:"code", so an unknown tag echoes the
+ * code straight back; the `!== code` guards stop that echo being mistaken for a
+ * real name.
+ */
+export function languageDisplayName(code) {
+  if (!code) return code;
+  try {
+    const native = new Intl.DisplayNames([code], { type: "language" }).of(code);
+    if (native && native !== code) return native;
+  } catch (_) {
+    // Invalid locale for Intl — fall through to the English name.
+  }
+  try {
+    const english = new Intl.DisplayNames(["en"], { type: "language" }).of(code);
+    if (english && english !== code) return english;
+  } catch (_) {
+    // Intl unavailable — fall through to the raw code.
+  }
+  return code;
+}
+
+/** The dismissed locales, or [] when absent, unreadable or corrupt. */
+function dismissedLocales() {
+  try {
+    const raw = window.localStorage.getItem(LANG_DISMISSED_STORAGE_KEY);
+    const parsed = raw ? JSON.parse(raw) : [];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (_) {
+    return [];
+  }
+}
+
+/** Whether the nudge was already dismissed for `code`. */
+export function isLangDismissed(code) {
+  return dismissedLocales().includes(code);
+}
+
+/** Record a dismissal for `code` (append + de-dup). */
+export function persistLangDismissed(code) {
+  try {
+    const current = dismissedLocales();
+    if (current.includes(code)) return;
+    window.localStorage.setItem(
+      LANG_DISMISSED_STORAGE_KEY,
+      JSON.stringify([...current, code])
+    );
+  } catch (_) {
+    // storage unavailable — the dismissal simply isn't remembered
+  }
+}

--- a/custom_components/cover_time_based/frontend/translations.js
+++ b/custom_components/cover_time_based/frontend/translations.js
@@ -405,13 +405,23 @@ export const TRANSLATIONS = {
  * Separators are normalised (pt_BR -> pt-BR) but case is not: hass.language is
  * always one of HA's canonical codes with the region already correctly cased,
  * so exact lookups line up. Only the base is lowercased.
+ *
+ * The separator rule lives in {@link normaliseLocale} so callers that need the
+ * canonical code for their own purposes — the banner keys dismissals, display
+ * names and issue URLs off it — cannot drift from what resolution uses.
  */
+export function normaliseLocale(raw) {
+  return (raw || "").replace(/_/g, "-");
+}
+
 export function resolveLocale(raw) {
-  const code = (raw || "").replace(/_/g, "-");
+  const code = normaliseLocale(raw);
   if (!code) return "";
-  if (code in TRANSLATIONS) return code;
+  // hasOwn, not `in`: `in` walks the prototype chain, so "constructor" and
+  // friends would read as shipped catalogues.
+  if (Object.hasOwn(TRANSLATIONS, code)) return code;
   const base = code.split("-")[0].toLowerCase();
-  return base in TRANSLATIONS ? base : "";
+  return Object.hasOwn(TRANSLATIONS, base) ? base : "";
 }
 
 /**
@@ -429,7 +439,9 @@ export function translate(lang, key, replacements) {
   let str = strings[key] || EN[key] || key;
   if (replacements) {
     for (const [k, v] of Object.entries(replacements)) {
-      str = str.replace(`{${k}}`, v);
+      // split/join, not replace(): replace() substitutes only the first
+      // occurrence and interprets $&, $` and $' in the replacement value.
+      str = str.split(`{${k}}`).join(v);
     }
   }
   return str;

--- a/custom_components/cover_time_based/frontend/translations.js
+++ b/custom_components/cover_time_based/frontend/translations.js
@@ -6,6 +6,10 @@ export const EN = {
   "confirm_cancel_calibration": "A calibration is running. Cancel it and continue?",
   "create_new": "+ Create new cover entity",
   "yaml_warning": "This entity uses YAML configuration and cannot be configured from this card. Please migrate to the UI: Settings \u2192 Devices & Services \u2192 Helpers \u2192 Create Helper \u2192 Cover Time Based.",
+  "language_request.message":
+    "Your Home Assistant language is {language}, but Cover Time Based isn't translated into it yet.",
+  "language_request.action": "Request a translation →",
+  "language_request.dismiss": "Dismiss",
   "tabs.device": "Device",
   "tabs.calibration": "Calibration",
   "control_mode.label": "Control Mode",

--- a/custom_components/cover_time_based/frontend/translations.js
+++ b/custom_components/cover_time_based/frontend/translations.js
@@ -6,10 +6,6 @@ export const EN = {
   "confirm_cancel_calibration": "A calibration is running. Cancel it and continue?",
   "create_new": "+ Create new cover entity",
   "yaml_warning": "This entity uses YAML configuration and cannot be configured from this card. Please migrate to the UI: Settings \u2192 Devices & Services \u2192 Helpers \u2192 Create Helper \u2192 Cover Time Based.",
-  "language_request.message":
-    "Your Home Assistant language is {language}, but Cover Time Based isn't translated into it yet.",
-  "language_request.action": "Request a translation →",
-  "language_request.dismiss": "Dismiss",
   "tabs.device": "Device",
   "tabs.calibration": "Calibration",
   "control_mode.label": "Control Mode",

--- a/custom_components/cover_time_based/frontend/translations.js
+++ b/custom_components/cover_time_based/frontend/translations.js
@@ -391,8 +391,37 @@ export const TRANSLATIONS = {
   },
 };
 
+/**
+ * The TRANSLATIONS key covering `raw`, or "" when nothing does.
+ *
+ * Tries the exact (region-specific) code first, then its base language, so a
+ * pt-BR user reads European Portuguese rather than falling through to English,
+ * while a dedicated pt-BR catalogue would still win if one were ever added.
+ *
+ * Separators are normalised (pt_BR -> pt-BR) but case is not: hass.language is
+ * always one of HA's canonical codes with the region already correctly cased,
+ * so exact lookups line up. Only the base is lowercased.
+ */
+export function resolveLocale(raw) {
+  const code = (raw || "").replace(/_/g, "-");
+  if (!code) return "";
+  if (code in TRANSLATIONS) return code;
+  const base = code.split("-")[0].toLowerCase();
+  return base in TRANSLATIONS ? base : "";
+}
+
+/**
+ * Whether a shipped catalogue covers `raw` — i.e. whether to suppress the
+ * "request a translation" banner. A missing or undeterminable language counts
+ * as supported: it renders in English anyway, and nagging on it would be noise.
+ */
+export function isLanguageSupported(raw) {
+  if (!raw) return true;
+  return resolveLocale(raw) !== "";
+}
+
 export function translate(lang, key, replacements) {
-  const strings = TRANSLATIONS[lang] || EN;
+  const strings = TRANSLATIONS[resolveLocale(lang)] || EN;
   let str = strings[key] || EN[key] || key;
   if (replacements) {
     for (const [k, v] of Object.entries(replacements)) {

--- a/tests/frontend/helpers/mount.mjs
+++ b/tests/frontend/helpers/mount.mjs
@@ -2,6 +2,7 @@ import "../../../custom_components/cover_time_based/frontend/cover-time-based-ca
 
 const HA_STUBS = [
   "ha-card", "ha-entity-picker", "ha-switch", "ha-icon", "ha-input", "ha-textfield",
+  "ha-icon-button",
 ];
 
 export function defineHaStubs({ exclude = [] } = {}) {

--- a/tests/frontend/language_banner.test.mjs
+++ b/tests/frontend/language_banner.test.mjs
@@ -1,0 +1,103 @@
+/**
+ * Tests for language-banner.js — the "request a translation" nudge.
+ *
+ * Run: npm run test:fe -- tests/frontend/language_banner.test.mjs
+ */
+
+import { test, expect, afterEach, vi } from "vitest";
+import {
+  GITHUB_REPO_URL,
+  LANG_DISMISSED_STORAGE_KEY,
+  buildTranslationRequestUrl,
+  languageDisplayName,
+  isLangDismissed,
+  persistLangDismissed,
+} from "../../custom_components/cover_time_based/frontend/language-banner.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  try {
+    window.localStorage.removeItem(LANG_DISMISSED_STORAGE_KEY);
+  } catch (_) {
+    // storage unavailable — nothing to clean up
+  }
+});
+
+test("buildTranslationRequestUrl points at the upstream repo's new-issue form", () => {
+  const url = buildTranslationRequestUrl("de", "Deutsch");
+  expect(url.startsWith(`${GITHUB_REPO_URL}/issues/new?`)).toBe(true);
+});
+
+test("buildTranslationRequestUrl prefills an English title and body naming the language", () => {
+  const params = new URL(buildTranslationRequestUrl("de", "Deutsch")).searchParams;
+  expect(params.get("title")).toBe("Translation request: Deutsch (de)");
+  expect(params.get("body")).toContain("Deutsch");
+  expect(params.get("body")).toContain("de");
+});
+
+test("buildTranslationRequestUrl requests no labels", () => {
+  // The upstream repo has no "translation" label; asking for one achieves nothing.
+  const params = new URL(buildTranslationRequestUrl("de", "Deutsch")).searchParams;
+  expect(params.get("labels")).toBe(null);
+});
+
+test("languageDisplayName returns a human-readable name for a real code", () => {
+  // Exact wording is Intl/ICU-dependent, so assert it is resolved, not echoed.
+  const name = languageDisplayName("de");
+  expect(name).not.toBe("de");
+  expect(name.length).toBeGreaterThan(0);
+});
+
+test("languageDisplayName echoes the raw code for an unrecognised tag", () => {
+  // Intl.DisplayNames defaults to fallback:"code" — the guard must not let that
+  // echo masquerade as a real display name, and must not throw either.
+  expect(languageDisplayName("zzz")).toBe("zzz");
+});
+
+test("languageDisplayName returns the input unchanged when it is empty", () => {
+  expect(languageDisplayName("")).toBe("");
+});
+
+test("isLangDismissed is false before anything is dismissed", () => {
+  expect(isLangDismissed("de")).toBe(false);
+});
+
+test("persistLangDismissed then isLangDismissed round-trips a locale", () => {
+  persistLangDismissed("de");
+  expect(isLangDismissed("de")).toBe(true);
+});
+
+test("dismissing a second locale preserves the first", () => {
+  // A scalar store would forget "de": dismiss de, switch to fr, switch back,
+  // and the nudge would reappear.
+  persistLangDismissed("de");
+  persistLangDismissed("fr");
+  expect(isLangDismissed("de")).toBe(true);
+  expect(isLangDismissed("fr")).toBe(true);
+});
+
+test("persistLangDismissed does not duplicate an already-dismissed locale", () => {
+  persistLangDismissed("de");
+  persistLangDismissed("de");
+  const stored = JSON.parse(window.localStorage.getItem(LANG_DISMISSED_STORAGE_KEY));
+  expect(stored).toEqual(["de"]);
+});
+
+test("isLangDismissed is false when storage access throws", () => {
+  vi.spyOn(window.localStorage, "getItem").mockImplementation(() => {
+    throw new Error("storage disabled");
+  });
+  expect(isLangDismissed("de")).toBe(false);
+});
+
+test("isLangDismissed is false when the stored value is corrupt", () => {
+  window.localStorage.setItem(LANG_DISMISSED_STORAGE_KEY, "not json");
+  expect(isLangDismissed("de")).toBe(false);
+});
+
+test("persistLangDismissed is a silent no-op when storage access throws", () => {
+  vi.spyOn(window.localStorage, "setItem").mockImplementation(() => {
+    throw new Error("storage disabled");
+  });
+  expect(() => persistLangDismissed("de")).not.toThrow();
+});

--- a/tests/frontend/language_banner.test.mjs
+++ b/tests/frontend/language_banner.test.mjs
@@ -13,6 +13,12 @@ import {
   isLangDismissed,
   persistLangDismissed,
 } from "../../custom_components/cover_time_based/frontend/language-banner.js";
+import { defineHaStubs, mountCard } from "./helpers/mount.mjs";
+import { makeHass } from "./helpers/hass.mjs";
+
+defineHaStubs();
+
+const banner = (el) => el.shadowRoot.querySelector(".lang-banner");
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -100,4 +106,58 @@ test("persistLangDismissed is a silent no-op when storage access throws", () => 
     throw new Error("storage disabled");
   });
   expect(() => persistLangDismissed("de")).not.toThrow();
+});
+
+test("the banner renders for a language with no shipped translation", async () => {
+  const el = await mountCard(makeHass({ language: "de" }));
+  expect(banner(el)).not.toBe(null);
+});
+
+test("the banner does not render for a shipped language", async () => {
+  const el = await mountCard(makeHass({ language: "pl" }));
+  expect(banner(el)).toBe(null);
+});
+
+test("the banner does not render for a region variant covered by its base", async () => {
+  // pt-BR reads European Portuguese, so there is nothing to request.
+  const el = await mountCard(makeHass({ language: "pt-BR" }));
+  expect(banner(el)).toBe(null);
+});
+
+test("the banner does not render when the language is undeterminable", async () => {
+  const el = await mountCard(makeHass({ language: "" }));
+  expect(banner(el)).toBe(null);
+});
+
+test("the banner names the language and links to a prefilled issue", async () => {
+  const el = await mountCard(makeHass({ language: "de" }));
+  const text = banner(el).textContent;
+  expect(text).toContain(languageDisplayName("de"));
+  const href = banner(el).querySelector("a").getAttribute("href");
+  expect(href).toBe(buildTranslationRequestUrl("de", languageDisplayName("de")));
+});
+
+test("the banner does not render for a locale already dismissed in storage", async () => {
+  persistLangDismissed("de");
+  const el = await mountCard(makeHass({ language: "de" }));
+  expect(banner(el)).toBe(null);
+});
+
+test("clicking dismiss hides the banner and persists the locale", async () => {
+  const el = await mountCard(makeHass({ language: "de" }));
+  banner(el).querySelector("ha-icon-button").click();
+  await el.updateComplete;
+  expect(banner(el)).toBe(null);
+  expect(isLangDismissed("de")).toBe(true);
+});
+
+test("dismissal sticks for the session when storage is unavailable", async () => {
+  // Persistence silently no-ops, but the in-memory set must still hide it.
+  vi.spyOn(window.localStorage, "setItem").mockImplementation(() => {
+    throw new Error("storage disabled");
+  });
+  const el = await mountCard(makeHass({ language: "de" }));
+  banner(el).querySelector("ha-icon-button").click();
+  await el.updateComplete;
+  expect(banner(el)).toBe(null);
 });

--- a/tests/frontend/language_banner.test.mjs
+++ b/tests/frontend/language_banner.test.mjs
@@ -10,7 +10,7 @@ import {
   LANG_DISMISSED_STORAGE_KEY,
   buildTranslationRequestUrl,
   languageDisplayName,
-  isLangDismissed,
+  loadDismissedLangs,
   persistLangDismissed,
 } from "../../custom_components/cover_time_based/frontend/language-banner.js";
 import { defineHaStubs, mountCard } from "./helpers/mount.mjs";
@@ -20,13 +20,10 @@ defineHaStubs();
 
 const banner = (el) => el.shadowRoot.querySelector(".lang-banner");
 
+// setup.mjs installs a fresh Storage before every test, so there is nothing to
+// clear here — only the spies some tests install on it.
 afterEach(() => {
   vi.restoreAllMocks();
-  try {
-    window.localStorage.removeItem(LANG_DISMISSED_STORAGE_KEY);
-  } catch (_) {
-    // storage unavailable — nothing to clean up
-  }
 });
 
 test("buildTranslationRequestUrl points at the upstream repo's new-issue form", () => {
@@ -64,13 +61,13 @@ test("languageDisplayName returns the input unchanged when it is empty", () => {
   expect(languageDisplayName("")).toBe("");
 });
 
-test("isLangDismissed is false before anything is dismissed", () => {
-  expect(isLangDismissed("de")).toBe(false);
+test("loadDismissedLangs is empty before anything is dismissed", () => {
+  expect(loadDismissedLangs()).toEqual([]);
 });
 
-test("persistLangDismissed then isLangDismissed round-trips a locale", () => {
+test("persistLangDismissed then loadDismissedLangs round-trips a locale", () => {
   persistLangDismissed("de");
-  expect(isLangDismissed("de")).toBe(true);
+  expect(loadDismissedLangs()).toContain("de");
 });
 
 test("dismissing a second locale preserves the first", () => {
@@ -78,8 +75,7 @@ test("dismissing a second locale preserves the first", () => {
   // and the nudge would reappear.
   persistLangDismissed("de");
   persistLangDismissed("fr");
-  expect(isLangDismissed("de")).toBe(true);
-  expect(isLangDismissed("fr")).toBe(true);
+  expect(loadDismissedLangs()).toEqual(["de", "fr"]);
 });
 
 test("persistLangDismissed does not duplicate an already-dismissed locale", () => {
@@ -89,16 +85,16 @@ test("persistLangDismissed does not duplicate an already-dismissed locale", () =
   expect(stored).toEqual(["de"]);
 });
 
-test("isLangDismissed is false when storage access throws", () => {
+test("loadDismissedLangs is empty when storage access throws", () => {
   vi.spyOn(window.localStorage, "getItem").mockImplementation(() => {
     throw new Error("storage disabled");
   });
-  expect(isLangDismissed("de")).toBe(false);
+  expect(loadDismissedLangs()).toEqual([]);
 });
 
-test("isLangDismissed is false when the stored value is corrupt", () => {
+test("loadDismissedLangs is empty when the stored value is corrupt", () => {
   window.localStorage.setItem(LANG_DISMISSED_STORAGE_KEY, "not json");
-  expect(isLangDismissed("de")).toBe(false);
+  expect(loadDismissedLangs()).toEqual([]);
 });
 
 test("persistLangDismissed is a silent no-op when storage access throws", () => {
@@ -148,7 +144,7 @@ test("clicking dismiss hides the banner and persists the locale", async () => {
   banner(el).querySelector("ha-icon-button").click();
   await el.updateComplete;
   expect(banner(el)).toBe(null);
-  expect(isLangDismissed("de")).toBe(true);
+  expect(loadDismissedLangs()).toContain("de");
 });
 
 test("dismissal sticks for the session when storage is unavailable", async () => {
@@ -159,5 +155,37 @@ test("dismissal sticks for the session when storage is unavailable", async () =>
   const el = await mountCard(makeHass({ language: "de" }));
   banner(el).querySelector("ha-icon-button").click();
   await el.updateComplete;
+  expect(banner(el)).toBe(null);
+});
+
+test("languageDisplayName falls back to the raw code when Intl throws", () => {
+  // "e" is a structurally invalid tag, so Intl.DisplayNames throws RangeError —
+  // unlike "zzz", which is valid and merely echoes. This is what exercises the
+  // guards; without it both catch arms are unreached.
+  expect(languageDisplayName("e")).toBe("e");
+});
+
+test("the issue body names the base language for a region variant", () => {
+  // de-AT, de-DE and de all want one `de` catalogue. Without this, each files a
+  // differently-titled issue and the maintainer can't tell which key to create.
+  const params = new URL(
+    buildTranslationRequestUrl("de-AT", "Österreichisches Deutsch")
+  ).searchParams;
+  expect(params.get("body")).toContain("de");
+  expect(params.get("body")).toContain("base language");
+});
+
+test("the issue body omits the base-language line for a plain language code", () => {
+  const params = new URL(buildTranslationRequestUrl("de", "Deutsch")).searchParams;
+  expect(params.get("body")).not.toContain("base language");
+});
+
+test("the banner does not render for English users", async () => {
+  const el = await mountCard(makeHass({ language: "en" }));
+  expect(banner(el)).toBe(null);
+});
+
+test("the banner does not render for a regional English variant", async () => {
+  const el = await mountCard(makeHass({ language: "en-GB" }));
   expect(banner(el)).toBe(null);
 });

--- a/tests/frontend/translations.test.mjs
+++ b/tests/frontend/translations.test.mjs
@@ -63,3 +63,34 @@ test("translate returns the key itself when no catalogue defines it", () => {
 test("translate substitutes placeholders", () => {
   expect(translate("en", "calibration.step", { step: 2 })).toBe("Step 2");
 });
+
+test("resolveLocale does not treat inherited Object properties as catalogues", () => {
+  // `in` walks the prototype chain; only own keys are real catalogues.
+  expect(resolveLocale("constructor")).toBe("");
+  expect(resolveLocale("toString")).toBe("");
+});
+
+test("isLanguageSupported is true for English so English users are never nudged", () => {
+  // The highest-consequence regression this feature could ship: if `en` ever
+  // stopped resolving, every English user would be told English is untranslated.
+  expect(isLanguageSupported("en")).toBe(true);
+  expect(isLanguageSupported("en-GB")).toBe(true);
+});
+
+test("translate substitutes every occurrence of a repeated placeholder", () => {
+  expect(translate("en", "language_request.message", { language: "X" })).not.toContain(
+    "{language}"
+  );
+  // A string repeating a placeholder must not leave the later ones raw.
+  expect(translate("en", "no.such.key.{a}.and.{a}", { a: "Z" })).toBe(
+    "no.such.key.Z.and.Z"
+  );
+});
+
+test("translate treats $-patterns in a replacement value as literal text", () => {
+  // String.replace interprets $&, $` and $' in the replacement — a display name
+  // containing one must not be able to splice the surrounding string into itself.
+  expect(translate("en", "no.such.key.{a}", { a: "$& $` $'" })).toBe(
+    "no.such.key.$& $` $'"
+  );
+});

--- a/tests/frontend/translations.test.mjs
+++ b/tests/frontend/translations.test.mjs
@@ -1,0 +1,65 @@
+/**
+ * Tests for translations.js — locale resolution and string lookup.
+ *
+ * Run: npm run test:fe -- tests/frontend/translations.test.mjs
+ */
+
+import { test, expect } from "vitest";
+import {
+  resolveLocale,
+  isLanguageSupported,
+  translate,
+} from "../../custom_components/cover_time_based/frontend/translations.js";
+
+test("resolveLocale matches a shipped language exactly", () => {
+  expect(resolveLocale("pt")).toBe("pt");
+});
+
+test("resolveLocale falls back to the base language for a region variant", () => {
+  // HA's canonical spelling, plus the underscore form, plus a region we do not
+  // ship — all covered by the European Portuguese catalogue.
+  expect(resolveLocale("pt-BR")).toBe("pt");
+  expect(resolveLocale("pt_BR")).toBe("pt");
+  expect(resolveLocale("pt-PT")).toBe("pt");
+});
+
+test("resolveLocale returns empty string for an unshipped language", () => {
+  expect(resolveLocale("de")).toBe("");
+  expect(resolveLocale("de-AT")).toBe("");
+});
+
+test("resolveLocale returns empty string when the language is missing", () => {
+  expect(resolveLocale("")).toBe("");
+  expect(resolveLocale(undefined)).toBe("");
+});
+
+test("isLanguageSupported treats a missing language as supported", () => {
+  // Undeterminable language: render English and never nudge.
+  expect(isLanguageSupported(undefined)).toBe(true);
+  expect(isLanguageSupported("")).toBe(true);
+});
+
+test("isLanguageSupported reflects whether a catalogue covers the locale", () => {
+  expect(isLanguageSupported("pl")).toBe(true);
+  expect(isLanguageSupported("pt-BR")).toBe(true);
+  expect(isLanguageSupported("de")).toBe(false);
+});
+
+test("translate renders a region variant in its base catalogue", () => {
+  // The bug this fixes: pt-BR used to fall through to English.
+  expect(translate("pt-BR", "loading")).toBe("A carregar...");
+});
+
+test("translate falls back to English for an unshipped language", () => {
+  expect(translate("de", "loading")).toBe("Loading...");
+});
+
+test("translate returns the key itself when no catalogue defines it", () => {
+  expect(translate("pt", "definitely.not.a.real.key")).toBe(
+    "definitely.not.a.real.key"
+  );
+});
+
+test("translate substitutes placeholders", () => {
+  expect(translate("en", "calibration.step", { step: 2 })).toBe("Step 2");
+});

--- a/tests/frontend/translations.test.mjs
+++ b/tests/frontend/translations.test.mjs
@@ -78,9 +78,6 @@ test("isLanguageSupported is true for English so English users are never nudged"
 });
 
 test("translate substitutes every occurrence of a repeated placeholder", () => {
-  expect(translate("en", "language_request.message", { language: "X" })).not.toContain(
-    "{language}"
-  );
   // A string repeating a placeholder must not leave the later ones raw.
   expect(translate("en", "no.such.key.{a}.and.{a}", { a: "Z" })).toBe(
     "no.such.key.Z.and.Z"


### PR DESCRIPTION
## What

Adds a dismissable banner to the configuration card, shown when the user's Home Assistant language has no shipped card translation. It names their language and links to a prefilled GitHub issue asking for one — the same nudge Ambience uses.

Along the way it fixes a locale-resolution bug the banner exposed.

## Why

The card ships strings in English, Portuguese and Polish. Everyone else silently reads English with no hint that asking for a translation is welcome — `TRANSLATING.md` already invites requests, but nothing in the product pointed at it.

## Changes

**Locale resolution (`translations.js`)** — `translate()` matched the locale by exact code only, so a `pt-BR` or `pt_PT` user rendered in **English despite `pt` shipping**. Resolution is now exact code → base language → English. Adding `de` now also covers `de-AT` and `de-CH`.

**The banner (`language-banner.js`, new)** — prefilled issue URL, native language display name via `Intl.DisplayNames`, and per-locale dismissal in `localStorage` (an array, not a flag: dismiss `de`, switch to `fr`, switch back, and a scalar store would re-nag). Rendered at the top of the card, above the entity picker.

For a region variant the issue body also names the base language, so `de-AT` and `de-DE` requests point at the single `de` catalogue that serves both rather than filing three differently-titled issues.

**Copy is intentionally not in the translation table.** The banner renders *only* when no catalogue covers the user's locale, so translated copy could never be displayed. It lives as constants in `language-banner.js`, which also keeps it out of the new language-parity gate rather than needing an exception to it.

**`TRANSLATING.md`** was stale — it located `EN`/`TRANSLATIONS` in `cover-time-based-card.js`, but they moved to `frontend/translations.js`, and its audit snippet grepped a layout that no longer exists. Corrected, and the base-language fallback documented.

## Testing

21 new frontend tests (345 total, all passing). Coverage: `language-banner.js` and `translations.js` both at 100% lines.

Verified manually in a dev HA instance with the profile language set to German: banner appears, the link opens a correctly prefilled issue, dismissal survives a reload; switching to Portuguese (Brazil) renders Portuguese with no banner.

## Notes for review

- Two config cards on one dashboard won't sync a dismissal until reload — the Set is seeded per instance at construction. Judged acceptable (a single config card is the expected usage, as `selection-storage.js` already assumes).
- `pt-BR` users now read European Portuguese instead of English, which also means they no longer see the banner and so have no in-product route to request a dedicated Brazilian catalogue. Net improvement, but a deliberate trade worth a second opinion.