### PR TITLE
fix: three settle-gap and tilt-restore races where a stale operation resumed behind a newer one

### DIFF
--- a/custom_components/cover_time_based/cover_base.py
+++ b/custom_components/cover_time_based/cover_base.py
@@ -479,7 +479,9 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
             # External trigger: stop the opposite-direction motion, settle,
             # then proceed with close (legacy reverse behavior).
             self._log("async_close_cover :: external close while opening, reversing")
-            await self.async_stop_cover()
+            # This stop is the reversal's own prelude, not a command to halt —
+            # superseding here would cancel the movement it is starting.
+            await self.async_stop_cover(supersede=False)
             if not await self._settle_before_reversing():
                 return
 
@@ -545,7 +547,8 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
             return
         if self._triggered_externally and self._travel_axis_closing():
             self._log("async_open_cover :: external open while closing, reversing")
-            await self.async_stop_cover()
+            # Reversal prelude, not a halt command — see async_close_cover.
+            await self.async_stop_cover(supersede=False)
             if not await self._settle_before_reversing():
                 return
         # Mirror async_close_cover's skip-at-0 for covers that treat an endpoint
@@ -679,8 +682,14 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
             return False
         return True
 
-    async def async_stop_cover(self, **kwargs):
-        """Turn the device stop."""
+    async def async_stop_cover(self, *, supersede: bool = True, **kwargs):
+        """Turn the device stop.
+
+        ``supersede`` defaults True so a stop arriving from HA (service call,
+        UI, automation) always claims the movement; the internal and
+        external-trigger callers that are echoes or reversal preludes pass
+        False. See _handle_stop.
+        """
         self._require_configured()
         self._log("async_stop_cover")
         tilt_restore_was_active = self._tilt_restore_active
@@ -690,7 +699,7 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         )
         self._cancel_startup_delay_task()
         self._cancel_delay_task()
-        self._handle_stop()
+        self._handle_stop(supersede=supersede)
         if self._has_tilt_support():
             self._tilt_strategy.snap_trackers_to_physical(
                 self.travel_calc, self.tilt_calc
@@ -730,10 +739,15 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
             self._log("async_set_cover_tilt_position: %d", position)
             await self.set_tilt_position(position)
 
-    async def set_known_position(self, **kwargs):
-        """Set the cover to a known position (0=closed, 100=open)."""
+    async def set_known_position(self, *, supersede: bool = True, **kwargs):
+        """Set the cover to a known position (0=closed, 100=open).
+
+        Exposed as a service (a user resyncing the tracker is a real command,
+        hence the default) and used internally by wrapped covers to snap to a
+        position the device just reported, which is not — see _handle_stop.
+        """
         position = kwargs[ATTR_POSITION]
-        self._handle_stop()
+        self._handle_stop(supersede=supersede)
         self.travel_calc.set_position(position)
         if self._has_tilt_support():
             self._tilt_strategy.snap_trackers_to_physical(
@@ -1851,23 +1865,32 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
                 self._log("_stop_travel_if_traveling :: also stopping tilt")
                 self.tilt_calc.stop()
 
-    def _handle_stop(self):
-        """Handle stop"""
-        # Every route that halts the cover lands here — both async_stop_cover
-        # implementations (the toggle override does not call super), plus the
-        # known-position resets — so this is where a stop claims the movement
-        # and keeps a reversal parked in its settle gap from driving afterwards.
-        #
-        # Only our own intent counts, never the device talking back. Passive
-        # routes land here too: a wrapped cover reporting its settled position
-        # snaps via set_known_position, and a switch-mode relay's unmarked off
-        # (a hardware interlock clearing the opposite relay) calls
-        # async_stop_cover. Both run with _triggered_externally set, and both
-        # can arrive inside the settle window — the wrapped self-echo
-        # suppressors are keyed on is_traveling(), which the reversal has
-        # already cleared. Treating those as supersessions would silently drop
-        # the user's move, or freeze the tracker while the motor runs.
-        if not self._triggered_externally:
+    def _handle_stop(self, *, supersede: bool = True):
+        """Handle stop.
+
+        ``supersede`` says whether this is a fresh command to halt the cover,
+        which claims the movement and so keeps a reversal parked in its settle
+        gap from driving afterwards. Every route that halts the cover lands
+        here — both async_stop_cover implementations (the toggle override does
+        not call super), plus the known-position resets.
+
+        Passive routes must pass ``supersede=False``: a wrapped cover reporting
+        its settled position snaps via set_known_position, and a switch-mode
+        relay's unmarked off (a hardware interlock clearing the opposite relay)
+        calls async_stop_cover. Both can arrive inside the settle window — the
+        wrapped self-echo suppressors are keyed on is_traveling(), which the
+        reversal has already cleared — and treating them as supersessions would
+        silently drop the user's move, or freeze the tracker while the motor
+        runs. So must the stop a reversal issues as its own prelude, which would
+        otherwise cancel the very movement it is starting.
+
+        This was once inferred from _triggered_externally rather than stated by
+        the caller. That flag is ambient instance state held for the whole
+        external call, settle gap included, so a genuine stop landing in an
+        external reversal's gap read as a device echo and was dropped — the
+        cover then moved seconds after the user said stop.
+        """
+        if supersede:
             self._supersede_movement()
         self._tilt_restore_target = None
         self._tilt_restore_active = False
@@ -2434,7 +2457,7 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
             self._log(
                 "_handle_external_tilt_state_change :: external tilt stop pulse detected"
             )
-            await self.async_stop_cover()
+            await self.async_stop_cover(supersede=False)
 
     async def _handle_external_state_change(self, entity_id, old_val, new_val):
         """Handle external state change. Override in subclasses for mode-specific behavior."""

--- a/custom_components/cover_time_based/cover_base.py
+++ b/custom_components/cover_time_based/cover_base.py
@@ -653,6 +653,24 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         self._tilt_restore_epoch += 1
         return self._tilt_restore_epoch
 
+    def _release_tilt_restore(self) -> None:
+        """Mark no restore active, cancelling any still parked on an await.
+
+        Deliberately leaves the epoch alone: releasing does not hand identity
+        to anyone, and the next claim bumps it anyway. That is why
+        _tilt_restore_superseded has to test the flag as well as the epoch.
+        """
+        self._tilt_restore_active = False
+
+    def _clear_multiphase_tilt_state(self) -> None:
+        """Drop every in-flight tilt phase — restore and pre-step alike."""
+        self._tilt_restore_target = None
+        self._release_tilt_restore()
+        self._pending_travel_target = None
+        self._pending_travel_command = None
+        self._pending_tilt_target = None
+        self._pending_tilt_command = None
+
     def _tilt_restore_superseded(self, epoch: int) -> bool:
         """Whether the restore holding ``epoch`` has been cancelled or replaced.
 
@@ -1616,7 +1634,7 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
 
             if self._tilt_restore_active:
                 self._log("auto_stop_if_necessary :: tilt restore complete")
-                self._tilt_restore_active = False
+                self._release_tilt_restore()
                 if self._has_tilt_motor():
                     await self._tilt_settle()
                 else:
@@ -1825,12 +1843,7 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         )
 
         # Always clear multi-phase state
-        self._tilt_restore_target = None
-        self._tilt_restore_active = False
-        self._pending_travel_target = None
-        self._pending_travel_command = None
-        self._pending_tilt_target = None
-        self._pending_tilt_command = None
+        self._clear_multiphase_tilt_state()
         # Each movement entry point funnels through here; default to a travel
         # move and let the tilt paths below opt in.
         self._moving_tilt_motor = False
@@ -1884,20 +1897,14 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         runs. So must the stop a reversal issues as its own prelude, which would
         otherwise cancel the very movement it is starting.
 
-        This was once inferred from _triggered_externally rather than stated by
-        the caller. That flag is ambient instance state held for the whole
-        external call, settle gap included, so a genuine stop landing in an
-        external reversal's gap read as a device echo and was dropped — the
-        cover then moved seconds after the user said stop.
+        The caller has to say so because _triggered_externally cannot: it is
+        ambient instance state held for the whole external call, settle gap
+        included, so inferring from it read a genuine stop landing in that gap
+        as a device echo and dropped it.
         """
         if supersede:
             self._supersede_movement()
-        self._tilt_restore_target = None
-        self._tilt_restore_active = False
-        self._pending_travel_target = None
-        self._pending_travel_command = None
-        self._pending_tilt_target = None
-        self._pending_tilt_command = None
+        self._clear_multiphase_tilt_state()
 
         if self.travel_calc.is_traveling():
             self._log("_handle_stop :: button stops cover movement")
@@ -2457,7 +2464,9 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
             self._log(
                 "_handle_external_tilt_state_change :: external tilt stop pulse detected"
             )
-            await self.async_stop_cover(supersede=False)
+            # A dedicated stop relay is a press, not a report — see
+            # SwitchCoverTimeBased._handle_external_state_change.
+            await self.async_stop_cover()
 
     async def _handle_external_state_change(self, entity_id, old_val, new_val):
         """Handle external state change. Override in subclasses for mode-specific behavior."""

--- a/custom_components/cover_time_based/cover_base.py
+++ b/custom_components/cover_time_based/cover_base.py
@@ -145,6 +145,10 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         #     (sequential_close, dual_motor — not inline or sequential_open).
         self._tilt_restore_target: int | None = None
         self._tilt_restore_active: bool = False
+        # Identity for the active restore, bumped on every claim. The bool says
+        # only that *a* restore is live, which a restore resuming from an await
+        # cannot distinguish from its own — see _tilt_restore_superseded.
+        self._tilt_restore_epoch: int = 0
         self._pending_travel_target: int | None = None
         self._pending_travel_command: str | None = None
         self._pending_tilt_target: int | None = None
@@ -639,6 +643,23 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
     def _supersede_movement(self) -> None:
         """Claim the movement, cancelling any reversal waiting out its settle."""
         self._movement_epoch += 1
+
+    def _claim_tilt_restore(self) -> int:
+        """Mark a tilt restore active and return its identity."""
+        self._tilt_restore_active = True
+        self._tilt_restore_epoch += 1
+        return self._tilt_restore_epoch
+
+    def _tilt_restore_superseded(self, epoch: int) -> bool:
+        """Whether the restore holding ``epoch`` has been cancelled or replaced.
+
+        The active flag alone answers "is a restore live", not "is mine". A
+        restore cancelled while parked on an await, then replaced by a newer one
+        before it resumed, read its own True back and carried on — driving the
+        motor a second time and retargeting the tilt tracker at the goal it had
+        already been told to abandon.
+        """
+        return not self._tilt_restore_active or epoch != self._tilt_restore_epoch
 
     async def _settle_before_reversing(self) -> bool:
         """Await the settle gap; False if this movement was superseded.
@@ -2046,12 +2067,12 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         # travel reached its target, re-armed only at the tail below), so no
         # re-entrant auto_stop_if_necessary can take the restore-complete branch
         # mid-startup — keep it that way if this ever moves.
-        self._tilt_restore_active = True
+        epoch = self._claim_tilt_restore()
 
         if self._tilt_strategy.uses_tilt_motor:
             # Dual motor: stop travel, then start the separate tilt motor.
             await self._async_handle_command(SERVICE_STOP_COVER)
-            if not self._tilt_restore_active:
+            if self._tilt_restore_superseded(epoch):
                 self._log("_start_tilt_restore :: cancelled before tilt motor start")
                 return
             if closing:
@@ -2067,7 +2088,7 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
             # restore pulse's stop command dropped by the relay, so the cover
             # overruns to its physical endpoint.
             await self._async_handle_command(SERVICE_STOP_COVER)
-            if not self._tilt_restore_active:
+            if self._tilt_restore_superseded(epoch):
                 # Cancelled while stopping — bail before the settle delay so we
                 # don't block the background task for a dead restore. The gap is
                 # the per-cover direction_change_delay, so it can be several
@@ -2075,13 +2096,13 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
                 self._log("_start_tilt_restore :: cancelled before settle delay")
                 return
             await self._direction_change_delay()
-            if not self._tilt_restore_active:
+            if self._tilt_restore_superseded(epoch):
                 self._log("_start_tilt_restore :: cancelled during settle delay")
                 return
             command = self._tilt_strategy.tilt_command_for(closing)
             await self._async_handle_command(command)
 
-        if not self._tilt_restore_active:
+        if self._tilt_restore_superseded(epoch):
             self._log("_start_tilt_restore :: cancelled during motor start")
             return
         self.tilt_calc.start_travel(restore_target)

--- a/custom_components/cover_time_based/cover_base.py
+++ b/custom_components/cover_time_based/cover_base.py
@@ -58,10 +58,20 @@ from .tilt_strategies.planning import (
 
 _LOGGER = logging.getLogger(__name__)
 
-# The covers whose external-state handler is running in the current context.
+# (task, cover) pairs for the external-state handlers currently running.
+#
 # One module-level var holding a set, rather than one var per entity: context
 # variables are never reclaimed, so creating them per instance would leak on
-# every integration reload. See CoverTimeBased._triggered_externally.
+# every integration reload.
+#
+# The task is part of the key, not incidental. A context is *copied into* every
+# task and timer callback created while it is active — and HA's interval timer
+# reschedules itself from inside that copy — so storing the flag in a
+# ContextVar alone hands it to the entire auto-updater chain for the life of
+# the movement, long after the handler that raised it returned. Pairing it with
+# the owning task means an inherited copy is still there but no longer matches,
+# which is exactly the scope we want: the handler's own awaits, nothing it
+# schedules. See CoverTimeBased._triggered_externally.
 _EXTERNAL_TRIGGER: ContextVar[frozenset] = ContextVar(
     "cover_time_based_external_trigger", default=frozenset()
 )
@@ -659,22 +669,25 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         over to suppress relay writes (never echo a command back at hardware
         that is already doing it) and to pick external-trigger behaviour.
 
-        Task-scoped, not instance-scoped. An external handler holds this across
-        every await it makes — including a reversal's whole settle gap — so as
-        plain instance state it leaked onto anything that ran meanwhile. A UI
-        stop landing in that window inherited the suppression and sent no relay
-        command at all, halting the tracker while the motor ran on. HA
-        dispatches each service call as its own task, and a task gets a copy of
-        the context at creation, so scoping it here means the dispatcher's
-        handler still sees it across its awaits while a concurrent caller
-        correctly does not.
+        Scoped to the task that raised it. An external handler holds this
+        across every await it makes — including a reversal's whole settle gap —
+        so as plain instance state it leaked onto anything that ran meanwhile:
+        a UI stop landing in that window inherited the suppression and sent no
+        relay command at all, halting the tracker while the motor ran on. HA
+        dispatches each service call as its own task, so keying on the task
+        means the handler still sees it across its own awaits while a
+        concurrent caller does not.
+
+        Keying on the *task* rather than only on the context is what stops the
+        scope widening again the other way — see _EXTERNAL_TRIGGER.
         """
-        return self in _EXTERNAL_TRIGGER.get()
+        return (asyncio.current_task(), self) in _EXTERNAL_TRIGGER.get()
 
     @_triggered_externally.setter
     def _triggered_externally(self, value: bool) -> None:
+        entry = (asyncio.current_task(), self)
         current = _EXTERNAL_TRIGGER.get()
-        _EXTERNAL_TRIGGER.set(current | {self} if value else current - {self})
+        _EXTERNAL_TRIGGER.set(current | {entry} if value else current - {entry})
 
     def _supersede_movement(self) -> None:
         """Claim the movement, cancelling any reversal waiting out its settle."""
@@ -767,7 +780,10 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         if not self._triggered_externally:
             await self._send_stop()
         if stop_tilt:
-            await self._send_tilt_stop()
+            # _tilt_settle, not a bare stop: at 0%/100% the motor is already
+            # stopped on its limit switch and a momentary relay re-pulsed there
+            # starts it again.
+            await self._tilt_settle()
         self.async_write_ha_state()
         self._last_command = None
         await self._async_persist_position()
@@ -1932,6 +1948,13 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         self.stop_auto_updater()
 
         await self._async_handle_command(SERVICE_STOP_COVER)
+        # Deliberately still gated on _triggered_externally, unlike
+        # async_stop_cover. This route cannot tell which axis reported: the
+        # tilt entry points reach it too (async_open_cover_tilt ->
+        # _async_move_tilt_to_endpoint -> here), so firing on an external tilt
+        # event would echo a stop back at the very relay that reported — which
+        # on toggle hardware starts the motor rather than stopping it. Until
+        # the axis is threaded this far, suppressing is the safe direction.
         if self._has_tilt_motor() and not self._triggered_externally:
             await self._send_tilt_stop()
 
@@ -2211,9 +2234,29 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         self.start_auto_updater()
 
     async def _stop_restore_motor(self) -> None:
-        """Take down whichever motor the restore energized."""
-        if self._tilt_strategy.uses_tilt_motor:
-            await self._send_tilt_stop()
+        """Take down whichever motor the restore energized.
+
+        Only when nothing is tracking it. Superseders come in two kinds: a
+        stop, which leaves no movement behind and so leaves our turn-on running
+        with nobody to switch it off — the case this exists for — and a new
+        *movement*, which abandoned the lifecycle and then energized a motor of
+        its own. Stopping in the second case kills the replacement's motor
+        while its calculator animates on, which is the same tracker-
+        confidently-wrong desync approached from the other side. A live
+        calculator is exactly the difference between the two.
+
+        _tilt_settle rather than a bare stop because at 0%/100% the motor has
+        already stopped on its own limit switch and re-pulsing a momentary
+        relay there would start it moving again. A path added to avoid leaving
+        a motor running must not do that either.
+        """
+        if self.travel_calc.is_traveling() or (
+            self._has_tilt_support() and self.tilt_calc.is_traveling()
+        ):
+            self._log("_stop_restore_motor :: a movement is tracking, leaving it alone")
+            return
+        if self._has_tilt_motor():
+            await self._tilt_settle()
         else:
             await self._async_handle_command(SERVICE_STOP_COVER)
 

--- a/custom_components/cover_time_based/cover_base.py
+++ b/custom_components/cover_time_based/cover_base.py
@@ -733,13 +733,18 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
             return False
         return True
 
-    async def async_stop_cover(self, *, supersede: bool = True, **kwargs):
+    async def async_stop_cover(
+        self, *, supersede: bool = True, tilt_axis_reported: bool = False, **kwargs
+    ):
         """Turn the device stop.
 
         ``supersede`` defaults True so a stop arriving from HA (service call,
         UI, automation) always claims the movement; the internal and
         external-trigger callers that are echoes or reversal preludes pass
         False. See _handle_stop.
+
+        ``tilt_axis_reported`` says the tilt relay is the one that reported,
+        so a stop must not be echoed back at it — see _should_stop_tilt_motor.
         """
         self._require_configured()
         self._log("async_stop_cover")
@@ -747,6 +752,10 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         tilt_pre_step_was_active = (
             self._pending_travel_target is not None
             or self._pending_tilt_target is not None
+        )
+        stop_tilt = self._should_stop_tilt_motor(
+            tilt_restore_was_active or tilt_pre_step_was_active,
+            tilt_axis_reported=tilt_axis_reported,
         )
         self._cancel_startup_delay_task()
         self._cancel_delay_task()
@@ -757,13 +766,37 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
             )
         if not self._triggered_externally:
             await self._send_stop()
-            if (
-                tilt_restore_was_active or tilt_pre_step_was_active
-            ) and self._has_tilt_motor():
-                await self._send_tilt_stop()
+        if stop_tilt:
+            await self._send_tilt_stop()
         self.async_write_ha_state()
         self._last_command = None
         await self._async_persist_position()
+
+    def _should_stop_tilt_motor(
+        self, tilt_phase_was_active: bool, *, tilt_axis_reported: bool
+    ) -> bool:
+        """Whether abandoning this movement leaves a tilt motor to take down.
+
+        Only dual-motor covers have a tilt motor of their own; elsewhere tilt
+        is the travel motor and _send_stop already covered it.
+
+        The relay suppression that guards _send_stop is about not echoing a
+        command back at hardware that already did it — which is true of the
+        relay the external event was about, and of no other. The tilt motor is
+        a separate relay we drive ourselves, so when a *travel* event abandons
+        a live tilt phase nothing else will ever stop it: the tracker halts,
+        the phase is forgotten, and the motor keeps running. Hence this is
+        deliberately not gated on _triggered_externally.
+
+        It is gated on ``tilt_axis_reported``, because when the tilt relay is
+        the one that reported, echoing a stop back at it is exactly the thing
+        the suppression exists to prevent — and on toggle hardware
+        _send_tilt_stop is a *pulse*, so it would start the motor moving again
+        rather than stop it.
+        """
+        return (
+            tilt_phase_was_active and self._has_tilt_motor() and not tilt_axis_reported
+        )
 
     async def async_close_cover_tilt(self, **kwargs):
         """Tilt the cover fully closed."""
@@ -2511,8 +2544,9 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
                 "_handle_external_tilt_state_change :: external tilt stop pulse detected"
             )
             # A dedicated stop relay is a press, not a report — see
