### PR TITLE
chore: enforce an explicit ruff rule set, unpin ruff in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,12 +88,13 @@ jobs:
           python-version: "3.14"
 
       - name: Install ruff
-        # Pinned deliberately. ruff's default rule set and formatter style shift
-        # between minor releases, so an unpinned install lets someone else's
-        # release turn this job red on a tree nobody touched — 0.16.0 did exactly
-        # that, surfacing 125 findings across files that had not changed. Bump
-        # this when you mean to, in a PR that also clears whatever it surfaces.
-        run: python -m pip install ruff==0.16.0
+        # Unpinned on purpose — we want the latest ruff. What keeps that from
+        # turning the job red on an untouched tree is the explicit rule set in
+        # pyproject.toml ([tool.ruff.lint].select), not a version pin: a bare
+        # `ruff check` follows ruff's *default* rules, which shift between
+        # releases (0.16.0 expanded them and surfaced 125 findings here). Pinning
+        # the rules we enforce, rather than the version, lets us stay current.
+        run: python -m pip install ruff
 
       - name: Check formatting
         run: ruff format --check .

--- a/custom_components/cover_time_based/cover_wrapped.py
+++ b/custom_components/cover_time_based/cover_wrapped.py
@@ -43,7 +43,7 @@ _COMMANDED_STATES = _MOVING_STATES | _STOPPED_STATES
 # ZHA) briefly bounce back to their pre-command state before settling on
 # the destination state — within this window we trust our own time-based
 # position calculation rather than the wrapped cover's transient state.
-# Observed bounces happen <250 ms after the command; 500 ms gives a 2×
+# Observed bounces happen <250 ms after the command; 500 ms gives a 2x
 # safety margin without interfering with legitimate later state changes.
 _BOUNCE_GRACE_PERIOD = 0.5
 

