### PR TITLE
chore: release v4.10.0-rc.1

### DIFF
--- a/custom_components/cover_time_based/manifest.json
+++ b/custom_components/cover_time_based/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/Sese-Schneider/ha-cover-time-based/issues",
   "requirements": [],
-  "version": "4.10.0"
+  "version": "4.10.0-rc.1"
 }


### PR DESCRIPTION
Release `v4.10.0-rc.1`: bumps the manifest to `4.10.0-rc.1`.

After merge, tag the merge commit to publish the pre-release:
```
git tag v4.10.0-rc.1 <merge-sha> && git push upstream v4.10.0-rc.1
```
The release workflow publishes it as a GitHub pre-release. Release notes will be set to the curated 'Fable review' summary.