### PR TITLE
fix: log every toggle pulse's reported relay state so an edge-less turn_on is visible (#153)

### DIFF
--- a/custom_components/cover_time_based/cover_toggle_base.py
+++ b/custom_components/cover_time_based/cover_toggle_base.py
@@ -94,23 +94,46 @@ class ToggleBaseCover(SwitchCoverTimeBased):
         call that doesn't change the entity's state (``turn_off`` on an
         already-off relay, ``turn_on`` on an already-on one) fires no event and
         so produces no echo to mark.
+
+        Each branch logs the relay's reported state and whether its ``turn_on``
+        can carry a rising edge, so a user-supplied debug log shows which
+        pulses could have moved the motor (issue #153).
         """
         is_on = self._switch_is_on(entity_id)
         if self._relay_reports_off and is_on:
             # Relay reports ON and we trust that report: release it first so the
             # following turn_on is a genuine OFF->ON edge. Two state changes
             # (off, then on) → two echoes.
+            self._log(
+                "_pulse_relay :: %s reports on, releasing first so the"
+                " turn_on is a rising edge",
+                entity_id,
+            )
             self._mark_switch_pending(entity_id, 2)
             await self._turn_off_relay(entity_id)
         elif not is_on:
             # Relay reports OFF: the turn_on produces a real OFF->ON edge → one
             # echo.
+            self._log(
+                "_pulse_relay :: %s reports off, turn_on is a rising edge",
+                entity_id,
+            )
             self._mark_switch_pending(entity_id, 1)
-        # else: relay_reports_off is disabled and the relay still *reports* ON
-        # (it never announced its self-release). The turn_on lands on an
-        # already-on entity, so HA emits no state change and no echo — marking
-        # one would orphan a pending count that could swallow the user's next
-        # genuine press until the safety timeout clears it.
+        else:
+            # relay_reports_off is disabled and the relay still *reports* ON
+            # (it never announced its self-release). The turn_on lands on an
+            # already-on entity, so HA emits no state change and no echo —
+            # marking one would orphan a pending count that could swallow the
+            # user's next genuine press until the safety timeout clears it.
+            # Log it: if the relay is also *physically* still on (a rapid
+            # re-pulse inside its own pulse window), this turn_on carries no
+            # edge and the motor never sees the command (issue #153).
+            self._log(
+                '_pulse_relay :: %s still reports on ("Relay reports its own'
+                ' OFF" disabled): no rising edge if the relay is physically'
+                " still on",
+                entity_id,
+            )
         await self.hass.services.async_call(
             "homeassistant",
             "turn_on",

--- a/tests/test_cover_toggle_mode.py
+++ b/tests/test_cover_toggle_mode.py
@@ -14,6 +14,7 @@ restart), to guarantee the motor sees a genuine OFF->ON edge.
 """
 
 import asyncio
+import logging
 from types import SimpleNamespace
 
 import pytest
@@ -1283,3 +1284,76 @@ class TestToggleRelayDoesNotReportOff:
             _ha("turn_on", "switch.tilt_close"),
         ]
         assert cover._last_tilt_direction == "close"
