### PR TITLE
chore: clear ruff 0.16 findings and pin ruff in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,7 +88,12 @@ jobs:
           python-version: "3.14"
 
       - name: Install ruff
-        run: python -m pip install ruff
+        # Pinned deliberately. ruff's default rule set and formatter style shift
+        # between minor releases, so an unpinned install lets someone else's
+        # release turn this job red on a tree nobody touched — 0.16.0 did exactly
+        # that, surfacing 125 findings across files that had not changed. Bump
+        # this when you mean to, in a PR that also clears whatever it surfaces.
+        run: python -m pip install ruff==0.16.0
 
       - name: Check formatting
         run: ruff format --check .

--- a/custom_components/cover_time_based/cover.py
+++ b/custom_components/cover_time_based/cover.py
@@ -9,11 +9,11 @@ from homeassistant.components.cover import (
     ATTR_TILT_POSITION,
     PLATFORM_SCHEMA,
 )
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     CONF_NAME,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, SupportsResponse
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -323,11 +323,11 @@ def _resolve_tilt_strategy(tilt_mode_str, tilt_time_close, tilt_time_open, **kwa
 
 def _create_cover_from_options(options, device_id="", name=""):
     """Create the appropriate cover subclass based on options."""
-    from .cover_wrapped import WrappedCoverTimeBased
-    from .cover_switch_mode import SwitchModeCover
     from .cover_pulse_mode import PulseModeCover
+    from .cover_switch_mode import SwitchModeCover
     from .cover_toggle_mode import ToggleModeCover
     from .cover_toggle_opposite_mode import ToggleOppositeModeCover
+    from .cover_wrapped import WrappedCoverTimeBased
 
     control_mode = options.get(CONF_CONTROL_MODE, CONTROL_MODE_SWITCH)
 
@@ -341,32 +341,32 @@ def _create_cover_from_options(options, device_id="", name=""):
     )
 
     # Common params for all subclasses
