### PR TITLE
chore: release v4.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 4.10.0 (2026-07-29)
 
 ### Features
 

--- a/custom_components/cover_time_based/manifest.json
+++ b/custom_components/cover_time_based/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/Sese-Schneider/ha-cover-time-based/issues",
   "requirements": [],
-  "version": "4.10.0-rc.2"
+  "version": "4.10.0"
 }


### PR DESCRIPTION
Release `v4.10.0`: bumps the manifest version to `4.10.0` and closes the CHANGELOG's `## Unreleased` section as `## 4.10.0 (2026-07-29)`.

The changelog close is required for a final tag: the release workflow fails the notes step when a non-pre-release tag has no matching CHANGELOG section.

Contents are what shipped in `v4.10.0-rc.1` and `v4.10.0-rc.2` — the 8-phase audit fixes plus the German, Italian and Dutch translations.

After merge, push the tag to publish the GitHub Release:

```
git tag v4.10.0
git push upstream v4.10.0
```

Then promote it off pre-release, and roll `main` forward via `bin/bump-dev.sh`.