### PR TITLE
chore: release v4.10.0-rc.2

### DIFF
--- a/custom_components/cover_time_based/manifest.json
+++ b/custom_components/cover_time_based/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/Sese-Schneider/ha-cover-time-based/issues",
   "requirements": [],
-  "version": "4.10.0-rc.1"
+  "version": "4.10.0-rc.2"
 }


### PR DESCRIPTION
Release `v4.10.0-rc.2`: bumps the manifest version to `4.10.0-rc.2`.

After merge, push the tag to publish the GitHub Release:

```
git tag v4.10.0-rc.2
git push origin v4.10.0-rc.2
```

The release workflow publishes the GitHub Release. Roll `main` forward to the
next minor for development separately, via bin/bump-dev.sh.