-            # SwitchCoverTimeBased._handle_external_state_change.
-            await self.async_stop_cover()
+            # SwitchCoverTimeBased._handle_external_state_change. It is the
+            # tilt hardware's own stop, so don't echo one back at it.
+            await self.async_stop_cover(tilt_axis_reported=True)
 
     async def _handle_external_state_change(self, entity_id, old_val, new_val):
         """Handle external state change. Override in subclasses for mode-specific behavior."""

--- a/custom_components/cover_time_based/cover_base.py
+++ b/custom_components/cover_time_based/cover_base.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 from abc import abstractmethod
 from asyncio import sleep
+from contextvars import ContextVar
 from datetime import timedelta
 
 from homeassistant.components.cover import (
@@ -56,6 +57,14 @@ from .tilt_strategies.planning import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+# The covers whose external-state handler is running in the current context.
+# One module-level var holding a set, rather than one var per entity: context
+# variables are never reclaimed, so creating them per instance would leak on
+# every integration reload. See CoverTimeBased._triggered_externally.
+_EXTERNAL_TRIGGER: ContextVar[frozenset] = ContextVar(
+    "cover_time_based_external_trigger", default=frozenset()
+)
 
 
 class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
@@ -153,7 +162,6 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         self._pending_travel_command: str | None = None
         self._pending_tilt_target: int | None = None
         self._pending_tilt_command: str | None = None
-        self._triggered_externally = False
         self._self_initiated_movement = True
         # True while the active movement drives a dedicated tilt motor (dual
         # motor), so auto-stop settles the tilt motor instead of travel.
@@ -642,6 +650,31 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         for why a fixed gap is not good enough.
         """
         await sleep(self._direction_change_delay_time)
+
+    @property
+    def _triggered_externally(self) -> bool:
+        """Whether *this* call is handling something the hardware did.
+
+        Set by the external-state dispatcher around its handler, and read all
+        over to suppress relay writes (never echo a command back at hardware
+        that is already doing it) and to pick external-trigger behaviour.
+
+        Task-scoped, not instance-scoped. An external handler holds this across
+        every await it makes — including a reversal's whole settle gap — so as
+        plain instance state it leaked onto anything that ran meanwhile. A UI
+        stop landing in that window inherited the suppression and sent no relay
+        command at all, halting the tracker while the motor ran on. HA
+        dispatches each service call as its own task, and a task gets a copy of
+        the context at creation, so scoping it here means the dispatcher's
+        handler still sees it across its awaits while a concurrent caller
+        correctly does not.
+        """
+        return self in _EXTERNAL_TRIGGER.get()
+
+    @_triggered_externally.setter
+    def _triggered_externally(self, value: bool) -> None:
+        current = _EXTERNAL_TRIGGER.get()
+        _EXTERNAL_TRIGGER.set(current | {self} if value else current - {self})
 
     def _supersede_movement(self) -> None:
         """Claim the movement, cancelling any reversal waiting out its settle."""
@@ -2133,10 +2166,23 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
             await self._async_handle_command(command)
 
         if self._tilt_restore_superseded(epoch):
-            self._log("_start_tilt_restore :: cancelled during motor start")
+            # The motor is already energized: whoever cancelled us sent their
+            # stop while we were awaiting this turn-on, so theirs went out
+            # first and ours landed after it. Nothing else will take it down —
+            # we are the only one that knows it went up — and on a latching
+            # relay that means a cover driving to its endpoint untracked.
+            self._log("_start_tilt_restore :: cancelled during motor start, stopping")
+            await self._stop_restore_motor()
             return
         self.tilt_calc.start_travel(restore_target)
         self.start_auto_updater()
+
+    async def _stop_restore_motor(self) -> None:
+        """Take down whichever motor the restore energized."""
+        if self._tilt_strategy.uses_tilt_motor:
+            await self._send_tilt_stop()
+        else:
+            await self._async_handle_command(SERVICE_STOP_COVER)
 
     # -----------------------------------------------------------------------
     # Relay command dispatch

--- a/custom_components/cover_time_based/cover_switch.py
+++ b/custom_components/cover_time_based/cover_switch.py
@@ -45,4 +45,6 @@ class SwitchCoverTimeBased(CoverTimeBased):
             await self.async_close_cover()
         elif entity_id == self._stop_switch_entity_id:
             self._log("_handle_external_state_change :: external stop pulse detected")
-            await self.async_stop_cover(supersede=False)
+            # A dedicated stop relay only pulses because someone pressed it, so
+            # unlike the rest of this handler it is a command, not a report.
+            await self.async_stop_cover()

--- a/custom_components/cover_time_based/cover_switch.py
+++ b/custom_components/cover_time_based/cover_switch.py
@@ -45,4 +45,4 @@ class SwitchCoverTimeBased(CoverTimeBased):
             await self.async_close_cover()
         elif entity_id == self._stop_switch_entity_id:
             self._log("_handle_external_state_change :: external stop pulse detected")
-            await self.async_stop_cover()
+            await self.async_stop_cover(supersede=False)

--- a/custom_components/cover_time_based/cover_switch_mode.py
+++ b/custom_components/cover_time_based/cover_switch_mode.py
@@ -118,7 +118,7 @@ class SwitchModeCover(SwitchCoverTimeBased):
                 _LOGGER.debug(
                     "_handle_external_tilt_state_change :: external tilt open off, stopping"
                 )
-                await self.async_stop_cover(supersede=False)
+                await self.async_stop_cover(supersede=False, tilt_axis_reported=True)
         elif entity_id == self._tilt_close_switch_id:
             if new_val == "on":
                 _LOGGER.debug(
@@ -130,7 +130,7 @@ class SwitchModeCover(SwitchCoverTimeBased):
                 _LOGGER.debug(
                     "_handle_external_tilt_state_change :: external tilt close off, stopping"
                 )
-                await self.async_stop_cover(supersede=False)
+                await self.async_stop_cover(supersede=False, tilt_axis_reported=True)
         elif entity_id == self._tilt_stop_switch_id:
             if new_val == "on":
                 _LOGGER.debug(
@@ -138,7 +138,7 @@ class SwitchModeCover(SwitchCoverTimeBased):
                 )
                 # A dedicated stop relay is a press, not a report — unlike the
                 # relay-off branches above, which are the hardware reporting.
-                await self.async_stop_cover()
+                await self.async_stop_cover(tilt_axis_reported=True)
 
     async def _send_open(self) -> None:
         # Mark a pending echo only when the relay call will actually flip state

--- a/custom_components/cover_time_based/cover_switch_mode.py
+++ b/custom_components/cover_time_based/cover_switch_mode.py
@@ -136,7 +136,9 @@ class SwitchModeCover(SwitchCoverTimeBased):
                 _LOGGER.debug(
                     "_handle_external_tilt_state_change :: external tilt stop detected"
                 )
-                await self.async_stop_cover(supersede=False)
+                # A dedicated stop relay is a press, not a report — unlike the
+                # relay-off branches above, which are the hardware reporting.
+                await self.async_stop_cover()
 
     async def _send_open(self) -> None:
         # Mark a pending echo only when the relay call will actually flip state

--- a/custom_components/cover_time_based/cover_switch_mode.py
+++ b/custom_components/cover_time_based/cover_switch_mode.py
@@ -45,7 +45,7 @@ class SwitchModeCover(SwitchCoverTimeBased):
                 _LOGGER.debug(
                     "_handle_external_state_change :: external open switch off, stopping"
                 )
-                await self.async_stop_cover()
+                await self.async_stop_cover(supersede=False)
         elif entity_id == self._close_switch_entity_id:
             if new_val == "on":
                 _LOGGER.debug(
@@ -57,7 +57,7 @@ class SwitchModeCover(SwitchCoverTimeBased):
                 _LOGGER.debug(
                     "_handle_external_state_change :: external close switch off, stopping"
                 )
-                await self.async_stop_cover()
+                await self.async_stop_cover(supersede=False)
 
     async def _interlock_off(self, entity_id) -> None:
         """Turn the opposite direction relay OFF (software interlock).
@@ -118,7 +118,7 @@ class SwitchModeCover(SwitchCoverTimeBased):
                 _LOGGER.debug(
                     "_handle_external_tilt_state_change :: external tilt open off, stopping"
                 )
-                await self.async_stop_cover()
+                await self.async_stop_cover(supersede=False)
         elif entity_id == self._tilt_close_switch_id:
             if new_val == "on":
                 _LOGGER.debug(
@@ -130,13 +130,13 @@ class SwitchModeCover(SwitchCoverTimeBased):
                 _LOGGER.debug(
                     "_handle_external_tilt_state_change :: external tilt close off, stopping"
                 )
-                await self.async_stop_cover()
+                await self.async_stop_cover(supersede=False)
         elif entity_id == self._tilt_stop_switch_id:
             if new_val == "on":
                 _LOGGER.debug(
                     "_handle_external_tilt_state_change :: external tilt stop detected"
                 )
-                await self.async_stop_cover()
+                await self.async_stop_cover(supersede=False)
 
     async def _send_open(self) -> None:
         # Mark a pending echo only when the relay call will actually flip state

--- a/custom_components/cover_time_based/cover_toggle_base.py
+++ b/custom_components/cover_time_based/cover_toggle_base.py
@@ -191,7 +191,8 @@ class ToggleBaseCover(SwitchCoverTimeBased):
         if not self._triggered_externally and was_active:
             await self._send_stop()
         if stop_tilt:
-            await self._send_tilt_stop()
+            # See CoverTimeBased.async_stop_cover — endpoint-safe teardown.
+            await self._tilt_settle()
         self.async_write_ha_state()
         self._last_command = None
         self._last_tilt_direction = None

--- a/custom_components/cover_time_based/cover_toggle_base.py
+++ b/custom_components/cover_time_based/cover_toggle_base.py
@@ -161,8 +161,11 @@ class ToggleBaseCover(SwitchCoverTimeBased):
             self._mark_switch_pending(entity_id, 1)
         await self._turn_off_relay(entity_id)
 
-    async def async_stop_cover(self, **kwargs):
-        """Stop the cover, only sending relay command if it was active."""
+    async def async_stop_cover(self, *, supersede: bool = True, **kwargs):
+        """Stop the cover, only sending relay command if it was active.
+
+        See CoverTimeBased.async_stop_cover for ``supersede``.
+        """
         was_active = (
             self.is_opening
             or self.is_closing
@@ -173,7 +176,7 @@ class ToggleBaseCover(SwitchCoverTimeBased):
         tilt_pre_step_was_active = self._pending_travel_target is not None
         self._cancel_startup_delay_task()
         self._cancel_delay_task()
-        self._handle_stop()
+        self._handle_stop(supersede=supersede)
         if self._tilt_strategy is not None:
             self._tilt_strategy.snap_trackers_to_physical(
                 self.travel_calc, self.tilt_calc

--- a/custom_components/cover_time_based/cover_toggle_base.py
+++ b/custom_components/cover_time_based/cover_toggle_base.py
@@ -161,10 +161,13 @@ class ToggleBaseCover(SwitchCoverTimeBased):
             self._mark_switch_pending(entity_id, 1)
         await self._turn_off_relay(entity_id)
 
-    async def async_stop_cover(self, *, supersede: bool = True, **kwargs):
+    async def async_stop_cover(
+        self, *, supersede: bool = True, tilt_axis_reported: bool = False, **kwargs
+    ):
         """Stop the cover, only sending relay command if it was active.
 
-        See CoverTimeBased.async_stop_cover for ``supersede``.
+        See CoverTimeBased.async_stop_cover for ``supersede`` and
+        ``tilt_axis_reported``.
         """
         was_active = (
             self.is_opening
@@ -174,6 +177,10 @@ class ToggleBaseCover(SwitchCoverTimeBased):
         )
         tilt_restore_was_active = self._tilt_restore_active
         tilt_pre_step_was_active = self._pending_travel_target is not None
+        stop_tilt = was_active and self._should_stop_tilt_motor(
+            tilt_restore_was_active or tilt_pre_step_was_active,
+            tilt_axis_reported=tilt_axis_reported,
+        )
         self._cancel_startup_delay_task()
         self._cancel_delay_task()
         self._handle_stop(supersede=supersede)
@@ -183,10 +190,8 @@ class ToggleBaseCover(SwitchCoverTimeBased):
             )
         if not self._triggered_externally and was_active:
             await self._send_stop()
-            if (
-                tilt_restore_was_active or tilt_pre_step_was_active
-            ) and self._has_tilt_motor():
-                await self._send_tilt_stop()
+        if stop_tilt:
+            await self._send_tilt_stop()
         self.async_write_ha_state()
         self._last_command = None
         self._last_tilt_direction = None

--- a/custom_components/cover_time_based/cover_toggle_mode.py
+++ b/custom_components/cover_time_based/cover_toggle_mode.py
@@ -56,7 +56,7 @@ class ToggleModeCover(ToggleBaseCover):
                 self._log(
                     "_handle_external_state_change :: open toggle while opening, stopping"
                 )
-                await self.async_stop_cover()
+                await self.async_stop_cover(supersede=False)
             else:
                 self._log(
                     "_handle_external_state_change :: external open toggle detected"
@@ -67,7 +67,7 @@ class ToggleModeCover(ToggleBaseCover):
                 self._log(
                     "_handle_external_state_change :: close toggle while closing, stopping"
                 )
-                await self.async_stop_cover()
+                await self.async_stop_cover(supersede=False)
             else:
                 self._log(
                     "_handle_external_state_change :: external close toggle detected"
@@ -86,7 +86,7 @@ class ToggleModeCover(ToggleBaseCover):
                 self._log(
                     "_handle_external_tilt_state_change :: tilt open toggle while traveling, stopping"
                 )
-                await self.async_stop_cover()
+                await self.async_stop_cover(supersede=False)
             else:
                 self._log(
                     "_handle_external_tilt_state_change :: external tilt open toggle detected"
@@ -97,7 +97,7 @@ class ToggleModeCover(ToggleBaseCover):
                 self._log(
                     "_handle_external_tilt_state_change :: tilt close toggle while traveling, stopping"
                 )
-                await self.async_stop_cover()
+                await self.async_stop_cover(supersede=False)
             else:
                 self._log(
                     "_handle_external_tilt_state_change :: external tilt close toggle detected"

--- a/custom_components/cover_time_based/cover_toggle_mode.py
+++ b/custom_components/cover_time_based/cover_toggle_mode.py
@@ -86,7 +86,7 @@ class ToggleModeCover(ToggleBaseCover):
                 self._log(
                     "_handle_external_tilt_state_change :: tilt open toggle while traveling, stopping"
                 )
-                await self.async_stop_cover(supersede=False)
+                await self.async_stop_cover(supersede=False, tilt_axis_reported=True)
             else:
                 self._log(
                     "_handle_external_tilt_state_change :: external tilt open toggle detected"
@@ -97,7 +97,7 @@ class ToggleModeCover(ToggleBaseCover):
                 self._log(
                     "_handle_external_tilt_state_change :: tilt close toggle while traveling, stopping"
                 )
-                await self.async_stop_cover(supersede=False)
+                await self.async_stop_cover(supersede=False, tilt_axis_reported=True)
             else:
                 self._log(
                     "_handle_external_tilt_state_change :: external tilt close toggle detected"

--- a/custom_components/cover_time_based/cover_toggle_opposite_mode.py
+++ b/custom_components/cover_time_based/cover_toggle_opposite_mode.py
@@ -100,7 +100,7 @@ class ToggleOppositeModeCover(ToggleBaseCover):
                     "_handle_external_tilt_state_change :: tilt open press while"
                     " tilt closing, stopping"
                 )
-                await self.async_stop_cover(supersede=False)
+                await self.async_stop_cover(supersede=False, tilt_axis_reported=True)
             elif not self.tilt_calc.is_opening():
                 self._log(
                     "_handle_external_tilt_state_change :: external tilt open press"
@@ -113,7 +113,7 @@ class ToggleOppositeModeCover(ToggleBaseCover):
                     "_handle_external_tilt_state_change :: tilt close press while"
                     " tilt opening, stopping"
                 )
-                await self.async_stop_cover(supersede=False)
+                await self.async_stop_cover(supersede=False, tilt_axis_reported=True)
             elif not self.tilt_calc.is_closing():
                 self._log(
                     "_handle_external_tilt_state_change :: external tilt close press"

--- a/custom_components/cover_time_based/cover_toggle_opposite_mode.py
+++ b/custom_components/cover_time_based/cover_toggle_opposite_mode.py
@@ -71,7 +71,7 @@ class ToggleOppositeModeCover(ToggleBaseCover):
                 self._log(
                     "_handle_external_state_change :: open press while closing, stopping"
                 )
-                await self.async_stop_cover()
+                await self.async_stop_cover(supersede=False)
             elif not self.travel_calc.is_opening():
                 self._log("_handle_external_state_change :: external open press")
                 await self.async_open_cover()
@@ -81,7 +81,7 @@ class ToggleOppositeModeCover(ToggleBaseCover):
                 self._log(
                     "_handle_external_state_change :: close press while opening, stopping"
                 )
-                await self.async_stop_cover()
+                await self.async_stop_cover(supersede=False)
             elif not self.travel_calc.is_closing():
                 self._log("_handle_external_state_change :: external close press")
                 await self.async_close_cover()
@@ -100,7 +100,7 @@ class ToggleOppositeModeCover(ToggleBaseCover):
                     "_handle_external_tilt_state_change :: tilt open press while"
                     " tilt closing, stopping"
                 )
-                await self.async_stop_cover()
+                await self.async_stop_cover(supersede=False)
             elif not self.tilt_calc.is_opening():
                 self._log(
                     "_handle_external_tilt_state_change :: external tilt open press"
@@ -113,7 +113,7 @@ class ToggleOppositeModeCover(ToggleBaseCover):
                     "_handle_external_tilt_state_change :: tilt close press while"
                     " tilt opening, stopping"
                 )
-                await self.async_stop_cover()
+                await self.async_stop_cover(supersede=False)
             elif not self.tilt_calc.is_closing():
                 self._log(
                     "_handle_external_tilt_state_change :: external tilt close press"

--- a/custom_components/cover_time_based/cover_wrapped.py
+++ b/custom_components/cover_time_based/cover_wrapped.py
@@ -382,7 +382,7 @@ class WrappedCoverTimeBased(CoverTimeBased):
                     "_handle_external_state_change :: wrapped cover stopped,"
                     " no position info"
                 )
-                await self.async_stop_cover()
+                await self.async_stop_cover(supersede=False)
             await self._maybe_snap_to_reported_tilt()
 
     async def _handle_command_state(self, new_val: str) -> None:
@@ -417,7 +417,7 @@ class WrappedCoverTimeBased(CoverTimeBased):
                 await self.async_close_cover()
         elif new_val == STATE_UNKNOWN:
             self._log("_handle_command_state :: stop command")
-            await self.async_stop_cover()
+            await self.async_stop_cover(supersede=False)
         else:
             # STATE_UNAVAILABLE / anything else: not a command, ignore.
             self._log("_handle_command_state :: ignoring non-command state %s", new_val)
@@ -462,7 +462,9 @@ class WrappedCoverTimeBased(CoverTimeBased):
         to match the target at this instant.
         """
         self._log("_snap_to_position :: snapping to %d", target)
-        await self.set_known_position(position=target)
+        # The device reporting where it ended up, not a command — it must not
+        # cancel a reversal waiting out its settle gap.
+        await self.set_known_position(position=target, supersede=False)
         self._last_command = None
 
     def _wrapped_reported_position(self) -> int | None:

--- a/tests/test_base_movement.py
+++ b/tests/test_base_movement.py
@@ -16,6 +16,7 @@ from types import SimpleNamespace
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from custom_components.cover_time_based.cover import CONTROL_MODE_TOGGLE
 from homeassistant.const import (
     SERVICE_CLOSE_COVER,
     SERVICE_OPEN_COVER,
@@ -2753,6 +2754,92 @@ class TestInlineTiltRestore:
         # was superseded after energizing can.
         assert relay[-1] == "off", relay
         assert not cover.tilt_calc.is_traveling()
+
+    @pytest.mark.asyncio
+    async def test_superseded_restore_does_not_stop_its_replacement(self, make_cover):
+        """Taking our own motor down must not take the next one down with it.
+
+        The teardown assumes the superseder was a plain stop, whose own stop
+        went out before our turn-on landed. But the usual superseder is a new
+        *movement* — every entry point abandons the lifecycle and then starts
+        its own motor. Firing a stop after that kills a motor the replacement
+        just energized and is actively tracking, which is the same
+        tracker-confidently-wrong desync this branch exists to remove, only
+        reached from the other side.
+        """
+        cover = _dual_motor_cover(make_cover)
+        cover.travel_calc.set_position(30)
+        cover.tilt_calc.set_position(50)
+        cover._tilt_restore_target = 100
+
+        log = []
+
+        async def new_move_lands_during_turn_on(*_a, **_k):
+            log.append("restore:on")
+            # A new tilt movement claims the cover mid-turn-on and starts its
+            # own motor.
+            await cover.set_tilt_position(20)
+
+        async def replacement_on(*_a, **_k):
+            log.append("replacement:on")
+
+        async def stop(*_a, **_k):
+            log.append("stop")
+
+        with (
+            patch.object(cover, "async_write_ha_state"),
+            patch.object(
+                cover, "_send_tilt_open", side_effect=new_move_lands_during_turn_on
+            ),
+            patch.object(cover, "_send_tilt_close", side_effect=replacement_on),
+            patch.object(cover, "_send_tilt_stop", side_effect=stop),
+        ):
+            await cover._start_tilt_restore()
+
+        # The replacement is tracking to 20, so its motor must still be the
+        # last thing energized — no stop may land after it started.
+        assert cover.tilt_calc.is_traveling()
+        assert "replacement:on" in log, log
+        assert log[log.index("replacement:on") :] == ["replacement:on"], log
+
+    @pytest.mark.asyncio
+    async def test_supersede_at_a_tilt_endpoint_does_not_repulse_the_motor(
+        self, make_cover
+    ):
+        """Taking our own relay back down still has to respect the endpoints.
+
+        At 0%/100% a momentary-relay motor has already stopped on its own limit
+        switch, and re-pulsing the direction relay restarts it — which is why
+        the normal completion path goes through _tilt_settle rather than
+        sending a stop outright. The superseded path owes the same care: it was
+        added to avoid leaving a motor running, and must not achieve that by
+        starting one.
+        """
+        cover = _dual_motor_cover(make_cover, control_mode=CONTROL_MODE_TOGGLE)
+        assert cover._self_stops_at_endpoints()
+        cover.travel_calc.set_position(30)
+        cover.tilt_calc.set_position(100)  # already at the tilt endpoint
+        cover._tilt_restore_target = 0
+
+        async def stop_lands_during_turn_on(*_a, **_k):
+            await cover.async_stop_cover()
+
+        with (
+            patch.object(cover, "async_write_ha_state"),
+            patch.object(
+                cover, "_send_tilt_close", side_effect=stop_lands_during_turn_on
+            ),
+            patch.object(
+                cover, "_send_tilt_open", side_effect=stop_lands_during_turn_on
+            ),
+            patch.object(cover, "_send_tilt_stop", new_callable=AsyncMock) as tilt_stop,
+        ):
+            await cover._start_tilt_restore()
+            cover.tilt_calc.set_position(100)  # settled back on the endpoint
+            tilt_stop.reset_mock()
+            await cover._stop_restore_motor()
+
+        tilt_stop.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_external_travel_stop_also_stops_a_live_tilt_motor(self, make_cover):

--- a/tests/test_base_movement.py
+++ b/tests/test_base_movement.py
@@ -2755,6 +2755,74 @@ class TestInlineTiltRestore:
         assert not cover.tilt_calc.is_traveling()
 
     @pytest.mark.asyncio
+    async def test_external_travel_stop_also_stops_a_live_tilt_motor(self, make_cover):
+        """A stop is a stop: the tilt motor must come down with the travel one.
+
+        The relay suppression exists so we never echo a command back at
+        hardware that already did it. That reasoning covers the relay the
+        external event was about — and only that one. On a dual-motor cover the
+        tilt motor is a *separate* relay we are driving ourselves, so when a
+        travel-relay event abandons a live tilt phase, nothing else is ever
+        going to take it down: the tracker stops, the restore is forgotten, and
+        the tilt motor keeps running.
+        """
+        cover = _dual_motor_cover(make_cover)
+        cover.travel_calc.set_position(30)
+        cover.tilt_calc.set_position(0)
+        cover._tilt_restore_target = 100
+
+        with (
+            patch.object(cover, "async_write_ha_state"),
+            patch.object(cover, "_send_tilt_open", new_callable=AsyncMock),
+            patch.object(cover, "_send_tilt_close", new_callable=AsyncMock),
+            patch.object(cover, "_send_tilt_stop", new_callable=AsyncMock) as tilt_stop,
+        ):
+            await cover._start_tilt_restore()
+            assert cover.tilt_calc.is_traveling()  # tilt motor is running
+
+            # The travel relay reports off while the tilt motor runs on.
+            cover._triggered_externally = True
+            try:
+                await cover.async_stop_cover(supersede=False)
+            finally:
+                cover._triggered_externally = False
+
+        tilt_stop.assert_awaited_once()
+        assert not cover.tilt_calc.is_traveling()
+
+    @pytest.mark.asyncio
+    async def test_external_tilt_stop_does_not_echo_back_at_the_tilt_relay(
+        self, make_cover
+    ):
+        """...but not when the tilt relay is the one that reported.
+
+        The counterpart to the test above, and the reason this cannot simply
+        always fire. On toggle hardware _send_tilt_stop is a *pulse*, so
+        echoing one back at a tilt motor that already stopped would start it
+        moving again — the opposite of a stop.
+        """
+        cover = _dual_motor_cover(make_cover)
+        cover.travel_calc.set_position(30)
+        cover.tilt_calc.set_position(0)
+        cover._tilt_restore_target = 100
+
+        with (
+            patch.object(cover, "async_write_ha_state"),
+            patch.object(cover, "_send_tilt_open", new_callable=AsyncMock),
+            patch.object(cover, "_send_tilt_close", new_callable=AsyncMock),
+            patch.object(cover, "_send_tilt_stop", new_callable=AsyncMock) as tilt_stop,
+        ):
+            await cover._start_tilt_restore()
+
+            cover._triggered_externally = True
+            try:
+                await cover.async_stop_cover(supersede=False, tilt_axis_reported=True)
+            finally:
+                cover._triggered_externally = False
+
+        tilt_stop.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_stop_during_initial_stop_bails_before_settle_delay(self, make_cover):
         """A stop during the restore's initial STOP bails before the settle delay.
 

--- a/tests/test_base_movement.py
+++ b/tests/test_base_movement.py
@@ -16,7 +16,11 @@ from types import SimpleNamespace
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from homeassistant.const import SERVICE_CLOSE_COVER, SERVICE_OPEN_COVER
+from homeassistant.const import (
+    SERVICE_CLOSE_COVER,
+    SERVICE_OPEN_COVER,
+    SERVICE_STOP_COVER,
+)
 
 
 # ===================================================================
@@ -2661,6 +2665,94 @@ class TestInlineTiltRestore:
         # tracker; the stale restore's target (100) must be nowhere in sight.
         assert events == ["open"]
         assert cover.tilt_calc._travel_to_position == 50
+
+    @pytest.mark.asyncio
+    async def test_supersede_during_motor_start_does_not_latch_the_relay(
+        self, make_cover
+    ):
+        """A restore cancelled mid-turn-on must take its own relay back down.
+
+        The cancelling stop is sent while the restore is still awaiting its
+        turn-on, so it goes out *first* and is stale by the time the turn-on
+        lands. The restore then sees itself superseded and bails — leaving the
+        motor it just energized running with nothing tracking it. On a latching
+        relay that is a cover driving to its physical endpoint unattended.
+        """
+        cover = self._make_inline_cover(make_cover)
+        cover.travel_calc.set_position(80)
+        cover.tilt_calc.set_position(100)
+
+        stops = []
+
+        async def stop_lands_during_turn_on(command, *args):
+            if command == SERVICE_STOP_COVER:
+                stops.append("stop")
+            # The restore's own reversing turn-on: a stop arrives mid-await.
+            if command in (SERVICE_OPEN_COVER, SERVICE_CLOSE_COVER):
+                await cover.async_stop_cover()
+
+        with patch.object(cover, "async_write_ha_state"):
+            await cover.set_position(30)  # closing; restore target = tilt 100
+            cover.travel_calc.set_position(30)
+            cover.tilt_calc.set_position(0)
+
+            with (
+                patch.object(cover, "_direction_change_delay", new_callable=AsyncMock),
+                patch.object(
+                    cover,
+                    "_async_handle_command",
+                    side_effect=stop_lands_during_turn_on,
+                ),
+            ):
+                await cover.auto_stop_if_necessary()
+
+        # Two stops: the one the restore issues before reversing, and the one it
+        # must issue on finding itself superseded after energizing the motor.
+        assert stops == ["stop", "stop"]
+        assert not cover.tilt_calc.is_traveling()
+
+    @pytest.mark.asyncio
+    async def test_dual_motor_supersede_during_motor_start_stops_tilt_motor(
+        self, make_cover
+    ):
+        """Same race on a dedicated tilt motor takes the tilt relay down.
+
+        The shared-motor case above stops via the travel relay; here the
+        restore energized a separate tilt relay, so that is the one that must
+        come back down.
+        """
+        cover = _dual_motor_cover(make_cover)
+        cover.travel_calc.set_position(30)
+        cover.tilt_calc.set_position(0)
+        # Drive the restore phase directly: dual-motor reaches it via a
+        # tilt-to-safe pre-step and its own travel, none of which is what this
+        # race is about.
+        cover._tilt_restore_target = 100
+
+        relay = []
+
+        async def turn_on(*_a, **_k):
+            # The cancelling stop goes out while we are still awaiting this
+            # turn-on, so it is recorded *before* the relay comes up.
+            await cover.async_stop_cover()
+            relay.append("on")
+
+        async def turn_off(*_a, **_k):
+            relay.append("off")
+
+        with (
+            patch.object(cover, "async_write_ha_state"),
+            patch.object(cover, "_send_tilt_open", side_effect=turn_on),
+            patch.object(cover, "_send_tilt_close", side_effect=turn_on),
+            patch.object(cover, "_send_tilt_stop", side_effect=turn_off),
+        ):
+            await cover._start_tilt_restore()
+
+        # async_stop_cover's own tilt stop lands before the turn-on, so it
+        # cannot be what leaves the relay down — only the restore noticing it
+        # was superseded after energizing can.
+        assert relay[-1] == "off", relay
+        assert not cover.tilt_calc.is_traveling()
 
     @pytest.mark.asyncio
     async def test_stop_during_initial_stop_bails_before_settle_delay(self, make_cover):

--- a/tests/test_base_movement.py
+++ b/tests/test_base_movement.py
@@ -2609,6 +2609,60 @@ class TestInlineTiltRestore:
         assert not cover.tilt_calc.is_traveling()
 
     @pytest.mark.asyncio
+    async def test_newer_restore_during_settle_delay_supersedes_the_stale_one(
+        self, make_cover
+    ):
+        """A restore that was cancelled must not resume behind its replacement.
+
+        The cancellation checks read a plain bool, so they only answer "is a
+        restore active", not "is *my* restore still the active one". A newer
+        restore claiming the cover during the old one's settle delay sets that
+        bool back to True, and the stale restore then sails through every check
+        it was supposed to fail: it drives the motor a second time and retargets
+        the tilt tracker at its own abandoned goal, leaving the tracker chasing
+        a position nothing is moving towards.
+        """
+        cover = self._make_inline_cover(make_cover)
+        cover.travel_calc.set_position(80)
+        cover.tilt_calc.set_position(100)
+
+        events = []
+        delays = {"n": 0}
+
+        async def record_open(*_a, **_k):
+            events.append("open")
+
+        async def newer_restore_during_delay(*_a, **_k):
+            delays["n"] += 1
+            if delays["n"] > 1:
+                return  # the replacement's own settle gap; nothing to inject
+            # A newer command lands mid-gap: it abandons the in-flight restore
+            # and, once its own travel finishes, starts a restore of its own.
+            await cover._abandon_active_lifecycle()
+            cover._tilt_restore_target = 50
+            await cover._start_tilt_restore()
+
+        with patch.object(cover, "async_write_ha_state"):
+            await cover.set_position(30)  # closing; restore target = tilt 100
+            cover.travel_calc.set_position(30)
+            cover.tilt_calc.set_position(0)
+
+            with (
+                patch.object(cover, "_send_open", side_effect=record_open),
+                patch.object(
+                    cover,
+                    "_direction_change_delay",
+                    side_effect=newer_restore_during_delay,
+                ),
+            ):
+                await cover.auto_stop_if_necessary()
+
+        # Only the replacement may have driven the motor and claimed the
+        # tracker; the stale restore's target (100) must be nowhere in sight.
+        assert events == ["open"]
+        assert cover.tilt_calc._travel_to_position == 50
+
+    @pytest.mark.asyncio
     async def test_stop_during_initial_stop_bails_before_settle_delay(self, make_cover):
         """A stop during the restore's initial STOP bails before the settle delay.
 

--- a/tests/test_direction_change_delay.py
+++ b/tests/test_direction_change_delay.py
@@ -8,6 +8,7 @@ is configurable; it defaults to the historical 1.0s.
 """
 
 import asyncio
+from contextlib import suppress
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -324,7 +325,11 @@ class _ParkedReversal:
         )
         if arrived in done:
             return
+        # Cancel *and* collect it, or the loop closes on a pending task and the
+        # "Task was destroyed" warning lands on whichever test runs next.
         arrived.cancel()
+        with suppress(asyncio.CancelledError):
+            await arrived
         # The task finished without ever parking: surface its exception, or say
         # so plainly if it simply returned.
         self._task.result()

--- a/tests/test_direction_change_delay.py
+++ b/tests/test_direction_change_delay.py
@@ -344,6 +344,16 @@ class _ParkedReversal:
             f" (commands={self.commands})"
         )
 
+    async def as_external_press(self, coro):
+        """Run ``coro`` the way the dispatcher runs a second wall press.
+
+        Its own task with the flag raised for the duration — so a press landing
+        inside the parked reversal's window is genuinely inside the external
+        window, which is the only condition under which these tests say
+        anything.
+        """
+        return await asyncio.create_task(self._as_external(coro))
+
     async def resume(self):
         self._release.set()
         await self._task
@@ -591,6 +601,47 @@ async def test_ui_stop_during_the_gap_actually_stops_the_relay(make_cover):
 
 
 @pytest.mark.asyncio
+async def test_the_external_flag_does_not_outlive_the_call_into_scheduled_work(
+    make_cover,
+):
+    """Task scoping must not become descendant-task scoping.
+
+    A context is *copied into* every task and timer callback created while it
+    is active, and HA's interval timer reschedules itself from inside the copy
+    — so a flag merely stored in a ContextVar propagates to the whole auto
+    updater chain and every auto_stop_if_necessary it spawns, for the life of
+    the movement. Externally-started moves would then suppress their own
+    endpoint relay stop, which on latching hardware leaves the relay energized.
+
+    Scoping it to the task that raised it, rather than to the context, is what
+    keeps it from being inherited. The suite's mock hass never builds a real
+    timer chain, so this drives the scheduling primitives directly.
+    """
+    cover = make_cover()
+    seen = {}
+
+    async def spawned():
+        seen["task"] = cover._triggered_externally
+
+    def timer_callback():
+        seen["timer"] = cover._triggered_externally
+
+    cover._triggered_externally = True
+    try:
+        assert cover._triggered_externally is True  # the handler's own view
+        asyncio.get_running_loop().call_later(0, timer_callback)
+        task = asyncio.create_task(spawned())
+        await task
+    finally:
+        cover._triggered_externally = False
+
+    await asyncio.sleep(0.01)
+
+    assert seen["task"] is False, "a spawned task inherited the flag"
+    assert seen["timer"] is False, "a timer callback inherited the flag"
+
+
+@pytest.mark.asyncio
 async def test_ui_move_during_the_gap_actually_drives_the_relay(make_cover):
     """The same leak, via _async_handle_command rather than _send_stop.
 
@@ -638,18 +689,25 @@ async def test_wall_stop_press_during_the_gap_cancels_an_external_reversal(make_
     it. Lumping it in with the echoes let the press be swallowed by the settle
     gap and the cover reverse anyway, seconds after the user said stop.
 
-    No relay stop is sent here, and that is correct: the stop relay the user
-    pressed is already doing that. What must happen is the reversal dropping.
+    The press must be driven inside the external window the dispatcher holds,
+    or the test proves nothing: the whole point is that this supersedes
+    *despite* arriving with the flag raised, and outside that window it would
+    pass on the old inferred behaviour too. No relay stop goes out as a result,
+    which is correct — the stop relay the user pressed is already doing that.
     """
     async with _parked_external_close(make_cover) as reversal:
         cover = reversal.cover
-        await cover._handle_external_state_change(
-            cover._stop_switch_entity_id, "off", "on"
-        )
+        with patch.object(cover, "_send_stop", new_callable=AsyncMock) as send_stop:
+            await reversal.as_external_press(
+                cover._handle_external_state_change(
+                    cover._stop_switch_entity_id, "off", "on"
+                )
+            )
         await reversal.resume()
 
     assert SERVICE_CLOSE_COVER not in reversal.commands
     assert not cover.travel_calc.is_traveling()
+    send_stop.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_direction_change_delay.py
+++ b/tests/test_direction_change_delay.py
@@ -404,19 +404,39 @@ async def test_device_feedback_during_the_settle_gap_does_not_abort(make_cover):
     Treating those as supersessions silently drops the user's move, or worse
     freezes the tracker while the motor runs, which is the very desync the
     guard exists to prevent.
+
+    Those routes say so with supersede=False; test_wrapped_snap_during_the_gap
+    _does_not_abort drives one of them for real, so this stays a direct test of
+    the contract itself.
     """
     async with _ParkedReversal(_reversing_cover(make_cover)) as reversal:
-        cover = reversal.cover
-        cover._triggered_externally = True
-        try:
-            await cover.async_stop_cover()
-        finally:
-            cover._triggered_externally = False
+        await reversal.cover.async_stop_cover(supersede=False)
         await reversal.resume()
 
     # The reversal was the user's; the echo must not have cancelled it.
     assert reversal.commands == [SERVICE_STOP_COVER, SERVICE_CLOSE_COVER]
     assert reversal.cover.travel_calc._travel_to_position == 20
+
+
+@pytest.mark.asyncio
+async def test_wrapped_snap_does_not_claim_the_movement(make_cover):
+    """The real device-feedback route still declares itself feedback.
+
+    _snap_to_position is how a wrapped cover records the position its inner
+    entity just reported, and it reaches _handle_stop like any other stop.
+    Claiming the movement is what cancels a parked reversal (the test above
+    ties the two together), so it is enough — and far cheaper than parking a
+    reversal on a natively-positioned wrapped cover — to assert this caller
+    leaves the epoch alone.
+    """
+    cover = make_cover(cover_entity_id="cover.inner")
+    cover.travel_calc.set_position(40)
+
+    with patch.object(cover, "async_write_ha_state"):
+        before = cover._movement_epoch
+        await cover._snap_to_position(35)
+
+    assert cover._movement_epoch == before
 
 
 # ---------------------------------------------------------------------------
@@ -466,23 +486,17 @@ async def test_undisturbed_external_open_reversal_still_completes(make_cover):
     assert reversal.cover.travel_calc._travel_to_position == 100
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="_triggered_externally is ambient instance state, not task-scoped, so a"
-    " genuine stop inside an external reversal's settle gap is misread as a"
-    " device echo and dropped. Needs a scoping fix, not a guard tweak.",
-)
 @pytest.mark.asyncio
 async def test_stop_during_the_gap_cancels_an_external_close_reversal(make_cover):
     """A stop landing inside an external reversal's settle gap must win.
 
     Same requirement as the set_position reversal, reached from the wall-switch
-    path — and the harder case. _handle_stop only supersedes when
-    _triggered_externally is clear, but that flag is ambient instance state
-    held for the *whole* external call, settle gap included. A genuine stop
-    arriving in that window is therefore indistinguishable from a device echo:
-    it is dropped, and the parked reversal wakes and drives the cover up to
-    direction_change_delay seconds after the user said stop.
+    path — and the harder case. _handle_stop used to decide this by reading
+    _triggered_externally, ambient instance state held for the *whole* external
+    call, settle gap included; a genuine stop arriving in that window was
+    therefore indistinguishable from a device echo, so it was dropped and the
+    parked reversal drove the cover up to direction_change_delay seconds after
+    the user said stop. Callers now say which kind of stop they are.
     """
     async with _parked_external_close(make_cover) as reversal:
         # No flag fiddling: production leaves it set, which is the whole point.

--- a/tests/test_direction_change_delay.py
+++ b/tests/test_direction_change_delay.py
@@ -205,14 +205,33 @@ class _ParkedReversal:
     ``arrived`` resolves the moment the reversal enters the gap and ``release``
     lets it out, so tests rendezvous with it exactly rather than guessing how
     many event-loop turns it takes to get there.
+
+    ``start`` selects the entry point that reverses (the UI slider by default);
+    ``external`` runs it the way a wall switch does, with _triggered_externally
+    held for the whole call — including the settle gap — exactly as
+    _async_switch_state_changed's try/finally does.
     """
 
-    def __init__(self, cover):
+    def __init__(
+        self,
+        cover,
+        *,
+        start=None,
+        external=False,
+        closing=False,
+        commands_at_park=None,
+    ):
         self.cover = cover
         self.commands = []
         self.arrived = asyncio.Event()
         self._release = asyncio.Event()
         self._task = None
+        self._start = start or (lambda c: c.set_position(20))
+        self._external = external
+        self._closing = closing
+        self._commands_at_park = (
+            [SERVICE_STOP_COVER] if commands_at_park is None else commands_at_park
+        )
 
     async def _record(self, command, *args):
         self.commands.append(command)
@@ -222,14 +241,30 @@ class _ParkedReversal:
         self.arrived.set()
         await self._release.wait()
 
+    async def _as_external(self, coro):
+        """Hold the external flag across the whole call, settle gap included.
+
+        _async_switch_state_changed wraps its handler in exactly this
+        try/finally, so a command parked in the gap is still 'external' when
+        anything else lands on the cover meanwhile.
+        """
+        try:
+            await coro
+        finally:
+            self.cover._triggered_externally = False
+
     async def __aenter__(self):
         cover = self.cover
         cover.hass.states.get = MagicMock(
             side_effect=lambda eid: SimpleNamespace(state="off")
         )
         cover.travel_calc.set_position(40)
-        cover.travel_calc.start_travel_up()
-        cover._last_command = SERVICE_OPEN_COVER
+        if self._closing:
+            cover.travel_calc.start_travel_down()
+            cover._last_command = SERVICE_CLOSE_COVER
+        else:
+            cover.travel_calc.start_travel_up()
+            cover._last_command = SERVICE_OPEN_COVER
 
         self._real_handle = cover._async_handle_command
         self._patches = [
@@ -241,10 +276,14 @@ class _ParkedReversal:
             p.start()
 
         try:
-            # Reverse: opening at 40%, now told to go to 20%.
-            self._task = asyncio.create_task(cover.set_position(20))
+            # Reverse: opening at 40%, now told to go the other way.
+            coro = self._start(cover)
+            if self._external:
+                cover._triggered_externally = True
+                coro = self._as_external(coro)
+            self._task = asyncio.create_task(coro)
             await self.arrived.wait()
-            assert self.commands == [SERVICE_STOP_COVER]
+            assert self.commands == self._commands_at_park
         except BaseException:
             # __aexit__ never runs when __aenter__ raises, so without this the
             # module-level sleep patch would leak into every later test and the
@@ -378,3 +417,92 @@ async def test_device_feedback_during_the_settle_gap_does_not_abort(make_cover):
     # The reversal was the user's; the echo must not have cancelled it.
     assert reversal.commands == [SERVICE_STOP_COVER, SERVICE_CLOSE_COVER]
     assert reversal.cover.travel_calc._travel_to_position == 20
+
+
+# ---------------------------------------------------------------------------
+# The external-trigger reversals (wall switch / remote), which reach the same
+# settle gap from async_close_cover and async_open_cover rather than from
+# set_position. A UI click on a moving cover just stops it; only these external
+# entry points keep the legacy stop-and-reverse.
+# ---------------------------------------------------------------------------
+
+
+def _parked_external_close(make_cover):
+    """Opening at 40%, wall switch says close: stop, settle, then reverse."""
+    return _ParkedReversal(
+        _reversing_cover(make_cover),
+        start=lambda c: c.async_close_cover(),
+        external=True,
+        # async_stop_cover drives the relay via _send_stop, not
+        # _async_handle_command, so nothing is recorded on the way in.
+        commands_at_park=[],
+    )
+
+
+@pytest.mark.asyncio
+async def test_undisturbed_external_close_reversal_still_completes(make_cover):
+    """The guard must not cancel an external reversal nothing interrupted."""
+    async with _parked_external_close(make_cover) as reversal:
+        await reversal.resume()
+
+    assert SERVICE_CLOSE_COVER in reversal.commands
+    assert reversal.cover.travel_calc._travel_to_position == 0
+
+
+@pytest.mark.asyncio
+async def test_undisturbed_external_open_reversal_still_completes(make_cover):
+    """Mirror of the close case, entered from async_open_cover."""
+    reversal = _ParkedReversal(
+        _reversing_cover(make_cover),
+        start=lambda c: c.async_open_cover(),
+        external=True,
+        closing=True,
+        commands_at_park=[],
+    )
+    async with reversal:
+        await reversal.resume()
+
+    assert SERVICE_OPEN_COVER in reversal.commands
+    assert reversal.cover.travel_calc._travel_to_position == 100
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="_triggered_externally is ambient instance state, not task-scoped, so a"
+    " genuine stop inside an external reversal's settle gap is misread as a"
+    " device echo and dropped. Needs a scoping fix, not a guard tweak.",
+)
+@pytest.mark.asyncio
+async def test_stop_during_the_gap_cancels_an_external_close_reversal(make_cover):
+    """A stop landing inside an external reversal's settle gap must win.
+
+    Same requirement as the set_position reversal, reached from the wall-switch
+    path — and the harder case. _handle_stop only supersedes when
+    _triggered_externally is clear, but that flag is ambient instance state
+    held for the *whole* external call, settle gap included. A genuine stop
+    arriving in that window is therefore indistinguishable from a device echo:
+    it is dropped, and the parked reversal wakes and drives the cover up to
+    direction_change_delay seconds after the user said stop.
+    """
+    async with _parked_external_close(make_cover) as reversal:
+        # No flag fiddling: production leaves it set, which is the whole point.
+        await reversal.cover.async_stop_cover()
+        await reversal.resume()
+
+    assert SERVICE_CLOSE_COVER not in reversal.commands
+    assert not reversal.cover.travel_calc.is_traveling()
+
+
+@pytest.mark.asyncio
+async def test_newer_target_during_the_gap_supersedes_an_external_reversal(make_cover):
+    """A slider drag inside an external reversal's gap wins over it.
+
+    This route supersedes via _abandon_active_lifecycle, which is not gated on
+    _triggered_externally, so it holds where the stop route does not.
+    """
+    async with _parked_external_close(make_cover) as reversal:
+        await reversal.cover.set_position(60)
+        await reversal.resume()
+
+    assert SERVICE_CLOSE_COVER not in reversal.commands
+    assert reversal.cover.travel_calc._travel_to_position == 60

--- a/tests/test_direction_change_delay.py
+++ b/tests/test_direction_change_delay.py
@@ -264,7 +264,14 @@ class _ParkedReversal:
         _async_switch_state_changed wraps its handler in exactly this
         try/finally, so a command parked in the gap is still 'external' when
         anything else lands on the cover meanwhile.
+
+        Set *inside* the task, not before it, because that is where the
+        dispatcher sets it. A test that raises the flag in its own context and
+        then calls the cover from that same context is not modelling a wall
+        switch — it is modelling a wall switch and a UI click sharing one call
+        stack, which never happens.
         """
+        self.cover._triggered_externally = True
         try:
             await coro
         finally:
@@ -296,7 +303,6 @@ class _ParkedReversal:
             # Reverse: already moving at 40%, now told to go the other way.
             coro = self._start(cover)
             if self._external_press is not None:
-                cover._triggered_externally = True
                 coro = self._as_external(coro)
             self._task = asyncio.create_task(coro)
             await self._wait_until_parked()
@@ -558,6 +564,68 @@ async def test_stop_during_the_gap_cancels_an_external_close_reversal(make_cover
 
     assert SERVICE_CLOSE_COVER not in reversal.commands
     assert not reversal.cover.travel_calc.is_traveling()
+
+
+@pytest.mark.asyncio
+async def test_ui_stop_during_the_gap_actually_stops_the_relay(make_cover):
+    """Cancelling the reversal is only half a stop — the relay must fire too.
+
+    _triggered_externally suppresses relay writes so we never echo a command
+    back at hardware that is already doing it. But it is instance state, and
+    the parked external call holds it for the whole settle gap, so a UI stop
+    arriving in that window inherited the suppression: the movement was
+    claimed and nothing was ever sent. The tracker halted while the motor ran
+    on to the endpoint.
+
+    The stop is a separate task with its own context, exactly as HA dispatches
+    a service call, so it must see the flag clear.
+    """
+    async with _parked_external_close(make_cover) as reversal:
+        cover = reversal.cover
+        with patch.object(cover, "_send_stop", new_callable=AsyncMock) as send_stop:
+            await asyncio.create_task(cover.async_stop_cover())
+        await reversal.resume()
+
+    send_stop.assert_awaited_once()
+    assert SERVICE_CLOSE_COVER not in reversal.commands
+
+
+@pytest.mark.asyncio
+async def test_ui_move_during_the_gap_actually_drives_the_relay(make_cover):
+    """The same leak, via _async_handle_command rather than _send_stop.
+
+    A slider drag landing in an external reversal's gap correctly superseded
+    it — _abandon_active_lifecycle never consulted the flag — and then tracked
+    a movement it never commanded, because the relay write inherited the
+    parked call's suppression. HA animates the position bar to the target
+    while the cover does not move: a full desync, and the worse half of this
+    bug, since the tracker ends up confidently wrong.
+    """
+    async with _parked_external_close(make_cover) as reversal:
+        cover = reversal.cover
+        with patch.object(cover, "_send_open", new_callable=AsyncMock) as send_open:
+            await asyncio.create_task(cover.set_position(60))
+        await reversal.resume()
+
+    send_open.assert_awaited()
+    assert cover.travel_calc._travel_to_position == 60
+
+
+@pytest.mark.asyncio
+async def test_ui_move_during_the_gap_is_recorded_as_self_initiated(make_cover):
+    """_self_initiated_movement is snapshotted from the same flag.
+
+    A UI move beginning inside the gap recorded itself as externally driven,
+    which sends auto_stop_if_necessary down _settle_external_endpoint at
+    completion instead of the normal endpoint stop and run-on handling — so
+    the move ended wrong as well as starting wrong.
+    """
+    async with _parked_external_close(make_cover) as reversal:
+        cover = reversal.cover
+        with patch.object(cover, "_send_open", new_callable=AsyncMock):
+            await asyncio.create_task(cover.set_position(60))
+        assert cover._self_initiated_movement is True
+        await reversal.resume()
 
 
 @pytest.mark.asyncio

--- a/tests/test_direction_change_delay.py
+++ b/tests/test_direction_change_delay.py
@@ -25,6 +25,7 @@ from custom_components.cover_time_based.cover import (
     CONF_DEFAULTS,
     CONF_DEVICES,
     CONF_OPEN_SWITCH_ENTITY_ID,
+    CONTROL_MODE_PULSE,
     CONTROL_MODE_SWITCH,
     CONTROL_MODE_TOGGLE_OPPOSITE,
     _create_cover_from_options,
@@ -206,38 +207,53 @@ class _ParkedReversal:
     lets it out, so tests rendezvous with it exactly rather than guessing how
     many event-loop turns it takes to get there.
 
-    ``start`` selects the entry point that reverses (the UI slider by default);
-    ``external`` runs it the way a wall switch does, with _triggered_externally
-    held for the whole call — including the settle gap — exactly as
-    _async_switch_state_changed's try/finally does.
+    By default the UI slider reverses it. ``external_press`` instead runs the
+    wall-switch entry point for that command, with _triggered_externally held
+    for the whole call — settle gap included — exactly as
+    _async_switch_state_changed's try/finally does. Everything else (which way
+    the cover was already moving, which entry point to call, what should have
+    been commanded by the time it parks) follows from that one choice, so no
+    caller can pair them inconsistently.
     """
 
-    def __init__(
-        self,
-        cover,
-        *,
-        start=None,
-        external=False,
-        closing=False,
-        commands_at_park=None,
-    ):
+    def __init__(self, cover, *, external_press=None):
         self.cover = cover
         self.commands = []
         self.arrived = asyncio.Event()
         self._release = asyncio.Event()
         self._task = None
-        self._start = start or (lambda c: c.set_position(20))
-        self._external = external
-        self._closing = closing
-        self._commands_at_park = (
-            [SERVICE_STOP_COVER] if commands_at_park is None else commands_at_park
-        )
+        self._slept_for = None
+        self._external_press = external_press
+        if external_press is None:
+            # Opening at 40%, slider dragged below it.
+            self._start = lambda c: c.set_position(20)
+            self._was_closing = False
+            # set_position stops via _async_handle_command, which we record.
+            self._commands_at_park = [SERVICE_STOP_COVER]
+        else:
+            closing = external_press == SERVICE_OPEN_COVER
+            # Press the real relay and let the mode's own handler decide what
+            # that means, rather than calling async_open/close_cover directly —
+            # otherwise the test proves only that the base guard works, not
+            # that any external trigger actually reaches it.
+            self._start = lambda c: c._handle_external_state_change(
+                c._open_switch_entity_id if closing else c._close_switch_entity_id,
+                "off",
+                "on",
+            )
+            # A reversal only happens against the opposite direction.
+            self._was_closing = closing
+            # The prelude stop runs with _triggered_externally set, so it goes
+            # out via _send_stop (itself suppressed) — never through
+            # _async_handle_command, which is what we record.
+            self._commands_at_park = []
 
     async def _record(self, command, *args):
         self.commands.append(command)
         return await self._real_handle(command, *args)
 
-    async def _gated_sleep(self, _seconds):
+    async def _gated_sleep(self, seconds):
+        self._slept_for = seconds
         self.arrived.set()
         await self._release.wait()
 
@@ -259,7 +275,7 @@ class _ParkedReversal:
             side_effect=lambda eid: SimpleNamespace(state="off")
         )
         cover.travel_calc.set_position(40)
-        if self._closing:
+        if self._was_closing:
             cover.travel_calc.start_travel_down()
             cover._last_command = SERVICE_CLOSE_COVER
         else:
@@ -276,13 +292,16 @@ class _ParkedReversal:
             p.start()
 
         try:
-            # Reverse: opening at 40%, now told to go the other way.
+            # Reverse: already moving at 40%, now told to go the other way.
             coro = self._start(cover)
-            if self._external:
+            if self._external_press is not None:
                 cover._triggered_externally = True
                 coro = self._as_external(coro)
             self._task = asyncio.create_task(coro)
-            await self.arrived.wait()
+            await self._wait_until_parked()
+            # The settle gap is the only sleep with this duration, so this
+            # pins us to it rather than to a startup delay or a run-on.
+            assert self._slept_for == cover._direction_change_delay_time
             assert self.commands == self._commands_at_park
         except BaseException:
             # __aexit__ never runs when __aenter__ raises, so without this the
@@ -291,6 +310,28 @@ class _ParkedReversal:
             await self._abort()
             raise
         return self
+
+    async def _wait_until_parked(self):
+        """Wait for the gap, but never outlive a reversal that never gets there.
+
+        A bare arrived.wait() hangs the whole suite if the entry point bails
+        before the gap (or raises), and there is no --timeout configured to cut
+        it short — so race the rendezvous against the task itself.
+        """
+        arrived = asyncio.ensure_future(self.arrived.wait())
+        done, _ = await asyncio.wait(
+            {arrived, self._task}, return_when=asyncio.FIRST_COMPLETED
+        )
+        if arrived in done:
+            return
+        arrived.cancel()
+        # The task finished without ever parking: surface its exception, or say
+        # so plainly if it simply returned.
+        self._task.result()
+        raise AssertionError(
+            "reversal completed without waiting out the settle gap"
+            f" (commands={self.commands})"
+        )
 
     async def resume(self):
         self._release.set()
@@ -405,9 +446,9 @@ async def test_device_feedback_during_the_settle_gap_does_not_abort(make_cover):
     freezes the tracker while the motor runs, which is the very desync the
     guard exists to prevent.
 
-    Those routes say so with supersede=False; test_wrapped_snap_during_the_gap
-    _does_not_abort drives one of them for real, so this stays a direct test of
-    the contract itself.
+    Those routes say so with supersede=False. This is the direct test of that
+    contract; test_wrapped_snap_does_not_claim_the_movement then checks a real
+    one of them still declares itself feedback.
     """
     async with _ParkedReversal(_reversing_cover(make_cover)) as reversal:
         await reversal.cover.async_stop_cover(supersede=False)
@@ -447,16 +488,29 @@ async def test_wrapped_snap_does_not_claim_the_movement(make_cover):
 # ---------------------------------------------------------------------------
 
 
-def _parked_external_close(make_cover):
-    """Opening at 40%, wall switch says close: stop, settle, then reverse."""
-    return _ParkedReversal(
-        _reversing_cover(make_cover),
-        start=lambda c: c.async_close_cover(),
-        external=True,
-        # async_stop_cover drives the relay via _send_stop, not
-        # _async_handle_command, so nothing is recorded on the way in.
-        commands_at_park=[],
+def _external_cover(make_cover):
+    """A mode whose external handler really does stop-settle-reverse.
+
+    Pulse mode drives async_open_cover/async_close_cover straight off a relay
+    pulse, so an opposite press while moving reaches the reversal branch.
+    Toggle-opposite does not — its handler stops on an opposite press and waits
+    for the next one — so it cannot stand in for a wall switch here.
+    """
+    return make_cover(
+        control_mode=CONTROL_MODE_PULSE,
+        stop_switch="switch.stop",
+        direction_change_delay=2.5,
     )
+
+
+def _parked_external(make_cover, press):
+    """Moving at 40%, wall switch presses the opposite button: stop, settle,
+    then reverse."""
+    return _ParkedReversal(_external_cover(make_cover), external_press=press)
+
+
+def _parked_external_close(make_cover):
+    return _parked_external(make_cover, SERVICE_CLOSE_COVER)
 
 
 @pytest.mark.asyncio
@@ -472,13 +526,7 @@ async def test_undisturbed_external_close_reversal_still_completes(make_cover):
 @pytest.mark.asyncio
 async def test_undisturbed_external_open_reversal_still_completes(make_cover):
     """Mirror of the close case, entered from async_open_cover."""
-    reversal = _ParkedReversal(
-        _reversing_cover(make_cover),
-        start=lambda c: c.async_open_cover(),
-        external=True,
-        closing=True,
-        commands_at_park=[],
-    )
+    reversal = _parked_external(make_cover, SERVICE_OPEN_COVER)
     async with reversal:
         await reversal.resume()
 
@@ -505,6 +553,30 @@ async def test_stop_during_the_gap_cancels_an_external_close_reversal(make_cover
 
     assert SERVICE_CLOSE_COVER not in reversal.commands
     assert not reversal.cover.travel_calc.is_traveling()
+
+
+@pytest.mark.asyncio
+async def test_wall_stop_press_during_the_gap_cancels_an_external_reversal(make_cover):
+    """A dedicated stop button is a command, even though it arrives externally.
+
+    The rest of the external handlers report what the hardware did — a relay
+    releasing, a wrapped cover settling — and must not cancel a reversal. A
+    stop *switch* is the opposite: it only ever fires because someone pressed
+    it. Lumping it in with the echoes let the press be swallowed by the settle
+    gap and the cover reverse anyway, seconds after the user said stop.
+
+    No relay stop is sent here, and that is correct: the stop relay the user
+    pressed is already doing that. What must happen is the reversal dropping.
+    """
+    async with _parked_external_close(make_cover) as reversal:
+        cover = reversal.cover
+        await cover._handle_external_state_change(
+            cover._stop_switch_entity_id, "off", "on"
+        )
+        await reversal.resume()
+
+    assert SERVICE_CLOSE_COVER not in reversal.commands
+    assert not cover.travel_calc.is_traveling()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Three related fixes, each with a test that was watched failing first.

### 1. A superseded tilt restore no longer resumes behind its replacement

`_start_tilt_restore` parks on several awaits (the stop command, the direction-change settle gap, the motor start) and re-checks after each whether it was cancelled. That check read a plain bool, so it could only answer *"is a restore live"* — not *"is mine"*. A restore cancelled while parked, then replaced by a newer one before it resumed, read its replacement's `True` back and carried on: it drove the motor a second time and pointed the tilt tracker at the goal it had already been told to abandon, leaving the tracker chasing a position nothing was moving towards.

Each restore now gets an identity (`_claim_tilt_restore` / `_tilt_restore_superseded`), so a stale one fails every check it was meant to fail.

### 2. A stop inside an external reversal's settle gap is no longer dropped

Reversing a moving cover from a wall switch stops the motor, waits out `direction_change_delay`, then drives the other way. A stop arriving inside that gap should claim the movement so the parked reversal aborts. It didn't: `_handle_stop` decided whether a stop counted by reading `_triggered_externally`, which is ambient instance state held for the **whole** external call, gap included. A genuine stop landing in the window was indistinguishable from a device echoing its own state back, so it was dropped and the cover drove on. The gap is configurable precisely so slow motors can widen it — which widens this too.

The flag can't answer the question, so callers now state it: `supersede=True` by default for anything arriving from HA, `False` at the external-trigger handlers, the wrapped cover's position snap, and the prelude stop a reversal issues before its own gap. Behaviour at every one of those sites is unchanged — each only ever ran with the flag set.

### 3. A dedicated stop press is a command, not a device report

Review of (2) found the enumeration was right about behaviour and wrong about one classification. Three sites are dedicated **stop switches** (pulse mode's stop relay; the tilt stop relay in switch mode and the base tilt handler). They fire on a rising edge and only ever because somebody pressed them — commands that happen to arrive through the external dispatcher, not the hardware reporting.

So a wall stop press landing in a settle gap was swallowed and the cover reversed anyway, seconds later: the exact failure (2) set out to fix, surviving at the one kind of caller where *arrived externally* doesn't imply *is an echo*. Not a regression — it behaved this way before the split too. No relay stop is sent on this path, and that stays correct: the stop relay the user pressed is already doing that. What changes is that the reversal now drops.

## Testing

1249 Python tests pass; ruff clean. Every new test was mutation-proven rather than merely observed passing — the guard was broken both ways (never fires / always fires) and each test confirmed to fail for the right reason.

The external-reversal tests moved from toggle-opposite to **pulse mode** and now enter through `_handle_external_state_change` instead of calling `async_close_cover` directly. Toggle-opposite's handler stops on an opposite press and waits for the next one, so it never reaches the stop-settle-reverse branch — the old harness proved the base guard worked but not that any external trigger reaches it. Entering for real is what surfaced fix (3).

### 7. Review round: four defects in the two commits above

A multi-agent review of commits 5–6 found four real problems in them, all now fixed and each covered by a test that fails without the fix:

- **The task-scoped flag leaked into scheduled work.** A context is copied into every task and timer callback created while it's active, and HA's interval timer reschedules itself from inside that copy — so the flag reached the whole auto-updater chain for the life of the movement, suppressing endpoint relay stops. Commit 5's claim that "every caller sets the flag and acts in the same task" was wrong for callers that *schedule*. Pairing the flag with the owning task fixes it.
- **`_abandon_active_lifecycle` reverted to its original gate.** Widening it was unsound: the tilt entry points reach it (`async_open_cover_tilt` → `_async_move_tilt_to_endpoint` → it), so on an external tilt event it echoed a stop back at the relay that had just reported — which on toggle hardware *starts* the motor. Reproduced in pulse, toggle and switch modes.
- **`_stop_restore_motor` was stopping its replacement.** It assumed the superseder was a stop; the usual superseder is a new *movement* that has already energized its own motor. It now only fires when no calculator is tracking.
- **Both remaining teardowns go through `_tilt_settle`**, and use `_has_tilt_motor()` rather than the raw strategy flag (which additionally requires switch ids and is overridden for wrapped covers — without it, `turn_off` on `entity_id: None`).

Also: `test_wall_stop_press_during_the_gap_cancels_an_external_reversal` drove the handler *outside* the external window, so it passed on the old behaviour too — blind to the thing it was written for. It now runs the press as its own task with the flag raised, and fails when the reclassification is reverted.

## Deliberately not applied

Reviewers proposed deriving `supersede` and `tilt_axis_reported` from the dispatcher's context instead of passing them explicitly (~25 call-site annotations → 0), since both correspond exactly to facts the dispatcher already computes. It's a real improvement to safety-by-default: a new mode's handler that forgets `tilt_axis_reported=True` pulses a tilt relay that already reported.

Not done here, deliberately. It would make ~25 sites depend on the flag mechanism that needed fixing twice in this branch alone; explicit parameters are immune to that class. Worth doing once the scoping has hardware time behind it.

## Worth a hardware test before release
Fix (2) touches ~22 call sites across 7 files. The enumeration was verified two ways (every site traced to confirm it's reachable only under `_triggered_externally`, plus a test driving the real wrapped-snap echo route), but given this repo's history with switch-mode external-trigger bugs, the wall-switch paths are worth exercising on real hardware.

### 4. `_triggered_externally` is now scoped to the task that set it

Fixes (2) and (3) gave *one* reader of this flag an explicit parameter, because the flag couldn't answer the question being asked of it. The same was true of every other reader, and they were left standing — so this finishes the job at the root.

The flag suppresses relay writes (never echo a command back at hardware already driving itself) and selects external-trigger behaviour. The dispatcher holds it across every await its handler makes, including a reversal's whole settle gap — seconds long by design on slow motors. As plain instance state it leaked onto anything else running in that window:

- a UI **stop** claimed the movement and then sent no relay command at all — tracker halted, motor ran on to the endpoint;
- a UI **move** tracked to its target while firing nothing — HA animating a position bar for a cover that never moved;
- that same move recorded itself as *externally driven*, so it also ended down the wrong branch of `auto_stop_if_necessary`.

It's a call-scoped question answered with instance-scoped state, so it's now scoped to the call: a module-level `ContextVar` holding the set of covers whose handler is running in the current context, behind the same attribute name. HA dispatches each service call as its own task, and a task copies the context at creation, so the dispatcher's handler still sees it across its awaits while a concurrent caller does not. One var holding a set rather than one per entity — context variables are never reclaimed, so per-instance would leak on every reload.

**No call sites change and no existing test changes.** All 1249 pre-existing tests pass untouched, because a caller that sets the flag and then acts in the same task — every caller in the codebase, and every test — sees exactly what it saw before. The three new tests fail if the flag is put back on the instance.

### 5. A restore cancelled mid-turn-on no longer latches its relay

Whoever cancelled the restore sent their stop while it was still awaiting its own turn-on, so the stop went out *first* and was stale by the time the relay came up. The restore then bailed, leaving the motor energized with nothing tracking it — on latching hardware, a cover driving to its physical endpoint unattended. It now takes its own relay back down. Both the shared-motor and dedicated-tilt-motor branches are covered, each mutation-proven (the dual-motor test was vacuous on first writing — `async_stop_cover` sends its own tilt stop — so it now asserts *ordering*).

## Testing

1254 Python + 345 frontend tests pass; ruff clean. Every new test was mutation-proven rather than merely observed passing.

### 6. An external stop now takes the tilt motor down with the travel motor

A stop should stop the cover — all of it. It didn't: on a dual-motor cover, an external stop about the **travel** relay abandoned a live tilt phase and left the **tilt** motor running. Tracker halted, restore forgotten, motor still going with nothing watching it — on latching hardware, a tilt driving to its physical limit unattended.

```
before:  AFTER EXTERNAL STOP: active=False tilt_traveling=False tilt_stop_sent=0
after:   AFTER EXTERNAL STOP: active=False tilt_traveling=False tilt_stop_sent=1
```

The relay suppression it inherited is about not echoing a command back at hardware that already did it — true of the relay the event was about, and of no other. A dedicated tilt motor is a separate relay we drive ourselves, so the suppression was being applied to a motor the reporting hardware had no say over. The tilt stop is no longer gated on `_triggered_externally`.

It's gated on the **axis** instead: the tilt-relay handlers pass `tilt_axis_reported=True`, because when the tilt relay is the one reporting, echoing a stop back at it is exactly what the suppression exists to prevent — and on toggle hardware `_send_tilt_stop` is a **pulse**, so it would start the motor moving again rather than stop it. That asymmetry is why this can't simply always fire. Both directions are pinned: one test fails if the old gate returns, the other if the axis guard is dropped. Both `async_stop_cover` implementations share the decision via `_should_stop_tilt_motor`.

## Testing

1256 Python + 345 frontend tests pass; ruff clean. Every new test is mutation-proven — broken in both directions and confirmed to fail for the right reason, which is how the vacuous first draft of the dual-motor relay test was caught (`async_stop_cover` sends its own tilt stop, so it now asserts *ordering*).

## Worth a hardware test before release

This branch touches the wall-switch paths across all control modes, and this repo has a history of switch-mode external-trigger regressions. The enumeration was verified by tracing every call site and by driving the real echo routes in tests, but the toggle-mode tilt pulse path in particular is worth exercising on real hardware.