--- a/custom_components/cover_time_based/websocket_api.py
+++ b/custom_components/cover_time_based/websocket_api.py
@@ -413,7 +413,7 @@ async def ws_start_calibration(
         if "direction" in msg:
             kwargs["direction"] = msg["direction"]
         await entity.start_calibration(**kwargs)
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         connection.send_error(msg["id"], "failed", str(exc))
         return
 
@@ -441,7 +441,7 @@ async def ws_stop_calibration(
 
     try:
         result = await entity.stop_calibration(cancel=msg["cancel"])
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         connection.send_error(msg["id"], "failed", str(exc))
         return
 
@@ -493,7 +493,7 @@ async def ws_raw_command(
             else:
                 entity.travel_calc.clear_position()
             entity.async_write_ha_state()
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         connection.send_error(msg["id"], "failed", str(exc))
         return
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,16 @@
+[tool.ruff]
+target-version = "py313"
+
+[tool.ruff.lint]
+# Enforce an explicit rule set rather than ruff's defaults, which shift between
+# releases. This is what lets CI install ruff unpinned and still stay green on
+# an untouched tree: the version floats, the rules we hold ourselves to don't.
+select = ["E", "F", "W", "I", "UP", "B", "SIM", "RUF"]
+# Line width is governed by `ruff format`; E501 would only fire on long string
+# literals, comments and test-failure messages the formatter deliberately leaves
+# intact, so enforcing it here buys noise, not readability.
+ignore = ["E501"]
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -132,7 +132,7 @@ class TestStopCalibrationTravelTime:
         from homeassistant.exceptions import HomeAssistantError
 
         cover = make_cover()
-        with pytest.raises(HomeAssistantError, match="[Nn]o calibration"):
+        with pytest.raises(HomeAssistantError, match=r"[Nn]o calibration"):
             await cover.stop_calibration()
 
     @pytest.mark.asyncio
@@ -349,7 +349,7 @@ class TestMotorOverheadCalibration:
         # Factory defaults travel_time to 30, so manually clear it
         cover._travel_time_close = None
         cover._travel_time_open = None
-        with pytest.raises(HomeAssistantError, match="[Tt]ravel time"):
+        with pytest.raises(HomeAssistantError, match=r"[Tt]ravel time"):
             await cover.start_calibration(
                 attribute="travel_startup_delay", timeout=300.0
             )
@@ -424,7 +424,7 @@ class TestMotorOverheadCalibration:
         from homeassistant.exceptions import HomeAssistantError
 
         cover = make_cover()  # No tilt time configured
-        with pytest.raises(HomeAssistantError, match="[Tt]ilt time"):
+        with pytest.raises(HomeAssistantError, match=r"[Tt]ilt time"):
             await cover.start_calibration(attribute="tilt_startup_delay", timeout=300.0)
 
     @pytest.mark.asyncio
@@ -545,7 +545,7 @@ class TestCalibrationEdgeCases:
         )
         # Mock strategy to reject tilt calibration
         cover._tilt_strategy.can_calibrate_tilt = lambda: False
-        with pytest.raises(HomeAssistantError, match="[Tt]ilt.*not available"):
+        with pytest.raises(HomeAssistantError, match=r"[Tt]ilt.*not available"):
             await cover.start_calibration(attribute="tilt_time_close", timeout=30.0)
 
     def test_resolve_direction_explicit_close(self, make_cover):

--- a/tests/test_cover_base_extra.py
+++ b/tests/test_cover_base_extra.py
@@ -1185,7 +1185,7 @@ class TestUnconfiguredEntity:
         cover._travel_time_close = None
         cover._travel_time_open = None
         with (
-            pytest.raises(HomeAssistantError, match="[Tt]ravel time"),
+            pytest.raises(HomeAssistantError, match=r"[Tt]ravel time"),
             patch.object(cover, "async_write_ha_state"),
         ):
             await cover.async_set_cover_position(position=50)

--- a/tests/test_cover_services.py
+++ b/tests/test_cover_services.py
@@ -56,7 +56,7 @@ class TestResolveEntity:
         hass = MagicMock()
         hass.data = {"entity_components": {"cover": component}}
 
-        with pytest.raises(HomeAssistantError, match="cover.test"):
+        with pytest.raises(HomeAssistantError, match=r"cover.test"):
             resolve_entity(hass, "cover.test")
 
     def test_raises_when_not_cover_time_based(self):

--- a/tests/test_coverage_extras.py
+++ b/tests/test_coverage_extras.py
@@ -250,7 +250,7 @@ class TestRequireTravelTimeRaisesClosing:
         cover = make_cover()
         cover._travel_time_close = None
 
-        with pytest.raises(HomeAssistantError, match="[Tt]ravel time"):
+        with pytest.raises(HomeAssistantError, match=r"[Tt]ravel time"):
             cover._require_travel_time(closing=True)
 
     def test_raises_when_travel_time_open_is_none(self, make_cover):
@@ -258,7 +258,7 @@ class TestRequireTravelTimeRaisesClosing:
         cover = make_cover()
         cover._travel_time_open = None
 
-        with pytest.raises(HomeAssistantError, match="[Tt]ravel time"):
+        with pytest.raises(HomeAssistantError, match=r"[Tt]ravel time"):
             cover._require_travel_time(closing=False)
 
     def test_returns_value_when_configured(self, make_cover):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -453,7 +453,7 @@ class TestFrontendCacheBuster:
     def test_card_js_url_lives_under_hashed_prefix(self):
         # Inner relative imports resolve under the same hashed prefix, so
         # `entity-filter.js` busts together with the main card.
-        assert _CARD_JS_URL == f"{_PANEL_URL}/cover-time-based-card.js"
+        assert f"{_PANEL_URL}/cover-time-based-card.js" == _CARD_JS_URL
 
 
 class TestIntegrationTeardown:


### PR DESCRIPTION
Follow-up to #207.

#207 fixed the ruff 0.16.0 findings but reacted to the root cause by pinning `ruff==0.16.0`. That freezes the linter — every future ruff improvement has to be pulled in by hand. This does it the other way round.

## Pin the rules, not the version

The actual cause was that the lint job ran a bare `ruff check` with **no rule set of its own**, so it followed ruff's *defaults* — and 0.16.0 expanded those defaults, reddening the job on an untouched tree.

`pyproject.toml` now declares an explicit `[tool.ruff.lint].select` (the same set the sibling repos use), so the rules we enforce are **ours and stable across ruff releases**, and CI goes back to installing ruff **unpinned** so we stay current:

```toml
[tool.ruff.lint]
select = ["E", "F", "W", "I", "UP", "B", "SIM", "RUF"]
ignore = ["E501"]
```

`E501` is left off deliberately: line width is the formatter's job, and enforcing it would only fire on long string literals, comments and test-failure messages `ruff format` leaves intact — noise, not readability.

## Findings the explicit set surfaced

Beyond what the earlier default run flagged:

| Rule | n | Change |
|---|---|---|
| `RUF043` | 8 | `pytest.raises(match=...)` patterns made raw strings |
| `RUF100` | 3 | stale `# noqa: BLE001` removed (BLE not in our set) |
| `SIM300` | 1 | Yoda condition flipped |
| `RUF003` | 1 | `2×` → `2x` in a comment |

Every `RUF043` pattern is a plain substring/character-class with no backslash, so the raw prefix changes nothing about what matches — confirmed by re-running the five affected test modules (239 tests).

## Verification

- `ruff check .` (0.16.0) → All checks passed!
- `ruff format --check .` → 80 files already formatted
- `pytest` → full suite passes

No production behaviour changes.