### PR TITLE
test: make the YAML backward-compat guards real, and finish the removal (#153)

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ cover:
 | min_movement_time      | float   | _Optional_                                      | Minimum movement duration (seconds) - blocks shorter movements          | None    |
 | travel_startup_delay   | float   | _Optional_                                      | Motor startup time compensation (seconds) for travel movements          | None    |
 | tilt_startup_delay     | float   | _Optional_                                      | Motor startup time compensation (seconds) for tilt movements            | None    |
-| direction_change_delay | float   | _Deprecated_                                    | No longer configurable — accepted and ignored. The settle gap is fixed at 1.0s | 1.0     |
+| direction_change_delay | float   | _Deprecated_                                    | No longer configurable — accepted and ignored. The settle gap is fixed at 1.0s | —       |
 | pulse_time             | float   | _Optional_                                      | Duration in seconds for button press in pulse mode                      | 1.0     |
 | relay_reports_off      | boolean | _Optional_                                      | Toggle mode: set false for pulse modules that never report their OFF    | true    |
 | send_endpoint_stop     | boolean | _Optional_                                      | Pulse mode: set false for auto-stop controllers that reposition on a stop received while stopped | true    |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,6 @@ from custom_components.cover_time_based.cover import (
 )
 from custom_components.cover_time_based.const import (
     CONF_CLOSE_INCLUDES_TILT,
-    CONF_DIRECTION_CHANGE_DELAY,
     CONF_FORCE_ENDPOINT_REDRIVE,
     CONF_FORCE_TIME_BASED_POSITION,
     CONF_IGNORE_REPORTED_POSITION,
@@ -102,7 +101,6 @@ def make_cover(make_hass, _mock_position_store):
         tilt_startup_delay=None,
         endpoint_runon_time=None,
         min_movement_time=None,
-        direction_change_delay=None,
         tilt_open_switch=None,
         tilt_close_switch=None,
         tilt_stop_switch=None,
@@ -155,8 +153,6 @@ def make_cover(make_hass, _mock_position_store):
             options[CONF_ENDPOINT_RUNON_TIME] = endpoint_runon_time
         if min_movement_time is not None:
             options[CONF_MIN_MOVEMENT_TIME] = min_movement_time
-        if direction_change_delay is not None:
-            options[CONF_DIRECTION_CHANGE_DELAY] = direction_change_delay
         if tilt_open_switch is not None:
             options[CONF_TILT_OPEN_SWITCH] = tilt_open_switch
         if tilt_close_switch is not None:

--- a/tests/frontend/card_render.test.mjs
+++ b/tests/frontend/card_render.test.mjs
@@ -597,19 +597,15 @@ test("pulse mode with send_endpoint_stop off timing table does NOT include endpo
   expect(inputs.length).toBe(4);
 });
 
-test.each([
-  ["switch", switchCfg],
-  ["pulse", pulseCfg],
-  ["toggle", toggleCfg],
-  ["toggle_opposite", toggleOppositeCfg],
-  ["wrapped", wrappedCfg],
-])("direction_change_delay row is gone in %s mode", async (_mode, cfg) => {
+test("direction_change_delay row is gone, even for an entry that still stores it", async () => {
   // The settle gap is fixed at 1.0s and no longer user-configurable, so the
-  // Timing tab must not offer it — including for an entry whose stored options
-  // still carry the key from a 4.9.0 release candidate.
+  // Timing tab must not offer it — including for a config entry written by a
+  // 4.9.0 release candidate, whose options still carry the key. One case is
+  // enough: the row was deleted from a static array that is not mode-gated,
+  // and per-mode row counts are covered in send_endpoint_stop.test.mjs.
   card = await mountCard(makeHass(), {
     selectedEntity: "cover.x",
-    config: cfg({ direction_change_delay: 3.5 }),
+    config: switchCfg({ direction_change_delay: 3.5 }),
     activeTab: "timing",
   });
   const row = [...card.shadowRoot.querySelectorAll("tr")].find(

--- a/tests/test_cover_toggle_mode.py
+++ b/tests/test_cover_toggle_mode.py
@@ -1295,10 +1295,12 @@ class TestPulseRelayEdgeLogging:
     """Every pulse logs the relay's reported state and the branch taken.
 
     Issue #153: in toggle-opposite mode a reversal pulses the SAME relay
-    twice, separated only by ``direction_change_delay``. At 0s the blind does
-    not move, and the debug log could not distinguish "the ``turn_on`` landed
-    on a still-energised relay (no rising edge)" from "the edge was delivered
-    and the motor ignored it". ``_pulse_relay`` therefore records, for every
+    twice, separated only by the settle gap. While that gap was briefly
+    configurable, a short one left the blind motionless, and the debug log
+    could not distinguish "the ``turn_on`` landed on a still-energised relay
+    (no rising edge)" from "the edge was delivered and the motor ignored it".
+    (The gap is fixed at 1.0s again, which covers both.) ``_pulse_relay``
+    therefore records, for every
     pulse, what state the relay *reported* and whether the ``turn_on`` can
     carry a rising edge — so a single debug log from a failing run shows
     which pulses could have moved the motor.

--- a/tests/test_direction_change_delay.py
+++ b/tests/test_direction_change_delay.py
@@ -22,9 +22,12 @@ from homeassistant.const import (
     SERVICE_STOP_COVER,
 )
 
+import voluptuous as vol
+
 from custom_components.cover_time_based.const import (
     CONF_DIRECTION_CHANGE_DELAY,
     DIRECTION_CHANGE_DELAY,
+    DOMAIN,
 )
 from custom_components.cover_time_based.cover import (
     CONF_CLOSE_SWITCH_ENTITY_ID,
@@ -35,6 +38,7 @@ from custom_components.cover_time_based.cover import (
     CONTROL_MODE_PULSE,
     CONTROL_MODE_SWITCH,
     CONTROL_MODE_TOGGLE_OPPOSITE,
+    PLATFORM_SCHEMA,
     _create_cover_from_options,
     devices_from_config,
 )
@@ -77,11 +81,25 @@ async def test_a_stored_option_no_longer_changes_the_gap():
     slept.assert_awaited_once_with(1.0)
 
 
-def test_yaml_carrying_the_removed_key_still_loads():
-    """Platform schemas are strict, so an unknown key would kill setup.
+def _validated(config):
+    """Put a YAML config through the real platform schema.
 
-    The key stays in the schema precisely so a YAML config written against the
-    rc keeps working -- accepted, then ignored.
+    ``devices_from_config`` does no validation at all — it happily accepts
+    invented keys — so calling it directly proves nothing about backward
+    compatibility. Home Assistant validates against PLATFORM_SCHEMA before the
+    platform ever sees the config, and that is what rejects unknown keys, so
+    it is what these tests have to go through.
+    """
+    return devices_from_config(PLATFORM_SCHEMA({"platform": DOMAIN, **config}))
+
+
+def test_yaml_carrying_the_removed_key_still_loads():
+    """Platform schemas are strict, so an unknown key kills setup outright.
+
+    The key stays in the schema precisely so a YAML config written against a
+    release candidate keeps working — accepted, then ignored. Delete the
+    schema entry and this fails with "extra keys not allowed", which is what
+    the affected user's log would say as their cover disappeared.
     """
     config = {
         CONF_DEFAULTS: {},
@@ -96,12 +114,33 @@ def test_yaml_carrying_the_removed_key_still_loads():
             },
         },
     }
-    devices = devices_from_config(config)
-    assert len(devices) == 1
+    assert len(_validated(config)) == 1
+
+
+def test_an_unknown_key_is_still_rejected():
+    """Proves the two BWC tests are not vacuous.
+
+    Without this they would keep passing if the schema were ever relaxed to
+    allow extra keys — demonstrating that nothing is validated rather than
+    that the retained entry is what keeps those configs loading.
+    """
+    config = {
+        CONF_DEFAULTS: {},
+        CONF_DEVICES: {
+            "blind1": {
+                "name": "Living Room",
+                CONF_OPEN_SWITCH_ENTITY_ID: "switch.open",
+                CONF_CLOSE_SWITCH_ENTITY_ID: "switch.close",
+                "no_such_option": 1,
+            },
+        },
+    }
+    with pytest.raises(vol.Invalid):
+        _validated(config)
 
 
 def test_yaml_defaults_block_carrying_the_removed_key_still_loads():
-    """Same, via the defaults: block (which also accepted null)."""
+    """Same, via the defaults: block — which also has to keep accepting null."""
     config = {
         CONF_DEFAULTS: {CONF_DIRECTION_CHANGE_DELAY: None},
         CONF_DEVICES: {
@@ -112,7 +151,7 @@ def test_yaml_defaults_block_carrying_the_removed_key_still_loads():
             },
         },
     }
-    assert len(devices_from_config(config)) == 1
+    assert len(_validated(config)) == 1
 
 
 @pytest.mark.asyncio
@@ -343,8 +382,7 @@ async def test_stop_during_the_settle_gap_cancels_the_reversal(make_cover):
     The reversal stops the motor, waits out the gap, then drives the new
     direction. Nothing re-checked that the movement was still wanted, so a stop
     arriving during the gap was overridden when the coroutine resumed — the
-    cover moved *after* the user told it to stop, up to direction_change_delay
-    seconds later. Raising the gap for slow motors widens that window.
+    cover moved *after* the user told it to stop, up to a second later.
     """
     async with _ParkedReversal(_reversing_cover(make_cover)) as reversal:
         await reversal.cover.async_stop_cover()
@@ -472,7 +510,6 @@ def _external_cover(make_cover):
     return make_cover(
         control_mode=CONTROL_MODE_PULSE,
         stop_switch="switch.stop",
-        direction_change_delay=2.5,
     )
 
 
@@ -516,7 +553,7 @@ async def test_stop_during_the_gap_cancels_an_external_close_reversal(make_cover
     _triggered_externally, ambient instance state held for the *whole* external
     call, settle gap included; a genuine stop arriving in that window was
     therefore indistinguishable from a device echo, so it was dropped and the
-    parked reversal drove the cover up to direction_change_delay seconds after
+    parked reversal drove the cover up to a second after
     the user said stop. Callers now say which kind of stop they are.
     """
     async with _parked_external_close(make_cover) as reversal:


### PR DESCRIPTION
Follow-up to #182, from the reviews that should have run before it merged. **No production behaviour changes** — tests and docs only.

## The YAML backward-compat tests were vacuous

Both called `devices_from_config()` directly, which performs **no validation at all**:

```python
>>> devices_from_config({... "TOTAL_NONSENSE_KEY": 99})   # accepted
```

So neither test could observe the thing it claimed to prove. Home Assistant validates against `PLATFORM_SCHEMA` *before* the platform sees a config, and that is what rejects unknown keys — so that is what they now go through.

Verified by simulating the regression they exist to catch. With both retained schema entries deleted:

```
FAILED test_yaml_carrying_the_removed_key_still_loads
FAILED test_yaml_defaults_block_carrying_the_removed_key_still_loads
```

Previously that left them green while every release-candidate tester's YAML died at startup with `extra keys not allowed`.

A third test pins the guard itself — an unknown key must still be rejected — so the pair above can't silently start passing because *nothing* is validated.

The websocket side already had this treatment; it was added in review of #182 and the identical flaw on the YAML side went unnoticed.

## Finishing the removal

| | |
|---|---|
| `tests/conftest.py` | `make_cover` kept a `direction_change_delay` kwarg writing an option nothing reads — a dead knob in the suite's most-shared fixture |
| `test_direction_change_delay.py` | `_external_cover` still passed `direction_change_delay=2.5`. Worse than dead: the harness asserts the slept value equals the fixed constant, so eight external-reversal tests passed *only because* the 2.5 was discarded |
| docstrings | still narrated the gap as variable ("up to `direction_change_delay` seconds", "raising the gap for slow motors") while the production comments beside them had been updated |
| `card_render.test.mjs` | the 5-mode `test.each` asserted absence of a row deleted from a static, non-mode-gated array; one case carries that, and `send_endpoint_stop.test.mjs` covers mode gating |
| `README.md` | the deprecated row still advertised a default of `1.0`, in a column meaning "what you get if you omit this" |

## Testing

1278 Python + 345 frontend tests pass; ruff clean. Diff is identical with and without `-w` (no line-ending churn).

## Known, not addressed here

The repo has no `.gitattributes` and is mixed CRLF/LF; #182 incidentally converted three files, inflating its diff ~6×. Worth a dedicated normalization commit rather than bundling it here.

Refs #153.