### PR TITLE
test: name the unshipped-language stand-in instead of hardcoding a real one

### DIFF
--- a/tests/frontend/card_logic.test.mjs
+++ b/tests/frontend/card_logic.test.mjs
@@ -10,6 +10,7 @@
 import { test, expect, afterEach, vi } from "vitest";
 import { makeHass } from "./helpers/hass.mjs";
 import { mountCard, defineHaStubs } from "./helpers/mount.mjs";
+import { UNSHIPPED_LANG } from "./helpers/lang.mjs";
 
 defineHaStubs();
 let card;
@@ -24,7 +25,7 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 test("_t falls back through language → EN → raw key", async () => {
-  card = await mountCard(makeHass({ language: "de" }));
+  card = await mountCard(makeHass({ language: UNSHIPPED_LANG }));
   // A key present in EN renders the English string, never the raw key.
   expect(card._t("header")).not.toBe("header");
   expect(card._t("header")).toBe("Cover Time Based Configuration");

--- a/tests/frontend/helpers/lang.mjs
+++ b/tests/frontend/helpers/lang.mjs
@@ -1,0 +1,20 @@
+/**
+ * A language code no shipped catalogue will ever cover.
+ *
+ * Several tests need "a language we don't translate" — to prove strings fall
+ * back to English, that locale resolution declines to match, and that the
+ * request-a-translation banner appears. Naming a real language there is a trap:
+ * the suite used `de` until German was translated, at which point five
+ * assertions started failing with messages that blame the code ("expected 'de'
+ * to be ''") rather than the stale fixture, in the pull request of whoever
+ * contributed the translation.
+ *
+ * ISO 639-2 reserves qaa-qtz for local use, so `qaa` is a structurally valid
+ * BCP-47 tag that cannot become a shipped catalogue. Intl.DisplayNames resolves
+ * it without throwing — it echoes the code back — so the banner's display-name
+ * and issue-URL paths behave exactly as they do for a real untranslated code.
+ */
+export const UNSHIPPED_LANG = "qaa";
+
+/** A region variant of {@link UNSHIPPED_LANG}, for base-language fallback tests. */
+export const UNSHIPPED_REGION = "qaa-QQ";

--- a/tests/frontend/language_banner.test.mjs
+++ b/tests/frontend/language_banner.test.mjs
@@ -15,6 +15,7 @@ import {
 } from "../../custom_components/cover_time_based/frontend/language-banner.js";
 import { defineHaStubs, mountCard } from "./helpers/mount.mjs";
 import { makeHass } from "./helpers/hass.mjs";
+import { UNSHIPPED_LANG } from "./helpers/lang.mjs";
 
 defineHaStubs();
 
@@ -71,11 +72,11 @@ test("persistLangDismissed then loadDismissedLangs round-trips a locale", () => 
 });
 
 test("dismissing a second locale preserves the first", () => {
-  // A scalar store would forget "de": dismiss de, switch to fr, switch back,
+  // A scalar store would forget "fr": dismiss fr, switch to es, switch back,
   // and the nudge would reappear.
-  persistLangDismissed("de");
   persistLangDismissed("fr");
-  expect(loadDismissedLangs()).toEqual(["de", "fr"]);
+  persistLangDismissed("es");
+  expect(loadDismissedLangs()).toEqual(["fr", "es"]);
 });
 
 test("persistLangDismissed does not duplicate an already-dismissed locale", () => {
@@ -105,7 +106,7 @@ test("persistLangDismissed is a silent no-op when storage access throws", () => 
 });
 
 test("the banner renders for a language with no shipped translation", async () => {
-  const el = await mountCard(makeHass({ language: "de" }));
+  const el = await mountCard(makeHass({ language: UNSHIPPED_LANG }));
   expect(banner(el)).not.toBe(null);
 });
 
@@ -126,25 +127,27 @@ test("the banner does not render when the language is undeterminable", async () 
 });
 
 test("the banner names the language and links to a prefilled issue", async () => {
-  const el = await mountCard(makeHass({ language: "de" }));
+  const el = await mountCard(makeHass({ language: UNSHIPPED_LANG }));
   const text = banner(el).textContent;
-  expect(text).toContain(languageDisplayName("de"));
+  expect(text).toContain(languageDisplayName(UNSHIPPED_LANG));
   const href = banner(el).querySelector("a").getAttribute("href");
-  expect(href).toBe(buildTranslationRequestUrl("de", languageDisplayName("de")));
+  expect(href).toBe(
+    buildTranslationRequestUrl(UNSHIPPED_LANG, languageDisplayName(UNSHIPPED_LANG))
+  );
 });
 
 test("the banner does not render for a locale already dismissed in storage", async () => {
-  persistLangDismissed("de");
-  const el = await mountCard(makeHass({ language: "de" }));
+  persistLangDismissed(UNSHIPPED_LANG);
+  const el = await mountCard(makeHass({ language: UNSHIPPED_LANG }));
   expect(banner(el)).toBe(null);
 });
 
 test("clicking dismiss hides the banner and persists the locale", async () => {
-  const el = await mountCard(makeHass({ language: "de" }));
+  const el = await mountCard(makeHass({ language: UNSHIPPED_LANG }));
   banner(el).querySelector("ha-icon-button").click();
   await el.updateComplete;
   expect(banner(el)).toBe(null);
-  expect(loadDismissedLangs()).toContain("de");
+  expect(loadDismissedLangs()).toContain(UNSHIPPED_LANG);
 });
 
 test("dismissal sticks for the session when storage is unavailable", async () => {
@@ -152,7 +155,7 @@ test("dismissal sticks for the session when storage is unavailable", async () =>
   vi.spyOn(window.localStorage, "setItem").mockImplementation(() => {
     throw new Error("storage disabled");
   });
-  const el = await mountCard(makeHass({ language: "de" }));
+  const el = await mountCard(makeHass({ language: UNSHIPPED_LANG }));
   banner(el).querySelector("ha-icon-button").click();
   await el.updateComplete;
   expect(banner(el)).toBe(null);

--- a/tests/frontend/translations.test.mjs
+++ b/tests/frontend/translations.test.mjs
@@ -10,6 +10,7 @@ import {
   isLanguageSupported,
   translate,
 } from "../../custom_components/cover_time_based/frontend/translations.js";
+import { UNSHIPPED_LANG, UNSHIPPED_REGION } from "./helpers/lang.mjs";
 
 test("resolveLocale matches a shipped language exactly", () => {
   expect(resolveLocale("pt")).toBe("pt");
@@ -24,8 +25,8 @@ test("resolveLocale falls back to the base language for a region variant", () =>
 });
 
 test("resolveLocale returns empty string for an unshipped language", () => {
-  expect(resolveLocale("de")).toBe("");
-  expect(resolveLocale("de-AT")).toBe("");
+  expect(resolveLocale(UNSHIPPED_LANG)).toBe("");
+  expect(resolveLocale(UNSHIPPED_REGION)).toBe("");
 });
 
 test("resolveLocale returns empty string when the language is missing", () => {
@@ -42,7 +43,7 @@ test("isLanguageSupported treats a missing language as supported", () => {
 test("isLanguageSupported reflects whether a catalogue covers the locale", () => {
   expect(isLanguageSupported("pl")).toBe(true);
   expect(isLanguageSupported("pt-BR")).toBe(true);
-  expect(isLanguageSupported("de")).toBe(false);
+  expect(isLanguageSupported(UNSHIPPED_LANG)).toBe(false);
 });
 
 test("translate renders a region variant in its base catalogue", () => {
@@ -51,7 +52,7 @@ test("translate renders a region variant in its base catalogue", () => {
 });
 
 test("translate falls back to English for an unshipped language", () => {
-  expect(translate("de", "loading")).toBe("Loading...");
+  expect(translate(UNSHIPPED_LANG, "loading")).toBe("Loading...");
 });
 
 test("translate returns the key itself when no catalogue defines it", () => {


### PR DESCRIPTION
Several frontend tests need "a language we do not translate" — to prove strings fall back to English, that `resolveLocale` declines to match, and that the request-a-translation banner appears. All of them spelled that as the literal `de`.

That works right up until German is translated. At that point five assertions across three files start failing, with messages that blame the code rather than the fixture — `expected 'de' to be ''` reads as a locale-resolution bug — and they fail inside the pull request of whoever contributed the translation, who has no reason to suspect the suite had picked their language as its example of an untranslated one.

This introduces `UNSHIPPED_LANG` in `tests/frontend/helpers/lang.mjs` and uses it at every site whose meaning depends on the language being untranslated.

**Why `qaa`:** ISO 639-2 reserves `qaa`–`qtz` for local use, so it is a structurally valid BCP-47 tag that cannot ever become a shipped catalogue. `Intl.DisplayNames` resolves it without throwing (it echoes the code back), so the banner's display-name and issue-URL paths behave exactly as they do for a real untranslated code — unlike e.g. `x-none`, which raises `RangeError`.

Sites that merely pass a language code as opaque data to a locale-agnostic function — the dismissal round-trip, `languageDisplayName` — keep using real codes, since shipped status is irrelevant there.

No behaviour change, and the test count is unchanged at 341.

This is groundwork for #189 — with it in place, adding a language touches no test file at all.