### PR TITLE
chore: release v4.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 4.9.0 (2026-07-20)
 
 ### Features
 

--- a/custom_components/cover_time_based/manifest.json
+++ b/custom_components/cover_time_based/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/Sese-Schneider/ha-cover-time-based/issues",
   "requirements": [],
-  "version": "4.9.0-rc.2"
+  "version": "4.9.0"
 }


### PR DESCRIPTION
Release `v4.9.0`.

- Bumps the manifest version to `4.9.0`.
- Closes the CHANGELOG's `## Unreleased` section as `## 4.9.0 (2026-07-20)` — required for a final tag, since the release workflow builds its notes from that section and only pre-release tags may fall back to auto-generated notes.

After merge, push the tag to publish the GitHub Release:

```
git tag v4.9.0 && git push upstream v4.9.0
```

Then promote it out of pre-release:

```
gh release edit v4.9.0 --prerelease=false --latest=true
```

This supersedes **v4.8.0**, which was published as a pre-release and never promoted — 4.9.0's notes cover everything since v4.7.2, the current `latest`.