-    common = dict(
-        device_id=device_id,
-        name=name,
-        tilt_strategy=tilt_strategy,
-        tilt_mode_str=tilt_mode_str,
-        travel_time_close=options.get(CONF_TRAVEL_TIME_CLOSE),
-        travel_time_open=options.get(CONF_TRAVEL_TIME_OPEN),
-        tilt_time_close=options.get(CONF_TILT_TIME_CLOSE),
-        tilt_time_open=options.get(CONF_TILT_TIME_OPEN),
-        travel_startup_delay=options.get(CONF_TRAVEL_STARTUP_DELAY),
-        tilt_startup_delay=options.get(CONF_TILT_STARTUP_DELAY),
-        endpoint_runon_time=options.get(
+    common = {
+        "device_id": device_id,
+        "name": name,
+        "tilt_strategy": tilt_strategy,
+        "tilt_mode_str": tilt_mode_str,
+        "travel_time_close": options.get(CONF_TRAVEL_TIME_CLOSE),
+        "travel_time_open": options.get(CONF_TRAVEL_TIME_OPEN),
+        "tilt_time_close": options.get(CONF_TILT_TIME_CLOSE),
+        "tilt_time_open": options.get(CONF_TILT_TIME_OPEN),
+        "travel_startup_delay": options.get(CONF_TRAVEL_STARTUP_DELAY),
+        "tilt_startup_delay": options.get(CONF_TILT_STARTUP_DELAY),
+        "endpoint_runon_time": options.get(
             CONF_ENDPOINT_RUNON_TIME, DEFAULT_ENDPOINT_RUNON_TIME
         ),
-        min_movement_time=options.get(CONF_MIN_MOVEMENT_TIME),
-        tilt_open_switch=options.get(CONF_TILT_OPEN_SWITCH),
-        tilt_close_switch=options.get(CONF_TILT_CLOSE_SWITCH),
-        tilt_stop_switch=options.get(CONF_TILT_STOP_SWITCH),
-        close_includes_tilt=options.get(
+        "min_movement_time": options.get(CONF_MIN_MOVEMENT_TIME),
+        "tilt_open_switch": options.get(CONF_TILT_OPEN_SWITCH),
+        "tilt_close_switch": options.get(CONF_TILT_CLOSE_SWITCH),
+        "tilt_stop_switch": options.get(CONF_TILT_STOP_SWITCH),
+        "close_includes_tilt": options.get(
             CONF_CLOSE_INCLUDES_TILT, DEFAULT_CLOSE_INCLUDES_TILT
         ),
-        assumed_state=options.get(CONF_ASSUMED_STATE, DEFAULT_ASSUMED_STATE),
-        force_endpoint_redrive=options.get(
+        "assumed_state": options.get(CONF_ASSUMED_STATE, DEFAULT_ASSUMED_STATE),
+        "force_endpoint_redrive": options.get(
             CONF_FORCE_ENDPOINT_REDRIVE, DEFAULT_FORCE_ENDPOINT_REDRIVE
         ),
-    )
+    }
 
     if control_mode == CONTROL_MODE_WRAPPED:
         return WrappedCoverTimeBased(

--- a/custom_components/cover_time_based/cover_base.py
+++ b/custom_components/cover_time_based/cover_base.py
@@ -30,11 +30,8 @@ from homeassistant.helpers.event import (
     async_track_time_interval,
 )
 from homeassistant.helpers.restore_state import RestoreEntity
-from .travel_calculator import TravelCalculator, TravelStatus
 
 from .calibration import CalibrationState
-from .cover_calibration import CalibrationMixin
-from .position_storage import async_get_position_store
 from .const import (
     CONF_ENDPOINT_RUNON_TIME,
     CONF_FORCE_ENDPOINT_REDRIVE,
@@ -48,6 +45,8 @@ from .const import (
     CONF_TRAVEL_TIME_OPEN,
     DIRECTION_CHANGE_DELAY,
 )
+from .cover_calibration import CalibrationMixin
+from .position_storage import async_get_position_store
 from .tilt_strategies import InlineTilt, SequentialTilt
 from .tilt_strategies.planning import (
     calculate_pre_step_delay,
@@ -55,6 +54,7 @@ from .tilt_strategies.planning import (
     extract_coupled_travel,
     has_travel_pre_step,
 )
+from .travel_calculator import TravelCalculator, TravelStatus
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/cover_time_based/cover_calibration.py
+++ b/custom_components/cover_time_based/cover_calibration.py
@@ -65,26 +65,27 @@ class CalibrationMixin:
             raise HomeAssistantError("Calibration already in progress")
 
         # Validate BEFORE creating state
-        if attribute in ("tilt_time_close", "tilt_time_open"):
-            if (
-                self._tilt_strategy is not None
-                and not self._tilt_strategy.can_calibrate_tilt()
-            ):
-                raise HomeAssistantError(
-                    "Tilt time calibration not available for this tilt mode"
-                )
+        if attribute in ("tilt_time_close", "tilt_time_open") and (
+            self._tilt_strategy is not None
+            and not self._tilt_strategy.can_calibrate_tilt()
+        ):
+            raise HomeAssistantError(
+                "Tilt time calibration not available for this tilt mode"
+            )
 
-        if attribute == "travel_startup_delay":
-            if not (self._travel_time_close or self._travel_time_open):
-                raise HomeAssistantError(
-                    "Travel time must be configured before calibrating startup delay"
-                )
+        if attribute == "travel_startup_delay" and not (
+            self._travel_time_close or self._travel_time_open
+        ):
+            raise HomeAssistantError(
+                "Travel time must be configured before calibrating startup delay"
+            )
 
-        if attribute == "tilt_startup_delay":
-            if not (self._tilting_time_close or self._tilting_time_open):
-                raise HomeAssistantError(
-                    "Tilt time must be configured before calibrating startup delay"
-                )
+        if attribute == "tilt_startup_delay" and not (
+            self._tilting_time_close or self._tilting_time_open
+        ):
+            raise HomeAssistantError(
+                "Tilt time must be configured before calibrating startup delay"
+            )
 
         # Neutralize any in-flight tracked movement: calibration drives the
         # motors directly, and a still-armed auto-updater would fire a relay
@@ -322,9 +323,9 @@ class CalibrationMixin:
         assert self._calibration is not None
         assert self._calibration.move_command is not None
         from .calibration import (
-            CALIBRATION_MIN_MOVEMENT_START,
             CALIBRATION_MIN_MOVEMENT_INCREMENT,
             CALIBRATION_MIN_MOVEMENT_INITIAL_PAUSE,
+            CALIBRATION_MIN_MOVEMENT_START,
             CALIBRATION_STEP_PAUSE,
         )
 

--- a/custom_components/cover_time_based/cover_switch_mode.py
+++ b/custom_components/cover_time_based/cover_switch_mode.py
@@ -131,14 +131,13 @@ class SwitchModeCover(SwitchCoverTimeBased):
                     "_handle_external_tilt_state_change :: external tilt close off, stopping"
                 )
                 await self.async_stop_cover(supersede=False, tilt_axis_reported=True)
-        elif entity_id == self._tilt_stop_switch_id:
-            if new_val == "on":
-                _LOGGER.debug(
-                    "_handle_external_tilt_state_change :: external tilt stop detected"
-                )
-                # A dedicated stop relay is a press, not a report — unlike the
-                # relay-off branches above, which are the hardware reporting.
-                await self.async_stop_cover(tilt_axis_reported=True)
+        elif entity_id == self._tilt_stop_switch_id and new_val == "on":
+            _LOGGER.debug(
+                "_handle_external_tilt_state_change :: external tilt stop detected"
+            )
+            # A dedicated stop relay is a press, not a report — unlike the
+            # relay-off branches above, which are the hardware reporting.
+            await self.async_stop_cover(tilt_axis_reported=True)
 
     async def _send_open(self) -> None:
         # Mark a pending echo only when the relay call will actually flip state

--- a/custom_components/cover_time_based/cover_wrapped.py
+++ b/custom_components/cover_time_based/cover_wrapped.py
@@ -747,9 +747,9 @@ class WrappedCoverTimeBased(CoverTimeBased):
             if pos is not None:
                 self._log(
                     "_send_stop :: no native stop; freezing via set_cover_position(%d)",
-                    int(round(pos)),
+                    round(pos),
                 )
-                await self._call_set_cover_position(int(round(pos)))
+                await self._call_set_cover_position(round(pos))
                 return
         await self._call_cover_service("stop_cover")
 

--- a/custom_components/cover_time_based/drivers.py
+++ b/custom_components/cover_time_based/drivers.py
@@ -51,7 +51,7 @@ class NativePositionDriver(PositionDriver):
     async def command_move(self, target, command, already_moving_same_dir) -> None:
         cover = self._cover
         cover._require_movement_target_available(cover._cover_entity_id)
-        position = int(round(target))
+        position = round(target)
         cover._log(
             "_command_position_move :: forwarding set_cover_position(%d)", position
         )

--- a/custom_components/cover_time_based/travel_calculator.py
+++ b/custom_components/cover_time_based/travel_calculator.py
@@ -11,8 +11,8 @@ Home Assistant's cover position convention (0=closed, 100=open).
 
 from __future__ import annotations
 
-from enum import Enum
 import time
+from enum import Enum
 
 
 class TravelStatus(Enum):

--- a/custom_components/cover_time_based/websocket_api.py
+++ b/custom_components/cover_time_based/websocket_api.py
@@ -11,18 +11,20 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from .calibration import CALIBRATABLE_ATTRIBUTES
+from .const import DOMAIN
 from .cover import (
     CONF_ASSUMED_STATE,
     CONF_CLOSE_INCLUDES_TILT,
     CONF_CLOSE_SWITCH_ENTITY_ID,
     CONF_CONTROL_MODE,
     CONF_COVER_ENTITY_ID,
+    CONF_ENDPOINT_RUNON_TIME,
     CONF_FORCE_ENDPOINT_REDRIVE,
     CONF_FORCE_TIME_BASED_POSITION,
     CONF_IGNORE_REPORTED_POSITION,
     CONF_INVERT,
-    CONF_MIN_MOVEMENT_TIME,
     CONF_MAX_TILT_ALLOWED_POSITION,
+    CONF_MIN_MOVEMENT_TIME,
     CONF_OPEN_SWITCH_ENTITY_ID,
     CONF_PULSE_TIME,
     CONF_RELAY_REPORTS_OFF,
@@ -30,7 +32,6 @@ from .cover import (
     CONF_SAFE_TILT_POSITION,
     CONF_SEND_ENDPOINT_STOP,
     CONF_STOP_SWITCH_ENTITY_ID,
-    CONF_ENDPOINT_RUNON_TIME,
     CONF_TILT_CLOSE_SWITCH,
     CONF_TILT_MODE,
     CONF_TILT_OPEN_SWITCH,
@@ -58,7 +59,6 @@ from .cover import (
     DEFAULT_REPORTS_COMMAND_NOT_ENDPOINT,
     DEFAULT_SEND_ENDPOINT_STOP,
 )
-from .const import DOMAIN
 from .helpers import resolve_entity_or_none
 
 _LOGGER = logging.getLogger(__name__)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,21 +1,30 @@
 """Shared fixtures for cover_time_based tests."""
 
 import asyncio
-
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
+from custom_components.cover_time_based.const import (
+    CONF_CLOSE_INCLUDES_TILT,
+    CONF_FORCE_ENDPOINT_REDRIVE,
+    CONF_FORCE_TIME_BASED_POSITION,
+    CONF_IGNORE_REPORTED_POSITION,
+    CONF_INVERT,
+    CONF_REPORTS_COMMAND_NOT_ENDPOINT,
+    CONF_SEND_ENDPOINT_STOP,
+)
 from custom_components.cover_time_based.cover import (
     CONF_CLOSE_SWITCH_ENTITY_ID,
     CONF_CONTROL_MODE,
     CONF_COVER_ENTITY_ID,
+    CONF_ENDPOINT_RUNON_TIME,
     CONF_MAX_TILT_ALLOWED_POSITION,
     CONF_MIN_MOVEMENT_TIME,
     CONF_OPEN_SWITCH_ENTITY_ID,
     CONF_PULSE_TIME,
     CONF_SAFE_TILT_POSITION,
     CONF_STOP_SWITCH_ENTITY_ID,
-    CONF_ENDPOINT_RUNON_TIME,
     CONF_TILT_CLOSE_SWITCH,
     CONF_TILT_MODE,
     CONF_TILT_OPEN_SWITCH,
@@ -30,15 +39,6 @@ from custom_components.cover_time_based.cover import (
     CONTROL_MODE_WRAPPED,
     DEFAULT_PULSE_TIME,
     _create_cover_from_options,
-)
-from custom_components.cover_time_based.const import (
-    CONF_CLOSE_INCLUDES_TILT,
-    CONF_FORCE_ENDPOINT_REDRIVE,
-    CONF_FORCE_TIME_BASED_POSITION,
-    CONF_IGNORE_REPORTED_POSITION,
-    CONF_INVERT,
-    CONF_REPORTS_COMMAND_NOT_ENDPOINT,
-    CONF_SEND_ENDPOINT_STOP,
 )
 
 DEFAULT_TRAVEL_TIME = 30

--- a/tests/integration/test_feedback.py
+++ b/tests/integration/test_feedback.py
@@ -7,9 +7,9 @@ movement).
 
 from __future__ import annotations
 
+import time as time_mod
 from datetime import timedelta
 from unittest.mock import patch
-import time as time_mod
 
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util

--- a/tests/integration/test_modes.py
+++ b/tests/integration/test_modes.py
@@ -5,9 +5,9 @@ Tests toggle mode stop-before-reverse and pulse mode relay pulsing.
 
 from __future__ import annotations
 
+import time as time_mod
 from datetime import timedelta
 from unittest.mock import patch
-import time as time_mod
 
 import pytest
 from homeassistant.core import HomeAssistant

--- a/tests/integration/test_movement.py
+++ b/tests/integration/test_movement.py
@@ -7,9 +7,9 @@ through the real HA service calls and event bus.
 from __future__ import annotations
 
 import asyncio
+import time as time_mod
 from datetime import timedelta
 from unittest.mock import patch
-import time as time_mod
 
 import pytest
 from homeassistant.core import HomeAssistant

--- a/tests/integration/test_tilt.py
+++ b/tests/integration/test_tilt.py
@@ -5,9 +5,9 @@ Tests sequential tilt constraints through real HA service calls.
 
 from __future__ import annotations
 
+import time as time_mod
 from datetime import timedelta
 from unittest.mock import patch
-import time as time_mod
 
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util

--- a/tests/test_base_movement.py
+++ b/tests/test_base_movement.py
@@ -12,17 +12,16 @@ These tests exercise the movement coordination logic in cover_base.py:
 
 import asyncio
 from types import SimpleNamespace
-
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from custom_components.cover_time_based.cover import CONTROL_MODE_TOGGLE
+import pytest
 from homeassistant.const import (
     SERVICE_CLOSE_COVER,
     SERVICE_OPEN_COVER,
     SERVICE_STOP_COVER,
 )
 
+from custom_components.cover_time_based.cover import CONTROL_MODE_TOGGLE
 
 # ===================================================================
 # Travel endpoint movement (async_close_cover / async_open_cover)

--- a/tests/test_bump_dev_script.py
+++ b/tests/test_bump_dev_script.py
@@ -40,6 +40,7 @@ def _run(cwd: Path, *args: str, env: dict | None = None) -> subprocess.Completed
         cwd=cwd,
         capture_output=True,
         text=True,
+        check=False,
         env=env or _clean_env(),
     )
 

--- a/tests/test_bump_version.py
+++ b/tests/test_bump_version.py
@@ -25,6 +25,7 @@ def _run(cwd: Path, *args: str) -> subprocess.CompletedProcess:
         cwd=cwd,
         capture_output=True,
         text=True,
+        check=False,
         env=_clean_env(),
     )
 

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -1,9 +1,9 @@
 """Tests for calibration services."""
 
 import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from unittest.mock import patch, AsyncMock, MagicMock
 
 
 class TestConfigEntryAccess:
@@ -38,12 +38,12 @@ class TestCalibrationState:
     def test_constants_defined(self):
         """Calibration constants should be accessible."""
         from custom_components.cover_time_based.calibration import (
-            CALIBRATION_STEP_PAUSE,
-            CALIBRATION_OVERHEAD_STEPS,
-            CALIBRATION_TILT_OVERHEAD_STEPS,
-            CALIBRATION_MIN_MOVEMENT_START,
-            CALIBRATION_MIN_MOVEMENT_INCREMENT,
             CALIBRATABLE_ATTRIBUTES,
+            CALIBRATION_MIN_MOVEMENT_INCREMENT,
+            CALIBRATION_MIN_MOVEMENT_START,
+            CALIBRATION_OVERHEAD_STEPS,
+            CALIBRATION_STEP_PAUSE,
+            CALIBRATION_TILT_OVERHEAD_STEPS,
             SERVICE_START_CALIBRATION,
             SERVICE_STOP_CALIBRATION,
         )
@@ -550,24 +550,27 @@ class TestCalibrationEdgeCases:
 
     def test_resolve_direction_explicit_close(self, make_cover):
         """_resolve_direction returns CLOSE for explicit 'close'."""
-        from custom_components.cover_time_based.cover_base import CoverTimeBased
         from homeassistant.const import SERVICE_CLOSE_COVER
+
+        from custom_components.cover_time_based.cover_base import CoverTimeBased
 
         result = CoverTimeBased._resolve_direction("close", 75)
         assert result == SERVICE_CLOSE_COVER
 
     def test_resolve_direction_explicit_open(self, make_cover):
         """_resolve_direction returns OPEN for explicit 'open'."""
-        from custom_components.cover_time_based.cover_base import CoverTimeBased
         from homeassistant.const import SERVICE_OPEN_COVER
+
+        from custom_components.cover_time_based.cover_base import CoverTimeBased
 
         result = CoverTimeBased._resolve_direction("open", 25)
         assert result == SERVICE_OPEN_COVER
 
     def test_resolve_direction_auto_from_low_position(self, make_cover):
         """_resolve_direction auto-detects OPEN when position < 50."""
-        from custom_components.cover_time_based.cover_base import CoverTimeBased
         from homeassistant.const import SERVICE_OPEN_COVER
+
+        from custom_components.cover_time_based.cover_base import CoverTimeBased
 
         result = CoverTimeBased._resolve_direction(None, 25)
         assert result == SERVICE_OPEN_COVER
@@ -688,19 +691,21 @@ class TestCalibrationRestoreOnStopFailure:
         """A raise from _calibration_stop during timeout must not skip restore."""
         cover = make_cover(travel_startup_delay=0.5)
         cover.travel_calc.set_position(100)
-        with patch.object(cover, "async_write_ha_state"):
-            with patch.object(
+        with (
+            patch.object(cover, "async_write_ha_state"),
+            patch.object(
                 cover,
                 "_calibration_stop",
                 AsyncMock(side_effect=RuntimeError("relay offline")),
-            ):
-                await cover.start_calibration(
-                    attribute="travel_startup_delay", timeout=0.02
-                )
-                assert cover._travel_startup_delay is None  # zeroed for the test
-                timeout_task = cover._calibration.timeout_task
-                with pytest.raises(RuntimeError, match="relay offline"):
-                    await timeout_task
+            ),
+        ):
+            await cover.start_calibration(
+                attribute="travel_startup_delay", timeout=0.02
+            )
+            assert cover._travel_startup_delay is None  # zeroed for the test
+            timeout_task = cover._calibration.timeout_task
+            with pytest.raises(RuntimeError, match="relay offline"):
+                await timeout_task
         assert cover._calibration is None
         assert cover._travel_startup_delay == 0.5
 
@@ -716,13 +721,15 @@ class TestCalibrationRestoreOnStopFailure:
                 attribute="travel_startup_delay", timeout=300.0
             )
             assert cover._travel_startup_delay is None  # zeroed for the test
-            with patch.object(
-                cover,
-                "_calibration_stop",
-                AsyncMock(side_effect=RuntimeError("relay offline")),
+            with (
+                patch.object(
+                    cover,
+                    "_calibration_stop",
+                    AsyncMock(side_effect=RuntimeError("relay offline")),
+                ),
+                pytest.raises(RuntimeError, match="relay offline"),
             ):
-                with pytest.raises(RuntimeError, match="relay offline"):
-                    await cover.stop_calibration()
+                await cover.stop_calibration()
         assert cover._calibration is None
         assert cover._travel_startup_delay == 0.5
 
@@ -783,8 +790,9 @@ class TestSetPositionAfterCalibrationNoTilt:
         _set_position_after_calibration with a tilt attribute.
         It should return early without error.
         """
-        from custom_components.cover_time_based.calibration import CalibrationState
         from homeassistant.const import SERVICE_CLOSE_COVER
+
+        from custom_components.cover_time_based.calibration import CalibrationState
 
         cover = make_cover()  # No tilt configured => no tilt_calc
         # Ensure no tilt_calc exists
@@ -812,6 +820,7 @@ class TestCalibrationResultOpenDirection:
         in the OPEN direction.
         """
         import time as time_mod
+
         from homeassistant.const import SERVICE_OPEN_COVER
 
         cover = make_cover(travel_time_close=60.0, travel_time_open=60.0)
@@ -843,6 +852,7 @@ class TestCalibrationResultOpenDirection:
         in the OPEN direction.
         """
         import time as time_mod
+
         from homeassistant.const import SERVICE_OPEN_COVER
 
         cover = make_cover(tilt_time_close=10.0, tilt_time_open=10.0)
@@ -1028,42 +1038,40 @@ class TestMinMovementPulseLoop:
         cover.hass.config_entries.async_get_entry = MagicMock(return_value=mock_entry)
         cover.hass.config_entries.async_update_entry = MagicMock()
 
-        with patch.object(cover, "async_write_ha_state"):
-            # Patch the initial pause to be very short so pulses start quickly.
-            # These constants are lazily imported from the calibration module
-            # inside _run_min_movement_pulses, so patching the source works.
-            with (
-                patch(
-                    "custom_components.cover_time_based.calibration.CALIBRATION_MIN_MOVEMENT_INITIAL_PAUSE",
-                    0.05,
-                ),
-                patch(
-                    "custom_components.cover_time_based.calibration.CALIBRATION_STEP_PAUSE",
-                    0.05,
-                ),
-            ):
-                await cover.start_calibration(
-                    attribute="min_movement_time", timeout=60.0
-                )
-                # Wait for at least 2 pulses to complete
-                for _ in range(200):
-                    await asyncio.sleep(0.05)
-                    if (
-                        cover._calibration is not None
-                        and cover._calibration.step_count >= 2
-                    ):
-                        break
+        # Patch the initial pause to be very short so pulses start quickly.
+        # These constants are lazily imported from the calibration module
+        # inside _run_min_movement_pulses, so patching the source works.
+        with (
+            patch.object(cover, "async_write_ha_state"),
+            patch(
+                "custom_components.cover_time_based.calibration.CALIBRATION_MIN_MOVEMENT_INITIAL_PAUSE",
+                0.05,
+            ),
+            patch(
+                "custom_components.cover_time_based.calibration.CALIBRATION_STEP_PAUSE",
+                0.05,
+            ),
+        ):
+            await cover.start_calibration(attribute="min_movement_time", timeout=60.0)
+            # Wait for at least 2 pulses to complete
+            for _ in range(200):
+                await asyncio.sleep(0.05)
+                if (
+                    cover._calibration is not None
+                    and cover._calibration.step_count >= 2
+                ):
+                    break
 
-                assert cover._calibration is not None
-                assert cover._calibration.step_count >= 2
-                assert cover._calibration.last_pulse_duration is not None
-                # Each pulse is 0.1s + 0.1s increment, so after 2 pulses
-                # last_pulse_duration should be 0.2
-                assert cover._calibration.last_pulse_duration == pytest.approx(
-                    0.1 * cover._calibration.step_count, abs=0.01
-                )
+            assert cover._calibration is not None
+            assert cover._calibration.step_count >= 2
+            assert cover._calibration.last_pulse_duration is not None
+            # Each pulse is 0.1s + 0.1s increment, so after 2 pulses
+            # last_pulse_duration should be 0.2
+            assert cover._calibration.last_pulse_duration == pytest.approx(
+                0.1 * cover._calibration.step_count, abs=0.01
+            )
 
-                result = await cover.stop_calibration()
+            result = await cover.stop_calibration()
 
         assert cover._calibration is None
         assert result["attribute"] == "min_movement_time"

--- a/tests/test_changelog_section.py
+++ b/tests/test_changelog_section.py
@@ -54,6 +54,7 @@ def _run(cwd: Path, *args: str) -> subprocess.CompletedProcess:
         cwd=cwd,
         capture_output=True,
         text=True,
+        check=False,
         env=_clean_env(),
     )
 

--- a/tests/test_close_includes_tilt.py
+++ b/tests/test_close_includes_tilt.py
@@ -8,8 +8,9 @@ mocking _async_move_to_endpoint would bypass _plan_tilt_for_travel entirely
 and hide bugs in how it honors close_includes_tilt.
 """
 
-import pytest
 from unittest.mock import AsyncMock, patch
+
+import pytest
 
 from custom_components.cover_time_based.travel_calculator import TravelStatus
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,8 +1,8 @@
 """Tests for CoverTimeBasedConfigFlow."""
 
-import pytest
 from unittest.mock import MagicMock
 
+import pytest
 from homeassistant.const import CONF_NAME
 
 from custom_components.cover_time_based.config_flow import CoverTimeBasedConfigFlow

--- a/tests/test_cover_base_extra.py
+++ b/tests/test_cover_base_extra.py
@@ -7,17 +7,15 @@ name fallback, _stop_travel_if_traveling with tilt.
 """
 
 import asyncio
-
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from homeassistant.components.cover import (
     ATTR_CURRENT_POSITION,
     ATTR_CURRENT_TILT_POSITION,
     CoverEntityFeature,
 )
 from homeassistant.const import SERVICE_CLOSE_COVER, SERVICE_OPEN_COVER
-
 
 # ===================================================================
 # Name / unique_id / device_class / assumed_state properties
@@ -33,11 +31,11 @@ class TestBasicProperties:
 
     def test_name_falls_back_to_device_id(self, make_cover):
         from custom_components.cover_time_based.cover import (
-            _create_cover_from_options,
+            CONF_CLOSE_SWITCH_ENTITY_ID,
             CONF_CONTROL_MODE,
             CONF_OPEN_SWITCH_ENTITY_ID,
-            CONF_CLOSE_SWITCH_ENTITY_ID,
             CONTROL_MODE_SWITCH,
+            _create_cover_from_options,
         )
 
         cover = _create_cover_from_options(
@@ -71,7 +69,6 @@ class TestBasicProperties:
         this guards against any mode dropping it in its **kwargs chain.
         """
         from custom_components.cover_time_based.cover import (
-            _create_cover_from_options,
             CONF_ASSUMED_STATE,
             CONF_CLOSE_SWITCH_ENTITY_ID,
             CONF_CONTROL_MODE,
@@ -81,6 +78,7 @@ class TestBasicProperties:
             CONTROL_MODE_SWITCH,
             CONTROL_MODE_TOGGLE,
             CONTROL_MODE_WRAPPED,
+            _create_cover_from_options,
         )
 
         mode_map = {
@@ -229,11 +227,13 @@ class TestStateRestoration:
         old_state = MagicMock()
         old_state.attributes = {ATTR_CURRENT_POSITION: 70}
 
-        with patch.object(cover, "async_get_last_state", return_value=old_state):
-            with patch(
+        with (
+            patch.object(cover, "async_get_last_state", return_value=old_state),
+            patch(
                 "custom_components.cover_time_based.cover_base.async_track_state_change_event"
-            ):
-                await cover.async_added_to_hass()
+            ),
+        ):
+            await cover.async_added_to_hass()
 
         assert cover.travel_calc.current_position() == 70
 
@@ -247,11 +247,13 @@ class TestStateRestoration:
             ATTR_CURRENT_TILT_POSITION: 80,
         }
 
-        with patch.object(cover, "async_get_last_state", return_value=old_state):
-            with patch(
+        with (
+            patch.object(cover, "async_get_last_state", return_value=old_state),
+            patch(
                 "custom_components.cover_time_based.cover_base.async_track_state_change_event"
-            ):
-                await cover.async_added_to_hass()
+            ),
+        ):
+            await cover.async_added_to_hass()
 
         assert cover.travel_calc.current_position() == 60
         assert cover.tilt_calc.current_position() == 80
@@ -260,11 +262,13 @@ class TestStateRestoration:
     async def test_no_restore_when_no_old_state(self, make_cover):
         cover = make_cover()
 
-        with patch.object(cover, "async_get_last_state", return_value=None):
-            with patch(
+        with (
+            patch.object(cover, "async_get_last_state", return_value=None),
+            patch(
                 "custom_components.cover_time_based.cover_base.async_track_state_change_event"
-            ):
-                await cover.async_added_to_hass()
+            ),
+        ):
+            await cover.async_added_to_hass()
 
         # Position should remain unset
         assert cover.travel_calc.current_position() is None
@@ -276,11 +280,13 @@ class TestStateRestoration:
         old_state = MagicMock()
         old_state.attributes = {}
 
-        with patch.object(cover, "async_get_last_state", return_value=old_state):
-            with patch(
+        with (
+            patch.object(cover, "async_get_last_state", return_value=old_state),
+            patch(
                 "custom_components.cover_time_based.cover_base.async_track_state_change_event"
-            ):
-                await cover.async_added_to_hass()
+            ),
+        ):
+            await cover.async_added_to_hass()
 
         assert cover.travel_calc.current_position() is None
 
@@ -288,11 +294,13 @@ class TestStateRestoration:
     async def test_registers_state_listeners_for_switch_entities(self, make_cover):
         cover = make_cover(stop_switch="switch.stop")
 
-        with patch.object(cover, "async_get_last_state", return_value=None):
-            with patch(
+        with (
+            patch.object(cover, "async_get_last_state", return_value=None),
+            patch(
                 "custom_components.cover_time_based.cover_base.async_track_state_change_event"
-            ) as mock_track:
-                await cover.async_added_to_hass()
+            ) as mock_track,
+        ):
+            await cover.async_added_to_hass()
 
         # Should register listeners for open, close, and stop switches
         assert mock_track.call_count == 3
@@ -347,9 +355,11 @@ class TestAutoUpdaterHook:
         cover.travel_calc.start_travel(100)
 
         mock_update = MagicMock()
-        with patch.object(cover, "async_schedule_update_ha_state", mock_update):
-            with patch.object(cover, "auto_stop_if_necessary", new_callable=AsyncMock):
-                cover.auto_updater_hook(None)
+        with (
+            patch.object(cover, "async_schedule_update_ha_state", mock_update),
+            patch.object(cover, "auto_stop_if_necessary", new_callable=AsyncMock),
+        ):
+            cover.auto_updater_hook(None)
 
         mock_update.assert_called_once()
 
@@ -362,9 +372,11 @@ class TestAutoUpdaterHook:
         unsub = MagicMock()
         cover._unsubscribe_auto_updater = unsub
 
-        with patch.object(cover, "async_schedule_update_ha_state"):
-            with patch.object(cover, "auto_stop_if_necessary", new_callable=AsyncMock):
-                cover.auto_updater_hook(None)
+        with (
+            patch.object(cover, "async_schedule_update_ha_state"),
+            patch.object(cover, "auto_stop_if_necessary", new_callable=AsyncMock),
+        ):
+            cover.auto_updater_hook(None)
 
         # Auto updater should have been stopped
         unsub.assert_called_once()
@@ -849,9 +861,11 @@ class TestHandleCommandExternallyTriggered:
         cover = make_cover()
         cover._triggered_externally = True
 
-        with patch.object(cover, "_send_close", new_callable=AsyncMock) as mock_send:
-            with patch.object(cover, "async_write_ha_state"):
-                await cover._async_handle_command(SERVICE_CLOSE_COVER)
+        with (
+            patch.object(cover, "_send_close", new_callable=AsyncMock) as mock_send,
+            patch.object(cover, "async_write_ha_state"),
+        ):
+            await cover._async_handle_command(SERVICE_CLOSE_COVER)
 
         mock_send.assert_not_awaited()
 
@@ -860,9 +874,11 @@ class TestHandleCommandExternallyTriggered:
         cover = make_cover()
         cover._triggered_externally = True
 
-        with patch.object(cover, "_send_open", new_callable=AsyncMock) as mock_send:
-            with patch.object(cover, "async_write_ha_state"):
-                await cover._async_handle_command(SERVICE_OPEN_COVER)
+        with (
+            patch.object(cover, "_send_open", new_callable=AsyncMock) as mock_send,
+            patch.object(cover, "async_write_ha_state"),
+        ):
+            await cover._async_handle_command(SERVICE_OPEN_COVER)
 
         mock_send.assert_not_awaited()
 
@@ -871,9 +887,11 @@ class TestHandleCommandExternallyTriggered:
         cover = make_cover()
         cover._triggered_externally = True
 
-        with patch.object(cover, "_send_stop", new_callable=AsyncMock) as mock_send:
-            with patch.object(cover, "async_write_ha_state"):
-                await cover._async_handle_command("stop_cover")
+        with (
+            patch.object(cover, "_send_stop", new_callable=AsyncMock) as mock_send,
+            patch.object(cover, "async_write_ha_state"),
+        ):
+            await cover._async_handle_command("stop_cover")
 
         mock_send.assert_not_awaited()
 
@@ -894,9 +912,11 @@ class TestStopCoverExternallyTriggered:
         cover._last_command = SERVICE_CLOSE_COVER
         cover._triggered_externally = True
 
-        with patch.object(cover, "_send_stop", new_callable=AsyncMock) as mock_send:
-            with patch.object(cover, "async_write_ha_state"):
-                await cover.async_stop_cover()
+        with (
+            patch.object(cover, "_send_stop", new_callable=AsyncMock) as mock_send,
+            patch.object(cover, "async_write_ha_state"),
+        ):
+            await cover.async_stop_cover()
 
         mock_send.assert_not_awaited()
 
@@ -1150,9 +1170,11 @@ class TestUnconfiguredEntity:
         from homeassistant.exceptions import HomeAssistantError
 
         cover = make_cover(open_switch="", close_switch="")
-        with pytest.raises(HomeAssistantError, match="not configured"):
-            with patch.object(cover, "async_write_ha_state"):
-                await cover.async_set_cover_position(position=50)
+        with (
+            pytest.raises(HomeAssistantError, match="not configured"),
+            patch.object(cover, "async_write_ha_state"),
+        ):
+            await cover.async_set_cover_position(position=50)
 
     @pytest.mark.asyncio
     async def test_require_travel_time_raises(self, make_cover):
@@ -1162,9 +1184,11 @@ class TestUnconfiguredEntity:
         cover = make_cover()
         cover._travel_time_close = None
         cover._travel_time_open = None
-        with pytest.raises(HomeAssistantError, match="[Tt]ravel time"):
-            with patch.object(cover, "async_write_ha_state"):
-                await cover.async_set_cover_position(position=50)
+        with (
+            pytest.raises(HomeAssistantError, match="[Tt]ravel time"),
+            patch.object(cover, "async_write_ha_state"),
+        ):
+            await cover.async_set_cover_position(position=50)
 
 
 # ===================================================================

--- a/tests/test_cover_factory.py
+++ b/tests/test_cover_factory.py
@@ -1,7 +1,8 @@
 """Tests for cover factory and YAML config parsing in cover.py."""
 
-import pytest
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from custom_components.cover_time_based.cover import (
     CONF_CLOSE_SWITCH_ENTITY_ID,
@@ -17,17 +18,17 @@ from custom_components.cover_time_based.cover import (
     CONF_RELAY_REPORTS_OFF,
     CONF_STOP_SWITCH_ENTITY_ID,
     CONF_TILT_STARTUP_DELAY,
+    CONF_TILT_TIME_CLOSE,
+    CONF_TILT_TIME_OPEN,
     CONF_TILTING_TIME_DOWN,
     CONF_TILTING_TIME_UP,
     CONF_TRAVEL_DELAY_AT_END,
     CONF_TRAVEL_MOVES_WITH_TILT,
     CONF_TRAVEL_STARTUP_DELAY,
-    CONF_TRAVELLING_TIME_DOWN,
-    CONF_TRAVELLING_TIME_UP,
     CONF_TRAVEL_TIME_CLOSE,
     CONF_TRAVEL_TIME_OPEN,
-    CONF_TILT_TIME_CLOSE,
-    CONF_TILT_TIME_OPEN,
+    CONF_TRAVELLING_TIME_DOWN,
+    CONF_TRAVELLING_TIME_UP,
     CONTROL_MODE_PULSE,
     CONTROL_MODE_SWITCH,
     CONTROL_MODE_TOGGLE,
@@ -37,8 +38,8 @@ from custom_components.cover_time_based.cover import (
     _resolve_tilt_strategy,
     devices_from_config,
 )
-from custom_components.cover_time_based.cover_switch_mode import SwitchModeCover
 from custom_components.cover_time_based.cover_pulse_mode import PulseModeCover
+from custom_components.cover_time_based.cover_switch_mode import SwitchModeCover
 from custom_components.cover_time_based.cover_toggle_mode import ToggleModeCover
 from custom_components.cover_time_based.cover_toggle_opposite_mode import (
     ToggleOppositeModeCover,
@@ -50,7 +51,6 @@ from custom_components.cover_time_based.tilt_strategies import (
     SequentialCloseTilt,
     SequentialOpenTilt,
 )
-
 
 # ===================================================================
 # _create_cover_from_options
@@ -554,6 +554,7 @@ class TestInputModeSchemaValidation:
     )
     def test_switch_cover_schema_accepts_input_mode(self, value):
         import voluptuous as vol
+
         from custom_components.cover_time_based.cover import SWITCH_COVER_SCHEMA
 
         validated = vol.Schema(SWITCH_COVER_SCHEMA)(
@@ -568,6 +569,7 @@ class TestInputModeSchemaValidation:
 
     def test_switch_cover_schema_rejects_unknown_input_mode(self):
         import voluptuous as vol
+
         from custom_components.cover_time_based.cover import SWITCH_COVER_SCHEMA
 
         with pytest.raises(vol.Invalid):
@@ -634,14 +636,16 @@ class TestAsyncSetupPlatform:
         }
 
         platform = MagicMock()
-        with patch("custom_components.cover_time_based.cover.async_create_issue"):
-            with patch(
+        with (
+            patch("custom_components.cover_time_based.cover.async_create_issue"),
+            patch(
                 "custom_components.cover_time_based.cover.entity_platform.current_platform"
-            ) as mock_platform:
-                mock_platform.get.return_value = platform
-                await async_setup_platform(
-                    hass, config, lambda entities: added_entities.extend(entities)
-                )
+            ) as mock_platform,
+        ):
+            mock_platform.get.return_value = platform
+            await async_setup_platform(
+                hass, config, lambda entities: added_entities.extend(entities)
+            )
 
         assert len(added_entities) == 1
         assert isinstance(added_entities[0], SwitchModeCover)

--- a/tests/test_cover_pulse_mode.py
+++ b/tests/test_cover_pulse_mode.py
@@ -8,12 +8,11 @@ await those tasks to verify the full call sequence.
 """
 
 import asyncio
-
-import pytest
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
-from custom_components.cover_time_based.cover_pulse_mode import PulseModeCover
+import pytest
 
+from custom_components.cover_time_based.cover_pulse_mode import PulseModeCover
 
 # ---------------------------------------------------------------------------
 # Factory

--- a/tests/test_cover_services.py
+++ b/tests/test_cover_services.py
@@ -2,27 +2,26 @@
 
 import json
 from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 import voluptuous as vol
 import yaml
-from unittest.mock import AsyncMock, MagicMock
-
 from homeassistant.exceptions import HomeAssistantError
 
-from custom_components.cover_time_based.helpers import resolve_entity
 from custom_components.cover_time_based.cover import (
-    _register_services,
-    _create_cover_from_options,
+    CONF_CLOSE_SWITCH_ENTITY_ID,
     CONF_CONTROL_MODE,
     CONF_OPEN_SWITCH_ENTITY_ID,
-    CONF_CLOSE_SWITCH_ENTITY_ID,
     CONF_TRAVEL_TIME_CLOSE,
     CONF_TRAVEL_TIME_OPEN,
     CONTROL_MODE_SWITCH,
     SERVICE_START_CALIBRATION,
     SERVICE_STOP_CALIBRATION,
+    _create_cover_from_options,
+    _register_services,
 )
+from custom_components.cover_time_based.helpers import resolve_entity
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 COMPONENT_DIR = REPO_ROOT / "custom_components" / "cover_time_based"

--- a/tests/test_cover_switch_mode.py
+++ b/tests/test_cover_switch_mode.py
@@ -5,16 +5,15 @@ service calls for the latching relay (switch) mode.
 """
 
 import asyncio
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock, call, patch
 
 from custom_components.cover_time_based.cover import (
     CONTROL_MODE_PULSE,
     CONTROL_MODE_TOGGLE,
 )
 from custom_components.cover_time_based.cover_switch_mode import SwitchModeCover
-
 
 # ---------------------------------------------------------------------------
 # Factory

--- a/tests/test_cover_toggle_mode.py
+++ b/tests/test_cover_toggle_mode.py
@@ -16,17 +16,15 @@ restart), to guarantee the motor sees a genuine OFF->ON edge.
 import asyncio
 import logging
 from types import SimpleNamespace
-
-import pytest
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
+import pytest
 from homeassistant.const import (
     SERVICE_CLOSE_COVER,
     SERVICE_OPEN_COVER,
 )
 
 from custom_components.cover_time_based.cover_toggle_mode import ToggleModeCover
-
 
 # ---------------------------------------------------------------------------
 # Factory

--- a/tests/test_cover_toggle_opposite_mode.py
+++ b/tests/test_cover_toggle_opposite_mode.py
@@ -8,10 +8,9 @@ direction.
 
 import asyncio
 from types import SimpleNamespace
-
-import pytest
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
+import pytest
 from homeassistant.const import SERVICE_CLOSE_COVER, SERVICE_OPEN_COVER
 
 from custom_components.cover_time_based.cover_toggle_opposite_mode import (

--- a/tests/test_cover_wrapped.py
+++ b/tests/test_cover_wrapped.py
@@ -4,15 +4,13 @@ Each test verifies that the correct cover.* service call is made.
 """
 
 import asyncio
-
-import pytest
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
+import pytest
 from homeassistant.components.cover import ATTR_CURRENT_POSITION
 from homeassistant.const import STATE_CLOSED, STATE_UNAVAILABLE
 
 from custom_components.cover_time_based.cover_wrapped import WrappedCoverTimeBased
-
 
 # CoverEntityFeature bit values (OPEN=1, CLOSE=2, SET_POSITION=4, STOP=8).
 _F_OPEN = 1
@@ -1279,8 +1277,9 @@ class TestNativeCouplingNeutralized:
 
     @pytest.mark.asyncio
     async def test_move_to_rejects_unavailable_target(self):
-        from custom_components.cover_time_based.drivers import NativeTiltDriver
         from homeassistant.exceptions import HomeAssistantError
+
+        from custom_components.cover_time_based.drivers import NativeTiltDriver
 
         cover = _make_wrapped_cover(
             tilt_time_close=5, tilt_time_open=5, tilt_mode="inline"

--- a/tests/test_coverage_extras.py
+++ b/tests/test_coverage_extras.py
@@ -6,10 +6,9 @@ Covers:
 """
 
 import asyncio
-
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from homeassistant.const import SERVICE_CLOSE_COVER, SERVICE_OPEN_COVER
 from homeassistant.exceptions import HomeAssistantError
 
@@ -20,7 +19,6 @@ from custom_components.cover_time_based.tilt_strategies.planning import (
     extract_coupled_travel,
 )
 from custom_components.cover_time_based.travel_calculator import TravelCalculator
-
 
 # ===================================================================
 # planning.py: extract_coupled_tilt
@@ -398,9 +396,11 @@ class TestExternalMovementAutoStop:
         cover._self_initiated_movement = False
         cover._last_command = SERVICE_CLOSE_COVER
 
-        with patch.object(cover, "async_write_ha_state"):
-            with patch.object(cover, "_send_stop", new_callable=AsyncMock) as mock_stop:
-                await cover.auto_stop_if_necessary()
+        with (
+            patch.object(cover, "async_write_ha_state"),
+            patch.object(cover, "_send_stop", new_callable=AsyncMock) as mock_stop,
+        ):
+            await cover.auto_stop_if_necessary()
 
         # Relay stop should NOT have been called
         mock_stop.assert_not_awaited()
@@ -421,12 +421,14 @@ class TestExternalMovementAutoStop:
         cover._self_initiated_movement = False
         cover._last_command = SERVICE_OPEN_COVER
 
-        with patch.object(cover, "async_write_ha_state"):
-            with patch.object(
+        with (
+            patch.object(cover, "async_write_ha_state"),
+            patch.object(
                 cover._tilt_strategy,
                 "snap_trackers_to_physical",
-            ) as mock_snap:
-                await cover.auto_stop_if_necessary()
+            ) as mock_snap,
+        ):
+            await cover.auto_stop_if_necessary()
 
         # snap_trackers_to_physical should have been called
         mock_snap.assert_called_once_with(cover.travel_calc, cover.tilt_calc)
@@ -502,11 +504,13 @@ class TestMoveEndpointStartupDelayDualMotorTiltStop:
         # Last command was OPEN, so closing (target=0) is a direction change
         cover._last_command = SERVICE_OPEN_COVER
 
-        with patch.object(cover, "async_write_ha_state"):
-            with patch.object(
+        with (
+            patch.object(cover, "async_write_ha_state"),
+            patch.object(
                 cover, "_send_tilt_stop", new_callable=AsyncMock
-            ) as mock_tilt_stop:
-                await cover._async_move_tilt_to_endpoint(target=0)
+            ) as mock_tilt_stop,
+        ):
+            await cover._async_move_tilt_to_endpoint(target=0)
 
         mock_tilt_stop.assert_awaited_once()
 
@@ -537,11 +541,13 @@ class TestMoveEndpointRelayWasOnDualMotorTiltStop:
         # Create an active delay task (not done) so _cancel_delay_task returns True
         cover._delay_task = asyncio.get_event_loop().create_future()
 
-        with patch.object(cover, "async_write_ha_state"):
-            with patch.object(
+        with (
+            patch.object(cover, "async_write_ha_state"),
+            patch.object(
                 cover, "_send_tilt_stop", new_callable=AsyncMock
-            ) as mock_tilt_stop:
-                await cover._async_move_tilt_to_endpoint(target=0)
+            ) as mock_tilt_stop,
+        ):
+            await cover._async_move_tilt_to_endpoint(target=0)
 
         mock_tilt_stop.assert_awaited_once()
 
@@ -586,9 +592,11 @@ class TestSetPositionEarlyReturnAfterDirectionChange:
                 return 51
             return 49
 
-        with patch.object(cover, "async_write_ha_state"):
-            with patch.object(TravelCalculator, "current_position", mock_current):
-                await cover.set_position(49)
+        with (
+            patch.object(cover, "async_write_ha_state"),
+            patch.object(TravelCalculator, "current_position", mock_current),
+        ):
+            await cover.set_position(49)
 
         # Early return at line 594 means _last_command is NOT updated at line 606
         assert cover._last_command == SERVICE_OPEN_COVER
@@ -622,12 +630,14 @@ class TestSetTiltPositionDirectionChangeDualMotor:
         # Last command was OPEN
         cover._last_command = SERVICE_OPEN_COVER
 
-        with patch.object(cover, "async_write_ha_state"):
-            with patch.object(
+        with (
+            patch.object(cover, "async_write_ha_state"),
+            patch.object(
                 cover, "_send_tilt_stop", new_callable=AsyncMock
-            ) as mock_tilt_stop:
-                # Set tilt to a position below current (closing) => direction change
-                await cover.set_tilt_position(20)
+            ) as mock_tilt_stop,
+        ):
+            # Set tilt to a position below current (closing) => direction change
+            await cover.set_tilt_position(20)
 
         mock_tilt_stop.assert_awaited_once()
 
@@ -673,9 +683,11 @@ class TestSetTiltPositionDirectionChangeDualMotor:
             # travel_calc
             return 50
 
-        with patch.object(cover, "async_write_ha_state"):
-            with patch.object(TravelCalculator, "current_position", mock_current):
-                await cover.set_tilt_position(49)
+        with (
+            patch.object(cover, "async_write_ha_state"),
+            patch.object(TravelCalculator, "current_position", mock_current),
+        ):
+            await cover.set_tilt_position(49)
 
         # Early return at line 669 means _last_command NOT updated at line 699
         assert cover._last_command == SERVICE_OPEN_COVER
@@ -707,11 +719,13 @@ class TestSetTiltPositionRelayWasOnDualMotor:
         # Create an active delay task so _cancel_delay_task returns True
         cover._delay_task = asyncio.get_event_loop().create_future()
 
-        with patch.object(cover, "async_write_ha_state"):
-            with patch.object(
+        with (
+            patch.object(cover, "async_write_ha_state"),
+            patch.object(
                 cover, "_send_tilt_stop", new_callable=AsyncMock
-            ) as mock_tilt_stop:
-                await cover.set_tilt_position(80)
+            ) as mock_tilt_stop,
+        ):
+            await cover.set_tilt_position(80)
 
         mock_tilt_stop.assert_awaited_once()
 
@@ -967,17 +981,19 @@ class TestTiltPreStepSendClose:
         cover.travel_calc.set_position(50)
         cover.tilt_calc.set_position(80)  # Current tilt is 80
 
-        with patch.object(cover, "async_write_ha_state"):
-            with patch.object(
+        with (
+            patch.object(cover, "async_write_ha_state"),
+            patch.object(
                 cover, "_send_tilt_close", new_callable=AsyncMock
-            ) as mock_tilt_close:
-                # tilt_target=30 < current_tilt=80 => closing_tilt=True
-                await cover._start_tilt_pre_step(
-                    tilt_target=30,
-                    travel_target=0,
-                    travel_command=SERVICE_CLOSE_COVER,
-                    restore_target=80,
-                )
+            ) as mock_tilt_close,
+        ):
+            # tilt_target=30 < current_tilt=80 => closing_tilt=True
+            await cover._start_tilt_pre_step(
+                tilt_target=30,
+                travel_target=0,
+                travel_command=SERVICE_CLOSE_COVER,
+                restore_target=80,
+            )
 
         mock_tilt_close.assert_awaited_once()
         assert cover._pending_travel_target == 0
@@ -1009,11 +1025,13 @@ class TestTiltRestoreSendOpen:
         # Set restore target to a higher value (opening)
         cover._tilt_restore_target = 80
 
-        with patch.object(cover, "async_write_ha_state"):
-            with patch.object(
+        with (
+            patch.object(cover, "async_write_ha_state"),
+            patch.object(
                 cover, "_send_tilt_open", new_callable=AsyncMock
-            ) as mock_tilt_open:
-                await cover._start_tilt_restore()
+            ) as mock_tilt_open,
+        ):
+            await cover._start_tilt_restore()
 
         mock_tilt_open.assert_awaited_once()
         assert cover._tilt_restore_active is True
@@ -1041,13 +1059,15 @@ class TestTiltSendMarkSwitchPending:
             tilt_stop_switch="switch.tilt_stop",
         )
 
-        with patch.object(
-            cover,
-            "_switch_is_on",
-            side_effect=lambda eid: eid == "switch.tilt_close",
+        with (
+            patch.object(
+                cover,
+                "_switch_is_on",
+                side_effect=lambda eid: eid == "switch.tilt_close",
+            ),
+            patch.object(cover, "_mark_switch_pending") as mock_mark,
         ):
-            with patch.object(cover, "_mark_switch_pending") as mock_mark:
-                await cover._send_tilt_open()
+            await cover._send_tilt_open()
 
         # Should mark close switch with 1 (it was on; one off echo expected)
         # and open switch with 1 (target was off; one on echo expected).
@@ -1071,13 +1091,15 @@ class TestTiltSendMarkSwitchPending:
             tilt_stop_switch="switch.tilt_stop",
         )
 
-        with patch.object(
-            cover,
-            "_switch_is_on",
-            side_effect=lambda eid: eid == "switch.tilt_open",
+        with (
+            patch.object(
+                cover,
+                "_switch_is_on",
+                side_effect=lambda eid: eid == "switch.tilt_open",
+            ),
+            patch.object(cover, "_mark_switch_pending") as mock_mark,
         ):
-            with patch.object(cover, "_mark_switch_pending") as mock_mark:
-                await cover._send_tilt_close()
+            await cover._send_tilt_close()
 
         calls = mock_mark.call_args_list
         assert any(c.args == ("switch.tilt_open", 1) for c in calls), (
@@ -1099,13 +1121,15 @@ class TestTiltSendMarkSwitchPending:
             tilt_stop_switch="switch.tilt_stop",
         )
 
-        with patch.object(
-            cover,
-            "_switch_is_on",
-            side_effect=lambda eid: eid == "switch.tilt_open",
+        with (
+            patch.object(
+                cover,
+                "_switch_is_on",
+                side_effect=lambda eid: eid == "switch.tilt_open",
+            ),
+            patch.object(cover, "_mark_switch_pending") as mock_mark,
         ):
-            with patch.object(cover, "_mark_switch_pending") as mock_mark:
-                await cover._send_tilt_stop()
+            await cover._send_tilt_stop()
 
         calls = mock_mark.call_args_list
         assert any(c.args == ("switch.tilt_open", 1) for c in calls), (
@@ -1124,13 +1148,15 @@ class TestTiltSendMarkSwitchPending:
             tilt_stop_switch="switch.tilt_stop",
         )
 
-        with patch.object(
-            cover,
-            "_switch_is_on",
-            side_effect=lambda eid: eid == "switch.tilt_close",
+        with (
+            patch.object(
+                cover,
+                "_switch_is_on",
+                side_effect=lambda eid: eid == "switch.tilt_close",
+            ),
+            patch.object(cover, "_mark_switch_pending") as mock_mark,
         ):
-            with patch.object(cover, "_mark_switch_pending") as mock_mark:
-                await cover._send_tilt_stop()
+            await cover._send_tilt_stop()
 
         calls = mock_mark.call_args_list
         assert any(c.args == ("switch.tilt_close", 1) for c in calls), (
@@ -1149,13 +1175,15 @@ class TestTiltSendMarkSwitchPending:
             tilt_stop_switch="switch.tilt_stop",
         )
 
-        with patch.object(
-            cover,
-            "_switch_is_on",
-            return_value=True,
+        with (
+            patch.object(
+                cover,
+                "_switch_is_on",
+                return_value=True,
+            ),
+            patch.object(cover, "_mark_switch_pending") as mock_mark,
         ):
-            with patch.object(cover, "_mark_switch_pending") as mock_mark:
-                await cover._send_tilt_stop()
+            await cover._send_tilt_stop()
 
         calls = mock_mark.call_args_list
         assert any(c.args == ("switch.tilt_open", 1) for c in calls), (

--- a/tests/test_direction_change_delay.py
+++ b/tests/test_direction_change_delay.py
@@ -16,13 +16,12 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+import voluptuous as vol
 from homeassistant.const import (
     SERVICE_CLOSE_COVER,
     SERVICE_OPEN_COVER,
     SERVICE_STOP_COVER,
 )
-
-import voluptuous as vol
 
 from custom_components.cover_time_based.const import (
     CONF_DIRECTION_CHANGE_DELAY,

--- a/tests/test_drivers.py
+++ b/tests/test_drivers.py
@@ -1,7 +1,8 @@
 """Unit tests for the wrapped-cover actuation drivers."""
 
-import pytest
 from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 
 from custom_components.cover_time_based.drivers import (
     NativePositionDriver,

--- a/tests/test_endpoint_self_stop.py
+++ b/tests/test_endpoint_self_stop.py
@@ -15,10 +15,9 @@ self-stops there, so the timed stop is essential.
 """
 
 import asyncio
-
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from homeassistant.const import SERVICE_CLOSE_COVER, SERVICE_OPEN_COVER
 
 from custom_components.cover_time_based.cover import (
@@ -840,7 +839,7 @@ async def test_switch_dual_motor_external_open_continues_into_travel(make_cover)
     # ... but no relay is driven — the hardware is doing the travel itself.
     relay_calls = [(c.args[1], c.args[2].get("entity_id")) for c in _ha_calls(cover)]
     assert relay_calls == [], (
-        "external continuation must not fire relays: %s" % relay_calls
+        f"external continuation must not fire relays: {relay_calls}"
     )
     await _cancel_tasks(cover)
 

--- a/tests/test_external_continuation.py
+++ b/tests/test_external_continuation.py
@@ -17,10 +17,9 @@ at the phase boundary for an externally-triggered move.
 """
 
 import asyncio
-
-import pytest
 from unittest.mock import patch
 
+import pytest
 
 RELAY_ENTITIES = (
     "switch.open",
@@ -88,7 +87,7 @@ async def test_external_tilt_prestep_continuation_fires_no_relays(make_cover):
 
     relay_calls = _relay_calls(cover, n_before)
     assert relay_calls == [], (
-        "external tilt-pre-step continuation fired relay commands: %s" % relay_calls
+        f"external tilt-pre-step continuation fired relay commands: {relay_calls}"
     )
     # Second phase is still *tracked* so the integration mirrors the motor.
     assert cover.travel_calc.is_traveling()
@@ -139,7 +138,7 @@ async def test_external_travel_prestep_continuation_fires_no_relays(make_cover):
 
     relay_calls = _relay_calls(cover, n_before)
     assert relay_calls == [], (
-        "external travel-pre-step continuation fired relay commands: %s" % relay_calls
+        f"external travel-pre-step continuation fired relay commands: {relay_calls}"
     )
     # Second phase (tilt) is still tracked.
     assert cover.tilt_calc.is_traveling()

--- a/tests/test_force_endpoint_redrive.py
+++ b/tests/test_force_endpoint_redrive.py
@@ -7,9 +7,9 @@ re-driven for the full travel time (modeled from the opposite endpoint) instead
 of being skipped as a no-op / short resync pulse.
 """
 
-import pytest
 from unittest.mock import patch
 
+import pytest
 from homeassistant.const import SERVICE_CLOSE_COVER, SERVICE_OPEN_COVER
 from homeassistant.exceptions import HomeAssistantError
 
@@ -232,9 +232,8 @@ async def test_force_redrive_failed_validation_does_not_corrupt_tracker(make_cov
     # Make the movement target unavailable.
     cover.hass.states.get.return_value = None
 
-    with patch.object(cover, "async_write_ha_state"):
-        with pytest.raises(HomeAssistantError):
-            await cover.async_close_cover()
+    with patch.object(cover, "async_write_ha_state"), pytest.raises(HomeAssistantError):
+        await cover.async_close_cover()
 
     assert cover.travel_calc.current_position() == 0, (
         "tracker must not be corrupted to the opposite endpoint by a failed redrive"
@@ -261,9 +260,8 @@ async def test_force_redrive_validates_even_with_stale_self_initiated_flag(make_
     # Simulate a prior externally-triggered movement leaving this flag stale.
     cover._self_initiated_movement = False
 
-    with patch.object(cover, "async_write_ha_state"):
-        with pytest.raises(HomeAssistantError):
-            await cover.async_close_cover()
+    with patch.object(cover, "async_write_ha_state"), pytest.raises(HomeAssistantError):
+        await cover.async_close_cover()
 
     assert cover.travel_calc.current_position() == 0, (
         "tracker must not be corrupted to the opposite endpoint by a failed "
@@ -303,10 +301,12 @@ async def test_force_redrive_failing_tilt_prestep_does_not_corrupt_tracker(make_
     async def _boom():
         raise HomeAssistantError("tilt relay failed")
 
-    with patch.object(cover, "async_write_ha_state"):
-        with patch.object(cover, "_send_tilt_open", side_effect=_boom):
-            with pytest.raises(HomeAssistantError):
-                await cover.async_close_cover()
+    with (
+        patch.object(cover, "async_write_ha_state"),
+        patch.object(cover, "_send_tilt_open", side_effect=_boom),
+        pytest.raises(HomeAssistantError),
+    ):
+        await cover.async_close_cover()
 
     assert cover.travel_calc.current_position() == 0, (
         "tracker must not be left seeded at the opposite endpoint by a failed "

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,10 +1,9 @@
 """Tests for __init__.py integration setup/teardown."""
 
 import re
-
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from homeassistant.helpers.issue_registry import IssueSeverity
 
 from custom_components.cover_time_based import (

--- a/tests/test_position_persistence.py
+++ b/tests/test_position_persistence.py
@@ -10,9 +10,9 @@ stopped.
 """
 
 import asyncio
+from unittest.mock import patch
 
 import pytest
-from unittest.mock import patch
 
 from custom_components.cover_time_based.cover import (
     CONTROL_MODE_SWITCH,

--- a/tests/test_pulse_pulse_lifecycle.py
+++ b/tests/test_pulse_pulse_lifecycle.py
@@ -31,9 +31,9 @@ is RED on HEAD and GREEN once the fix lands.
 """
 
 import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
 
 from custom_components.cover_time_based.cover import CONTROL_MODE_PULSE
 

--- a/tests/test_relay_commands.py
+++ b/tests/test_relay_commands.py
@@ -9,10 +9,9 @@ pulses a relay with a single turn_on and schedules no completion task.
 """
 
 import logging
-
-import pytest
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
+import pytest
 from homeassistant.const import (
     SERVICE_CLOSE_COVER,
     SERVICE_OPEN_COVER,
@@ -24,7 +23,6 @@ from custom_components.cover_time_based.cover import (
     CONTROL_MODE_SWITCH,
     CONTROL_MODE_TOGGLE,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -516,12 +514,11 @@ class TestPulseModePendingSwitchOpen:
             await cover._async_handle_command(SERVICE_OPEN_COVER)
             await _drain_tasks(cover)
 
-        # close switch was ON -> 1 pending, plus open switch always gets 2
-        assert "switch.close" in cover._pending_switch or True
-        # Verify the pending counts were set (they may have been decremented
-        # by echo filtering, but the code path was exercised).
-        # The key assertion: the call sequence is unchanged, but the
-        # _mark_switch_pending branch on line 49 was hit.
+        # The close switch was ON, so the _mark_switch_pending branch is the
+        # one exercised here. Deliberately no assertion on _pending_switch:
+        # echo filtering may already have decremented the count by the time we
+        # look, so its contents are timing-dependent. This test is a regression
+        # guard that the branch runs to completion without raising.
 
     @pytest.mark.asyncio
     async def test_open_marks_stop_switch_pending_when_on(self, make_cover):

--- a/tests/test_release_script.py
+++ b/tests/test_release_script.py
@@ -43,6 +43,7 @@ def _run(cwd: Path, *args: str) -> subprocess.CompletedProcess:
         cwd=cwd,
         capture_output=True,
         text=True,
+        check=False,
         env=_clean_env(),
     )
 
@@ -218,6 +219,7 @@ def test_pushes_and_opens_pr(tmp_path: Path):
         cwd=repo,
         capture_output=True,
         text=True,
+        check=False,
         env=env,
     )
     assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/test_send_endpoint_stop.py
+++ b/tests/test_send_endpoint_stop.py
@@ -15,10 +15,9 @@ between the two, mirroring the toggle-mode ``relay_reports_off`` option.
 """
 
 import asyncio
-
-import pytest
 from unittest.mock import patch
 
+import pytest
 from homeassistant.const import SERVICE_CLOSE_COVER, SERVICE_OPEN_COVER
 
 from custom_components.cover_time_based.cover import (

--- a/tests/test_state_monitoring.py
+++ b/tests/test_state_monitoring.py
@@ -9,11 +9,11 @@ External state changes only start tracking movement — they never auto-stop,
 since we can't reliably know when the motor stopped from switch state alone.
 """
 
+import contextlib
 import time
-
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from homeassistant.components.cover import ATTR_CURRENT_POSITION
 from homeassistant.const import SERVICE_CLOSE_COVER, SERVICE_OPEN_COVER
 
@@ -1822,10 +1822,10 @@ async def _drain_bg_tasks(cover):
     """Wait for all background tasks (pulse completions etc.) to finish."""
     for task in cover.hass._test_tasks:
         if not task.done():
-            try:
+            # A background task failing is not this helper's concern — callers
+            # assert on the cover's resulting state, not on task outcomes.
+            with contextlib.suppress(Exception):
                 await task
-            except Exception:
-                pass
 
 
 class TestRawDirectionChangeEchoFiltering:
@@ -2219,9 +2219,11 @@ class TestWrappedCoverReportsCommandNotEndpoint:
         _set_wrapped_state(cover, "closed", current_position=None)
 
         event = _make_attribute_event("cover.inner", "closed", None)
-        with patch.object(cover, "_snap_to_position") as snap:
-            with patch.object(cover, "async_write_ha_state"):
-                await cover._handle_external_attribute_change(event)
+        with (
+            patch.object(cover, "_snap_to_position") as snap,
+            patch.object(cover, "async_write_ha_state"),
+        ):
+            await cover._handle_external_attribute_change(event)
 
         snap.assert_not_called()
         assert cover.travel_calc.current_position() == 70

--- a/tests/test_tilt_reversal.py
+++ b/tests/test_tilt_reversal.py
@@ -14,18 +14,17 @@ duplication is intentional per the plan.
 """
 
 import asyncio
-
-import pytest
 from unittest.mock import patch
 
+import pytest
 
-DUAL = dict(
-    tilt_time_close=5.0,
-    tilt_time_open=5.0,
-    tilt_mode="dual_motor",
-    tilt_open_switch="switch.tilt_open",
-    tilt_close_switch="switch.tilt_close",
-)
+DUAL = {
+    "tilt_time_close": 5.0,
+    "tilt_time_open": 5.0,
+    "tilt_mode": "dual_motor",
+    "tilt_open_switch": "switch.tilt_open",
+    "tilt_close_switch": "switch.tilt_close",
+}
 
 
 @pytest.mark.asyncio
@@ -158,17 +157,17 @@ async def test_set_position_during_shared_motor_tilt_does_not_repulse(make_cover
 # ---------------------------------------------------------------------------
 
 
-DUAL_TO = dict(
-    control_mode="toggle_opposite",
-    travel_time_close=0.2,
-    travel_time_open=0.2,
-    tilt_time_close=0.2,
-    tilt_time_open=0.2,
-    tilt_mode="dual_motor",
-    tilt_open_switch="switch.tilt_open",
-    tilt_close_switch="switch.tilt_close",
-    safe_tilt_position=100,
-)
+DUAL_TO = {
+    "control_mode": "toggle_opposite",
+    "travel_time_close": 0.2,
+    "travel_time_open": 0.2,
+    "tilt_time_close": 0.2,
+    "tilt_time_open": 0.2,
+    "tilt_mode": "dual_motor",
+    "tilt_open_switch": "switch.tilt_open",
+    "tilt_close_switch": "switch.tilt_close",
+    "safe_tilt_position": 100,
+}
 
 
 @pytest.mark.asyncio

--- a/tests/test_tilt_stop.py
+++ b/tests/test_tilt_stop.py
@@ -1,10 +1,9 @@
 """Stopping tilt-motor movements — audit findings core-C1a/C1b."""
 
 import asyncio
-
-import pytest
 from unittest.mock import MagicMock, patch
 
+import pytest
 from homeassistant.const import SERVICE_OPEN_COVER
 
 from custom_components.cover_time_based.cover import (
@@ -41,13 +40,13 @@ def _tilt_switch_calls(cover, start=0):
     ]
 
 
-DUAL = dict(
-    tilt_time_close=5.0,
-    tilt_time_open=5.0,
-    tilt_mode="dual_motor",
-    tilt_open_switch="switch.tilt_open",
-    tilt_close_switch="switch.tilt_close",
-)
+DUAL = {
+    "tilt_time_close": 5.0,
+    "tilt_time_open": 5.0,
+    "tilt_mode": "dual_motor",
+    "tilt_open_switch": "switch.tilt_open",
+    "tilt_close_switch": "switch.tilt_close",
+}
 
 
 @pytest.mark.asyncio
@@ -92,11 +91,11 @@ def _all_calls(cover, start=0):
         ("toggle_opposite", {}),
         (
             "pulse",
-            dict(
-                send_endpoint_stop=False,
-                stop_switch="switch.stop",
-                tilt_stop_switch="switch.tilt_stop",
-            ),
+            {
+                "send_endpoint_stop": False,
+                "stop_switch": "switch.stop",
+                "tilt_stop_switch": "switch.tilt_stop",
+            },
         ),
     ],
     ids=["toggle", "toggle_opposite", "pulse-no-endpoint-stop"],
@@ -442,11 +441,11 @@ async def test_tilt_restore_completion_clears_stale_direction(make_cover):
         ("toggle_opposite", {}),
         (
             "pulse",
-            dict(
-                send_endpoint_stop=False,
-                stop_switch="switch.stop",
-                tilt_stop_switch="switch.tilt_stop",
-            ),
+            {
+                "send_endpoint_stop": False,
+                "stop_switch": "switch.stop",
+                "tilt_stop_switch": "switch.tilt_stop",
+            },
         ),
     ],
     ids=["toggle", "toggle_opposite", "pulse-no-endpoint-stop"],
@@ -545,12 +544,12 @@ async def test_external_tilt_press_before_tilt_calibration_does_not_crash(
     ``_handle_external_tilt_state_change`` directly, so the test exercises
     the guard actually added at the dispatch site rather than bypassing it.
     """
-    kwargs = dict(
-        control_mode=control_mode,
-        tilt_mode="dual_motor",
-        tilt_open_switch="switch.tilt_open",
-        tilt_close_switch="switch.tilt_close",
-    )
+    kwargs = {
+        "control_mode": control_mode,
+        "tilt_mode": "dual_motor",
+        "tilt_open_switch": "switch.tilt_open",
+        "tilt_close_switch": "switch.tilt_close",
+    }
     if control_mode == CONTROL_MODE_PULSE:
         # Pulse mode requires a dedicated stop switch, and its tilt axis has
         # its own dedicated stop relay too (see DUAL fixtures above).

--- a/tests/test_tilt_strategy.py
+++ b/tests/test_tilt_strategy.py
@@ -1,7 +1,5 @@
 """Tests for TiltStrategy classes (SequentialTilt and DualMotorTilt)."""
 
-from custom_components.cover_time_based.travel_calculator import TravelCalculator
-
 from custom_components.cover_time_based.tilt_strategies import (
     DualMotorTilt,
     InlineTilt,
@@ -14,7 +12,7 @@ from custom_components.cover_time_based.tilt_strategies import (
 from custom_components.cover_time_based.tilt_strategies.planning import (
     has_travel_pre_step,
 )
-
+from custom_components.cover_time_based.travel_calculator import TravelCalculator
 
 # ===================================================================
 # MovementStep dataclasses

--- a/tests/test_toggle_behavior.py
+++ b/tests/test_toggle_behavior.py
@@ -6,9 +6,9 @@ cover when a same-direction command arrives while already moving, and that
 the stop guard prevents relay commands when the cover is idle.
 """
 
-import pytest
 from unittest.mock import AsyncMock, patch
 
+import pytest
 from homeassistant.const import (
     SERVICE_CLOSE_COVER,
     SERVICE_OPEN_COVER,
@@ -18,7 +18,6 @@ from custom_components.cover_time_based.cover import (
     CONTROL_MODE_SWITCH,
     CONTROL_MODE_TOGGLE,
 )
-
 
 # ===================================================================
 # Toggle: close/open while already moving in the same direction

--- a/tests/test_unavailable_targets.py
+++ b/tests/test_unavailable_targets.py
@@ -1,8 +1,8 @@
 """Tests for rejecting commands / marking unavailable when targets are unavailable."""
 
-import pytest
 from unittest.mock import MagicMock, patch
 
+import pytest
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.exceptions import HomeAssistantError
 
@@ -214,9 +214,11 @@ class TestMovementStartGating:
         cover = make_cover(open_switch="switch.open", close_switch="switch.close")
         _set_target_states(cover, {"switch.open": STATE_UNAVAILABLE})
         cover.travel_calc.set_position(0)
-        with patch.object(cover, "async_write_ha_state"):
-            with pytest.raises(HomeAssistantError):
-                await cover.async_open_cover()
+        with (
+            patch.object(cover, "async_write_ha_state"),
+            pytest.raises(HomeAssistantError),
+        ):
+            await cover.async_open_cover()
         assert not cover.travel_calc.is_traveling()
 
     @pytest.mark.asyncio
@@ -233,9 +235,11 @@ class TestMovementStartGating:
         cover = make_cover(open_switch="switch.open", close_switch="switch.close")
         _set_target_states(cover, {"switch.close": STATE_UNAVAILABLE})
         cover.travel_calc.set_position(100)
-        with patch.object(cover, "async_write_ha_state"):
-            with pytest.raises(HomeAssistantError):
-                await cover.async_close_cover()
+        with (
+            patch.object(cover, "async_write_ha_state"),
+            pytest.raises(HomeAssistantError),
+        ):
+            await cover.async_close_cover()
         assert not cover.travel_calc.is_traveling()
 
     @pytest.mark.asyncio
@@ -286,9 +290,11 @@ class TestMovementStartGating:
         cover = make_cover(cover_entity_id="cover.real")
         _set_target_states(cover, {"cover.real": STATE_UNAVAILABLE})
         cover.travel_calc.set_position(0)
-        with patch.object(cover, "async_write_ha_state"):
-            with pytest.raises(HomeAssistantError):
-                await cover.async_open_cover()
+        with (
+            patch.object(cover, "async_write_ha_state"),
+            pytest.raises(HomeAssistantError),
+        ):
+            await cover.async_open_cover()
         assert not cover.travel_calc.is_traveling()
 
     @pytest.mark.asyncio
@@ -314,9 +320,11 @@ class TestMovementStartGating:
         )
         _set_target_states(cover, {"switch.tilt_open": STATE_UNAVAILABLE})
         cover.tilt_calc.set_position(0)
-        with patch.object(cover, "async_write_ha_state"):
-            with pytest.raises(HomeAssistantError):
-                await cover.async_open_cover_tilt()
+        with (
+            patch.object(cover, "async_write_ha_state"),
+            pytest.raises(HomeAssistantError),
+        ):
+            await cover.async_open_cover_tilt()
         assert not cover.tilt_calc.is_traveling()
 
     @pytest.mark.asyncio
@@ -357,9 +365,11 @@ class TestSequentialOpenTiltGating:
         cover = self._make(make_cover)
         _set_target_states(cover, {"switch.open": STATE_UNAVAILABLE})
         cover.tilt_calc.set_position(100)
-        with patch.object(cover, "async_write_ha_state"):
-            with pytest.raises(HomeAssistantError):
-                await cover.async_close_cover_tilt()
+        with (
+            patch.object(cover, "async_write_ha_state"),
+            pytest.raises(HomeAssistantError),
+        ):
+            await cover.async_close_cover_tilt()
         assert not cover.tilt_calc.is_traveling()
 
     @pytest.mark.asyncio
@@ -410,9 +420,11 @@ class TestPreStepGating:
                 "switch.tilt_close": STATE_UNAVAILABLE,
             },
         )
-        with patch.object(cover, "async_write_ha_state"):
-            with pytest.raises(HomeAssistantError):
-                await cover.async_open_cover()
+        with (
+            patch.object(cover, "async_write_ha_state"),
+            pytest.raises(HomeAssistantError),
+        ):
+            await cover.async_open_cover()
         assert not cover.tilt_calc.is_traveling()
         assert not cover.travel_calc.is_traveling()
 
@@ -435,9 +447,11 @@ class TestPreStepGating:
         cover.tilt_calc.set_position(30)
         # Tilt targets fine; the OPEN travel relay (fired after the pre-step) is dead.
         _set_target_states(cover, {"switch.open": STATE_UNAVAILABLE})
-        with patch.object(cover, "async_write_ha_state"):
-            with pytest.raises(HomeAssistantError):
-                await cover.async_open_cover()
+        with (
+            patch.object(cover, "async_write_ha_state"),
+            pytest.raises(HomeAssistantError),
+        ):
+            await cover.async_open_cover()
         assert not cover.tilt_calc.is_traveling()
         assert not cover.travel_calc.is_traveling()
 
@@ -471,8 +485,10 @@ class TestPreStepGating:
                 "switch.close": STATE_UNAVAILABLE,
             },
         )
-        with patch.object(cover, "async_write_ha_state"):
-            with pytest.raises(HomeAssistantError):
-                await cover.async_set_cover_tilt_position(tilt_position=50)
+        with (
+            patch.object(cover, "async_write_ha_state"),
+            pytest.raises(HomeAssistantError),
+        ):
+            await cover.async_set_cover_tilt_position(tilt_position=50)
         assert not cover.travel_calc.is_traveling()
         assert not cover.tilt_calc.is_traveling()

--- a/tests/test_websocket_api.py
+++ b/tests/test_websocket_api.py
@@ -1,7 +1,8 @@
 """Tests for the WebSocket API module."""
 
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from custom_components.cover_time_based.cover import (
     CONF_CLOSE_SWITCH_ENTITY_ID,
@@ -859,7 +860,7 @@ class TestWsUpdateConfig:
 
     @pytest.mark.asyncio
     async def test_update_single_field(self):
-        hass, config_entry, entity_reg = _make_hass(
+        hass, _config_entry, entity_reg = _make_hass(
             options={CONF_CONTROL_MODE: CONTROL_MODE_SWITCH}
         )
         conn = _make_connection()
@@ -1302,7 +1303,7 @@ class TestPulseTimeSchemaValidation:
 
     @pytest.mark.asyncio
     async def test_null_pops_stored_key(self):
-        hass, config_entry, entity_reg = _make_hass(options={CONF_PULSE_TIME: 3.0})
+        hass, _config_entry, entity_reg = _make_hass(options={CONF_PULSE_TIME: 3.0})
         conn = _make_connection()
 
         with patch(
@@ -2015,8 +2016,8 @@ class TestWsResolveEntity:
         assert resolve_entity_or_none(hass, "cover.test") is None
 
     def test_returns_entity_when_valid(self):
-        from custom_components.cover_time_based.helpers import resolve_entity_or_none
         from custom_components.cover_time_based.cover import _create_cover_from_options
+        from custom_components.cover_time_based.helpers import resolve_entity_or_none
 
         entity = _create_cover_from_options(
             {


### PR DESCRIPTION
## Why CI is red on `main`

The `lint` job installs ruff **unpinned**:

```yaml
- name: Install ruff
  run: python -m pip install ruff
```

**ruff 0.16.0** shipped on 2026-07-23 with an expanded default rule set, and the existing tree trips it 125 times — so the job went red on `main` and on every open PR without a commit having touched the code. Measured before this change, same ruff version both sides:

| Tree | `ruff check` |
|---|---|
| `main` @ 79a1591 | `Found 125 errors.` |
| an unrelated translation branch | `Found 125 errors.` |

`ruff format --check` was and remains clean — only linting broke.

## What this does

**Clears all 125 findings.** The bulk is mechanical, applied by ruff itself (`--fix`, then `--unsafe-fixes` once each affected rule had been read):

| Rule | n | Change |
|---|---|---|
| `I001` | 54 | import blocks sorted |
| `SIM117` | 30 | nested `with` blocks combined |
| `C408` | 7 | `dict()` → literal |
| `SIM102` | 4 | nested guard `if`s merged |
| `UP031` | 3 | `%`-format assertion messages → f-strings |
| `RUF046` | 3 | `int(round(x))` → `round(x)` — `round()` already returns `int` |
| `RUF059` | 2 | unused unpacked bindings underscored |

`UP031` sites are all `assert cond, msg` messages, which stay lazily evaluated as f-strings, so no behaviour change.

**Four needed judgement, not a fix:**

- **`SIM222`** flagged `assert "switch.close" in cover._pending_switch or True` — an assertion that *cannot fail*. Its own comment concedes the count may already have been decremented by echo filtering. The vacuous `or True` is dropped and the comment now says plainly that the test guards the branch running, not `_pending_switch`'s contents.
- **`S110`/`BLE001`** on a `try`/`except`/`pass` task-drainer become `contextlib.suppress(Exception)` — same behaviour, said outright.
- **`PLW1510`** (5) `subprocess.run` calls gain explicit `check=False`. Every caller already asserts on `returncode`, so this documents existing behaviour rather than changing it.

**Pins `ruff==0.16.0`** so a future release cannot do this again. An unpinned linter makes CI non-reproducible — the same tree passes or fails depending on the day.

## On the 30 `SIM117` rewrites

Ruff declines to fix these even unsafely (multi-line context managers), so they were rewritten mechanically. An early attempt **silently dropped a `pytest.raises`** from a triple-nested block — editing several targets from one AST parse invalidates the line ranges of any enclosing target. `tests/test_force_endpoint_redrive.py` caught it. The rewrite now collapses only non-overlapping sites per parse, and the result was checked two ways:

- every `patch(...)` and `pytest.raises(...)` occurrence counted per file before and after — **unchanged in all 7 files**
- full suite re-run

## Verification

- `ruff check .` (0.16.0) → **All checks passed!**
- `ruff format --check .` (0.16.0) → 80 files already formatted
- `pytest` → **1387 passed**
- `npm run test:fe` → **387 passed**

No production behaviour changes.