### PR TITLE
docs: audit follow-up comment accuracy + dead-code cleanup

### DIFF
--- a/custom_components/cover_time_based/cover_base.py
+++ b/custom_components/cover_time_based/cover_base.py
@@ -1026,7 +1026,13 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
                 )
                 return
 
-        # Committed to acting: now claim the movement's bookkeeping.
+        # Committed to acting: now claim the movement's bookkeeping. Unlike the
+        # tilt funnel (_async_move_tilt_to_endpoint, which sets this flag then
+        # runs a post-flag in-motion reversal), the travel funnel's only
+        # direction change is the startup-delay cancel above, which returns
+        # before this line — so on that path _self_initiated_movement is left
+        # stale. Benign: the cover is fully stopped there and the next funnel
+        # call overwrites the flag.
         self._self_initiated_movement = not self._triggered_externally
 
         current = self.travel_calc.current_position()
@@ -1449,7 +1455,13 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
             await self._stop_displaced_movement_for_tilt(was_tilt_motor_move)
             # A reversal is stop → settle → go: give the motor (or momentary
             # relay) time to come to rest before driving the other way, and bail
-            # if a stop/newer target claimed the movement inside the gap.
+            # if a stop/newer target claimed the movement inside the gap. This
+            # settle is intentionally NOT gated on _triggered_externally: the
+            # dual-motor drive below (_send_tilt_close/open) is itself ungated on
+            # external, so an external redirect reaching here (e.g. a sequential
+            # external close) still drives the motor and must get its rest gap —
+            # reversing a physical cover too fast can trip its supply. Do not
+            # "optimise" this to skip the settle when external.
             if was_moving and not await self._settle_before_reversing():
                 return
             current = self.tilt_calc.current_position()
@@ -1978,7 +1990,9 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
                 # The motor self-stops at its physical limit switch. Sending a
                 # stop here is redundant (and for toggle re-pulses → restart),
                 # so skip the relay stop and any run-on; just settle the
-                # tracker. Run-on (below) is therefore switch-mode only.
+                # tracker. The run-on (below) is therefore reached only by
+                # hardware that does NOT self-stop at its endpoints — switch
+                # mode, and pulse with send_endpoint_stop enabled.
                 self._log(
                     "auto_stop_if_necessary :: motor self-stops at endpoint"
                     " (position=%d), no relay stop",
@@ -2166,7 +2180,8 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         # this lifecycle. A dual-motor tilt pre-step never starts the travel
         # motor, so its abandon must not pulse a travel relay off a stale
         # _last_command at an idle motor (#153 / #133, audit Task 5B). A pending
-        # run-on delay counts as still-driving (switch mode only).
+        # run-on delay counts as still-driving (any mode with an endpoint run-on
+        # arms _delay_task — e.g. pulse — not switch mode only).
         travel_was_running = self.travel_calc.is_traveling() or (
             self._delay_task is not None and not self._delay_task.done()
         )

--- a/custom_components/cover_time_based/cover_wrapped.py
+++ b/custom_components/cover_time_based/cover_wrapped.py
@@ -524,6 +524,11 @@ class WrappedCoverTimeBased(CoverTimeBased):
         # opening/closing (e.g. MQTT position-topic-only) hit this mid-travel;
         # their report describes a lagging past, not a settled present. Native
         # moves keep snapping — the device holds itself.
+        # This guard keys on is_traveling() and intentionally does NOT extend
+        # into the startup-delay window: there is no auto-updater to kill there,
+        # and the delay-fire's own auto-stop still catches the target. (The
+        # state-channel guard, by contrast, does extend into it via
+        # in_startup_window — see _handle_external_state_change.)
         if (
             self.travel_calc.is_traveling()
             and self._self_initiated_movement

--- a/custom_components/cover_time_based/frontend/card-render.js
+++ b/custom_components/cover_time_based/frontend/card-render.js
@@ -56,9 +56,9 @@ export function renderEntityPicker(card) {
               card.requestUpdate();
               return;
             }
-            if (card._isCalibrating()) {
-              card._onStopCalibration(true);
-            }
+            // Confirmed: nothing between the outer guard and here changes
+            // calibration state, so no redundant re-check — just cancel.
+            card._onStopCalibration(true);
           }
           // Flush any pending debounced edit to the OUTGOING entity before
           // swapping _selectedEntity/_config over to the new one - _autoSave


### PR DESCRIPTION
Final slice of the audit follow-ups: comment accuracy + one dead-code removal. **No behavior change** (Item J is a behavior-preserving simplification). Independent of #199/#200; branched off `main`.

## Comments (deferred nits from the audit ledger)
- **`set_tilt_position` reversal settle**: pin it as intentionally **not** gated on `_triggered_externally`. The dual-motor drive just below (`_send_tilt_close/open`) is itself ungated on external, so an external redirect (e.g. a sequential external close) still drives the motor and must get its stop→settle→go rest gap — reversing a physical cover too fast can trip its supply. Documents the decision so it isn't "optimised" into an external-skip later. *(The original deferred note proposed the skip; rejected on hardware-safety grounds.)*
- **`_abandon_active_lifecycle`**: correct the "(switch mode only)" note — any mode with an endpoint run-on arms `_delay_task` (e.g. **pulse**), not switch mode only. Also fixed the identical stale framing in the sibling `auto_stop_if_necessary` run-on comment (flagged in review) so the file is internally consistent.
- **wrapped `_handle_external_attribute_change`**: note the guard keys on `is_traveling()` and intentionally doesn't extend into the startup-delay window (no auto-updater to kill there; the delay-fire's own auto-stop catches the target), unlike the state-channel guard which uses `in_startup_window`.
- **travel funnel**: document the benign `_self_initiated_movement` asymmetry vs the tilt funnel (travel's only direction change — the startup-delay cancel — returns before the flag is set, leaving it stale; benign, overwritten next call).

## Dead code
- **`card-render.js` device picker**: remove the redundant inner `_isCalibrating()` re-check in the cancel path — always true when reached (nothing between it and the outer guard mutates calibration state). Covered by `card_events.test.mjs`'s picker-confirm-stops-calibration test.

## Verification
- ruff check + format clean; touched Python test subset green (308); full frontend suite green (383).
- Independent opus review: **all five comment claims verified accurate against source; the dead-code removal is behavior-preserving and test-covered. Ready to merge.**
