### PR TITLE
fix: fail the translation check on an untranslated key, not just a stale one

### DIFF
--- a/TRANSLATING.md
+++ b/TRANSLATING.md
@@ -40,7 +40,7 @@ In [`custom_components/cover_time_based/frontend/translations.js`](custom_compon
 
 2. Add a `de:` entry mirroring the existing `pt:` and `pl:` blocks. Use the `EN` object above it as the master list of keys: copy every key across and translate its value.
 
-The card falls back to English for any key you miss, so a partial translation will work — but the [audit below](#verifying-translations-are-in-sync) will flag what's missing.
+A key you miss falls back to English at runtime, so a partial translation renders — but it will not pass CI. Both surfaces are held to complete catalogues: the card by `tests/frontend/translation_parity.test.mjs`, and the Home Assistant strings by `scripts/check_translations.py`, which the pre-push hook and CI both run. Translate every key, and use the [audit below](#verifying-translations-are-in-sync) to find any you've missed.
 
 The card resolves a locale by trying the exact code first, then its base language, then English — so a `pt-BR` user reads the `pt` catalogue, and adding `de` also covers `de-AT` and `de-CH`. Add a region-specific key (`pt-BR`) only when that variant needs wording of its own.
 

--- a/scripts/check_translations.py
+++ b/scripts/check_translations.py
@@ -1,16 +1,25 @@
 #!/usr/bin/env python3
 """Validate translation files against the source strings.json.
 
-Catches the drift that matters: a string key that was renamed or removed in
-strings.json but left behind in a translations/<lang>.json (a "stale" key).
-Stale keys are ERRORS — they're dead weight that can mask typos and never
-surface to the user. Missing keys (a language that hasn't translated a string
-yet) are only WARNINGS — partial translations are normal and expected.
+Catches drift in both directions, and both are ERRORS:
+
+- a *stale* key, renamed or removed in strings.json but left behind in a
+  translations/<lang>.json — dead weight that can mask a typo and never
+  surfaces to the user;
+- a *missing* key, present in strings.json but absent from a catalogue — which
+  ships an untranslated string to that language with nothing to notice it.
+
+Missing keys used to be warnings, on the theory that partial translations are
+normal. In practice a warning nobody sees is how a language quietly rots: the
+English string lands, the catalogues are never updated, and every user of that
+language reads English with a green build. The card's catalogues have always
+been held to full parity by tests/frontend/translation_parity.test.mjs; this
+holds the Home Assistant strings to the same standard.
 
 Auto-detects the integration under custom_components/<component>/. Pass an
 explicit component dir as the first argument to override.
 
-Exit code: 1 if any stale keys are found, else 0.
+Exit code: 1 if any language is out of sync with strings.json, else 0.
 """
 
 from __future__ import annotations
@@ -76,14 +85,19 @@ def main() -> int:
             for k in stale:
                 print(f"      {k}")
         if missing:
-            print(f"  ⚠ {path.name}: {len(missing)} untranslated key(s)")
+            had_error = True
+            print(f"  ✗ {path.name}: {len(missing)} untranslated key(s):")
+            for k in missing:
+                print(f"      {k}")
 
     if had_error:
         print(
-            "\ncheck_translations: stale keys found — remove them or fix strings.json"
+            "\ncheck_translations: translations are out of sync with strings.json —"
+            "\n  stale keys: remove them, or restore them to strings.json"
+            "\n  untranslated keys: add them to every translations/<lang>.json"
         )
         return 1
-    print("check_translations: no stale keys ✓")
+    print("check_translations: translations in sync ✓")
     return 0
 
 

--- a/tests/test_check_translations.py
+++ b/tests/test_check_translations.py
@@ -1,0 +1,112 @@
+"""Tests for scripts/check_translations.py.
+
+Guards the translation drift gate the pre-push hook and CI run. Two kinds of
+drift matter, and both must fail the build:
+
+- a *stale* key, left in a translations/<lang>.json after being renamed or
+  removed in strings.json — dead weight that can mask a typo;
+- a *missing* key, present in strings.json but never translated — which ships
+  an untranslated string to that language with nothing to notice it.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "check_translations.py"
+
+STRINGS = {
+    "config": {"step": {"user": {"title": "Add a cover", "data": {"name": "Name"}}}},
+    "services": {"set_known_position": {"name": "Set position"}},
+}
+
+
+def build_component(tmp_path: Path, translations: dict[str, dict]) -> Path:
+    """A minimal component dir: strings.json plus the given catalogues."""
+    component = tmp_path / "my_component"
+    (component / "translations").mkdir(parents=True)
+    (component / "strings.json").write_text(json.dumps(STRINGS), encoding="utf-8")
+    for lang, payload in translations.items():
+        (component / "translations" / f"{lang}.json").write_text(
+            json.dumps(payload), encoding="utf-8"
+        )
+    return component
+
+
+def run(component: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), str(component)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_complete_translation_passes(tmp_path):
+    result = run(build_component(tmp_path, {"pt": STRINGS}))
+    assert result.returncode == 0, result.stdout
+
+
+def test_missing_key_is_an_error(tmp_path):
+    """A key in strings.json that a catalogue never translated must fail.
+
+    Otherwise a new English string merges, nobody translates it, and every
+    non-English user silently reads English with a green build.
+    """
+    partial = {
+        "config": {"step": {"user": {"title": "Adicionar", "data": {"name": "Nome"}}}},
+        # services.set_known_position.name never translated
+    }
+    result = run(build_component(tmp_path, {"pt": partial}))
+    assert result.returncode == 1, result.stdout
+
+
+def test_missing_key_output_names_the_key(tmp_path):
+    """Naming the key is what makes the failure actionable."""
+    partial = {
+        "config": {"step": {"user": {"title": "Adicionar", "data": {"name": "Nome"}}}},
+    }
+    result = run(build_component(tmp_path, {"pt": partial}))
+    assert "services.set_known_position.name" in result.stdout
+    assert "pt.json" in result.stdout
+
+
+def test_stale_key_is_still_an_error(tmp_path):
+    """The pre-existing guard must survive the missing-key change."""
+    with_extra = json.loads(json.dumps(STRINGS))
+    with_extra["config"]["step"]["user"]["removed_long_ago"] = "Sobra"
+    result = run(build_component(tmp_path, {"pt": with_extra}))
+    assert result.returncode == 1, result.stdout
+    assert "removed_long_ago" in result.stdout
+
+
+def test_reports_every_offending_language_not_just_the_first(tmp_path):
+    """A contributor should see the whole job, not fix-and-rerun once per file."""
+    partial = {
+        "config": {"step": {"user": {"title": "T", "data": {"name": "N"}}}},
+    }
+    result = run(build_component(tmp_path, {"pl": partial, "pt": partial}))
+    assert result.returncode == 1, result.stdout
+    assert "pl.json" in result.stdout
+    assert "pt.json" in result.stdout
+
+
+def test_no_translations_dir_passes(tmp_path):
+    component = tmp_path / "bare"
+    component.mkdir()
+    (component / "strings.json").write_text(json.dumps(STRINGS), encoding="utf-8")
+    result = run(component)
+    assert result.returncode == 0, result.stdout
+
+
+def test_real_repo_translations_are_complete():
+    """The shipped catalogues must satisfy the gate this script enforces."""
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout


### PR DESCRIPTION
`scripts/check_translations.py` treated a key present in `strings.json` but absent from a `translations/<lang>.json` as a **warning**, on the documented theory that partial translations are normal and expected.

In practice a warning nobody reads is how a language quietly rots. A new English string merges, the catalogues are never updated, and users of every other language read English from then on — with a green build and no signal that anything is owed. Nothing in the pipeline ever escalates it: the warning prints into a *passing* pre-push run and scrolls away.

The card has never worked this way. `tests/frontend/translation_parity.test.mjs` requires every English key in every catalogue and fails the suite otherwise. This brings the Home Assistant strings to the same standard, so both translated surfaces are enforced rather than one.

### Changes

- A missing key is now an error, exactly like a stale one.
- Missing keys are listed **by name**. `3 untranslated key(s)` is not actionable without going and diffing the files yourself.
- `TRANSLATING.md` no longer says a partial translation "will work" — it renders via English fallback, but it does not pass CI. That sentence was already only half-true, since the card parity test has always rejected one.
- Adds `tests/test_check_translations.py`. The script had no tests at all: this covers the new behaviour, the stale-key behaviour it must not break, and a guard that the real shipped catalogues keep passing the gate.

### Cost to adopt: none

`en`, `pt` and `pl` are already complete against `strings.json`, so the stricter gate passes as-is. Verified before making the change, and `test_real_repo_translations_are_complete` keeps it honest.

### The tradeoff, stated plainly

Adding a user-facing string now means translating it into every shipped language *in the same PR*, or the build fails. That is the point — but it is real friction, and it grows with each language added. If you would rather keep the escape hatch, the natural middle ground is to let a catalogue opt out explicitly (a listed set of known-incomplete languages) rather than to let silence be the default. Happy to switch to that if you prefer.