### PR TITLE
fix: gate calibration Finish until the startup-delay final step

### DIFF
--- a/custom_components/cover_time_based/frontend/card-render.js
+++ b/custom_components/cover_time_based/frontend/card-render.js
@@ -739,6 +739,14 @@ export function renderCalibration(card, calibrating) {
   if (calibrating) {
     const calAttr = attrs.calibration_attribute || card._calibratingAttribute;
     const calLabel = card._t(`timing.${calAttr}`);
+    // The startup-delay ("overhead") test steps the motor before a final
+    // continuous run; only that final run yields a real measurement, and
+    // finishing during the stepped phase records a hard-coded 0. Gate Finish
+    // until the calibration reports its final step. Simple travel/tilt-time
+    // tests have no stepped phase, so their Finish stays enabled throughout.
+    const isOverheadTest =
+      calAttr === "travel_startup_delay" || calAttr === "tilt_startup_delay";
+    const finishDisabled = isOverheadTest && !attrs.calibration_final_step;
     return html`
       <div class="section calibration-active">
         <div class="field-label cal-label">
@@ -760,7 +768,10 @@ export function renderCalibration(card, calibrating) {
             <ha-button @click=${() => card._onStopCalibration(true)}
               >${card._t("calibration.cancel")}</ha-button
             >
-            <ha-button unelevated @click=${() => card._onStopCalibration(false)}
+            <ha-button
+              unelevated
+              ?disabled=${finishDisabled}
+              @click=${() => card._onStopCalibration(false)}
               >${card._t("calibration.finish")}</ha-button
             >
           </div>

--- a/tests/frontend/calibration_finish_gate.test.mjs
+++ b/tests/frontend/calibration_finish_gate.test.mjs
@@ -1,0 +1,82 @@
+/**
+ * The startup-delay ("overhead") calibration runs a stepped phase before a
+ * final continuous phase; only the final phase produces a real measurement.
+ * Finishing during the stepped phase returns a hard-coded 0, so the card gates
+ * the Finish button until the calibration reports its final step. Simple
+ * travel/tilt-time tests have no stepped phase, so their Finish stays enabled.
+ *
+ * Run: npm run test:fe -- tests/frontend/calibration_finish_gate.test.mjs
+ */
+
+import { test, expect, afterEach, vi } from "vitest";
+import { makeHass } from "./helpers/hass.mjs";
+import { mountCard, defineHaStubs } from "./helpers/mount.mjs";
+
+defineHaStubs();
+let card;
+afterEach(() => {
+  vi.restoreAllMocks();
+  card?.remove();
+  card = null;
+});
+
+const switchCfg = (over = {}) => ({
+  control_mode: "switch",
+  open_switch_entity_id: "switch.o",
+  close_switch_entity_id: "switch.c",
+  ...over,
+});
+
+const calibratingHass = (attrs) =>
+  makeHass({
+    states: {
+      "cover.x": {
+        state: "open",
+        attributes: { calibration_active: true, ...attrs },
+      },
+    },
+  });
+
+// The Finish button is the "unelevated" one in the active-calibration panel
+// (Cancel is not unelevated; the non-calibrating Start button is not shown).
+const finishButton = (c) =>
+  c.shadowRoot.querySelector(".cal-active-buttons ha-button[unelevated]");
+
+async function mountCalibrating(attrs) {
+  return mountCard(calibratingHass(attrs), {
+    selectedEntity: "cover.x",
+    config: switchCfg(),
+    activeTab: "timing",
+  });
+}
+
+test("startup-delay calibration: Finish is disabled during the stepped phase", async () => {
+  card = await mountCalibrating({
+    calibration_attribute: "travel_startup_delay",
+    calibration_step: 3,
+  });
+  const finish = finishButton(card);
+  expect(finish).not.toBeNull();
+  expect(finish.hasAttribute("disabled")).toBe(true);
+});
+
+test("startup-delay calibration: Finish is enabled once the final step is reached", async () => {
+  card = await mountCalibrating({
+    calibration_attribute: "travel_startup_delay",
+    calibration_final_step: true,
+  });
+  expect(finishButton(card).hasAttribute("disabled")).toBe(false);
+});
+
+test("tilt startup-delay calibration: Finish is disabled during the stepped phase", async () => {
+  card = await mountCalibrating({
+    calibration_attribute: "tilt_startup_delay",
+    calibration_step: 1,
+  });
+  expect(finishButton(card).hasAttribute("disabled")).toBe(true);
+});
+
+test("simple travel-time calibration: Finish is enabled immediately (no stepped phase)", async () => {
+  card = await mountCalibrating({ calibration_attribute: "travel_time_close" });
+  expect(finishButton(card).hasAttribute("disabled")).toBe(false);
+});

--- a/tests/frontend/calibration_finish_gate.test.mjs
+++ b/tests/frontend/calibration_finish_gate.test.mjs
@@ -65,7 +65,9 @@ test("startup-delay calibration: Finish is enabled once the final step is reache
     calibration_attribute: "travel_startup_delay",
     calibration_final_step: true,
   });
-  expect(finishButton(card).hasAttribute("disabled")).toBe(false);
+  const finish = finishButton(card);
+  expect(finish).not.toBeNull();
+  expect(finish.hasAttribute("disabled")).toBe(false);
 });
 
 test("tilt startup-delay calibration: Finish is disabled during the stepped phase", async () => {
@@ -73,10 +75,14 @@ test("tilt startup-delay calibration: Finish is disabled during the stepped phas
     calibration_attribute: "tilt_startup_delay",
     calibration_step: 1,
   });
-  expect(finishButton(card).hasAttribute("disabled")).toBe(true);
+  const finish = finishButton(card);
+  expect(finish).not.toBeNull();
+  expect(finish.hasAttribute("disabled")).toBe(true);
 });
 
 test("simple travel-time calibration: Finish is enabled immediately (no stepped phase)", async () => {
   card = await mountCalibrating({ calibration_attribute: "travel_time_close" });
-  expect(finishButton(card).hasAttribute("disabled")).toBe(false);
+  const finish = finishButton(card);
+  expect(finish).not.toBeNull();
+  expect(finish.hasAttribute("disabled")).toBe(false);
 });


### PR DESCRIPTION
## What

On the **startup delay** ("overhead") calibration, the **Finish** button is now disabled during the initial stepped phase and only enabled once the cover reaches the final continuous step.

## Why

The startup-delay test runs a stepped phase, then a final continuous run — and only the continuous run produces a real measurement. If you press **Finish** during the stepped phase, the backend hits:

```python
if continuous_start is None:
    _LOGGER.warning("Overhead calibration stopped before continuous phase started")
    return 0.0
```

…and the card writes that hard-coded `0` into the field. That's a silent footgun: nothing tells you to wait, and finishing early records a wrong value (reported as "the startup-delay test sets it to 0").

## Fix

Gate the Finish button: disabled while a **travel/tilt startup-delay** calibration is in its stepped phase (`calibration_final_step` not yet set), enabled once the final step is reached. **Cancel** stays available throughout so you're never trapped. Simple **travel/tilt-time** tests have no stepped phase, so their Finish stays enabled the whole time.

The active panel already shows a "Step N" / "final step" indicator, so the disabled Finish reads naturally: wait for the final step, then finish.

## Tests

- New `calibration_finish_gate.test.mjs`: Finish disabled during the stepped phase (travel + tilt startup delay), enabled at the final step, and enabled immediately for a simple time test. Verified failing before the change.
- Full frontend suite green (413 tests); coverage 99.14% (gate 90%).

## Notes

Independent of #224 (which fixes the calibration-section layout order) — different function, no overlap.