+
+
+# ===================================================================
+# _pulse_relay logs the relay's reported state (issue #153 diagnostics)
+# ===================================================================
+
+
+class TestPulseRelayEdgeLogging:
+    """Every pulse logs the relay's reported state and the branch taken.
+
+    Issue #153: in toggle-opposite mode a reversal pulses the SAME relay
+    twice, separated only by ``direction_change_delay``. At 0s the blind does
+    not move, and the debug log could not distinguish "the ``turn_on`` landed
+    on a still-energised relay (no rising edge)" from "the edge was delivered
+    and the motor ignored it". ``_pulse_relay`` therefore records, for every
+    pulse, what state the relay *reported* and whether the ``turn_on`` can
+    carry a rising edge — so a single debug log from a failing run shows
+    which pulses could have moved the motor.
+
+    The three tests pin one branch each and deliberately vary one axis at a
+    time: same config, different relay state (test 1 vs 2); same relay
+    state, different config (test 1 vs 3). ``_pulse_relay`` lives on the
+    shared toggle base, so both **Toggle** and **Toggle (opposite button)**
+    — the mode #153 is about — emit these lines.
+    """
+
+    LOGGER = "custom_components.cover_time_based.cover_base"
+
+    @pytest.mark.asyncio
+    async def test_edgeless_pulse_logs_no_rising_edge(self, caplog):
+        """relay_reports_off disabled + relay stuck reporting ON: the pulse
+        may land on an already-energised relay — the log must say so."""
+        cover = _make_toggle_cover(relay_reports_off=False)
+        _hold_relay_on(cover, "switch.close")
+
+        with caplog.at_level(logging.DEBUG, logger=self.LOGGER):
+            await cover._send_close()
+
+        assert any(
+            "switch.close" in m and "no rising edge" in m for m in caplog.messages
+        ), "the potentially edge-less pulse is indistinguishable from a real one"
+
+    @pytest.mark.asyncio
+    async def test_off_relay_pulse_logs_rising_edge(self, caplog):
+        """Same config as above, but the relay reports OFF: the turn_on is a
+        genuine rising edge (relay_reports_off is irrelevant on this branch)."""
+        cover = _make_toggle_cover(relay_reports_off=False)
+        _all_relays_off(cover)
+
+        with caplog.at_level(logging.DEBUG, logger=self.LOGGER):
+            await cover._send_close()
+
+        assert any(
+            "switch.close" in m and "reports off" in m and "rising edge" in m
+            for m in caplog.messages
+        )
+        assert "no rising edge" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_release_first_pulse_logs_release(self, caplog):
+        """Same stuck-ON relay as the first test, but with relay_reports_off
+        enabled the report is trusted: released first, then a real edge."""
+        cover = _make_toggle_cover(relay_reports_off=True)
+        _hold_relay_on(cover, "switch.close")
+
+        with caplog.at_level(logging.DEBUG, logger=self.LOGGER):
+            await cover._send_close()
+
+        assert any(
+            "switch.close" in m and "releasing first" in m and "rising edge" in m
+            for m in caplog.messages
+        )
+        assert "no rising edge" not in caplog.text


### PR DESCRIPTION
## Why

#153's `direction_change_delay = 0` failure is stuck on an unresolved diagnostic fork. In toggle-opposite mode a reversal pulses the **same relay twice**, separated only by the settle gap — at 0s they land ~4ms apart and the blind doesn't move. Two mechanisms fit the evidence and imply opposite fixes:

- **(A) No rising edge** — the second `turn_on` lands on a relay still energised from the stop pulse (the Aqara T2 holds for its 200ms `pulse_length` and never announces its self-release), so the motor never sees the command. The delay is really buying *relay-release* time.
- **(B) Motor settle** — the edge is delivered but the motor is still coming to rest and ignores it. `0` is simply invalid for that hardware; no code fix warranted.

The debug log cannot tell these apart: `_pulse_relay`'s edge-less branch — `relay_reports_off` disabled while the relay still *reports* ON — logged nothing at all.

## What

Every pulse now logs the state the relay **reported** and the branch taken:

- released first (guaranteed edge)
- reported off (the `turn_on` is the edge)
- still reporting on with **"Relay reports its own OFF"** disabled — *no rising edge if the relay is physically still on*

On hardware like the T2 the third line appears on most pulses, so its *presence* alone proves nothing; what it adds is the reported state plus a per-pulse timestamp, so a failing run shows exactly which pulses could have carried an edge and how far apart they landed relative to the device's own pulse window.

Same reasoning as #178, one layer down: #178 marks the write that was **suppressed**; this marks the write that was **issued** but may have landed on an already-on relay as a no-op.

Logging only — no behaviour change: relay command sequence, echo marking, and control flow are untouched.

## Testing

- 3 new tests (`TestPulseRelayEdgeLogging`) pin one branch each, varying one axis at a time; assertions require entity id + branch phrase in the same log record, and "no rising edge" is pinned as edge-less-branch-only.
- Full suite: 1281 passed; ruff clean.

Refs #153.