### PR TITLE
style: reformat all JS with Prettier + enforce in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,6 +77,12 @@ jobs:
       - name: Run frontend tests with coverage gate
         run: npm run test:fe:cov
 
+      - name: Check formatting (Prettier)
+        run: npm run format:check
+
+      - name: Check linting (ESLint)
+        run: npm run lint
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/custom_components/cover_time_based/frontend/card-render.js
+++ b/custom_components/cover_time_based/frontend/card-render.js
@@ -12,24 +12,24 @@ export function renderCard(card) {
       <div class="card-content">
         ${renderLanguageBanner(card)}
         ${renderEntityPicker(card)}
-        ${card._selectedEntity && card._config
-          ? renderConfigSections(card)
-          : ""}
-        ${card._loadError
-          ? html`<div class="yaml-warning">${card._loadError}</div>`
-          : ""}
-        ${card._loading
-          ? html`<div class="loading">
+        ${card._selectedEntity && card._config ? renderConfigSections(card) : ""}
+        ${card._loadError ? html`<div class="yaml-warning">${card._loadError}</div>` : ""}
+        ${
+          card._loading
+            ? html`<div class="loading">
               <ha-icon icon="mdi:loading" class="spin"></ha-icon> ${card._t("loading")}
             </div>`
-          : ""}
+            : ""
+        }
       </div>
-      ${card._openHelp
-        ? html`<div
+      ${
+        card._openHelp
+          ? html`<div
             class="popover-backdrop"
             @click=${card._closeHelp}
           ></div>`
-        : ""}
+          : ""
+      }
     </ha-card>
   `;
 }
@@ -95,8 +95,7 @@ export function renderConfigSections(card) {
       <div class="entity-info-row">
         <div>
           <strong>
-            ${card._getEntityState()?.attributes?.friendly_name ||
-            card._selectedEntity}
+            ${card._getEntityState()?.attributes?.friendly_name || card._selectedEntity}
           </strong>
           <span class="entity-id">${card._selectedEntity}</span>
         </div>
@@ -106,25 +105,30 @@ export function renderConfigSections(card) {
     <div class="tabs">
       <button
         class="tab ${card._activeTab === "device" ? "active" : ""}"
-        @click=${() => { card._activeTab = "device"; }}
+        @click=${() => {
+          card._activeTab = "device";
+        }}
       >${card._t("tabs.device")}</button>
       <button
         class="tab ${card._activeTab === "timing" ? "active" : ""}"
         ?disabled=${!card._hasRequiredEntities(c)}
-        @click=${() => { card._activeTab = "timing"; }}
+        @click=${() => {
+          card._activeTab = "timing";
+        }}
       >${card._t("tabs.calibration")}</button>
     </div>
 
-    ${card._activeTab === "device"
-      ? html`
+    ${
+      card._activeTab === "device"
+        ? html`
           <fieldset ?disabled=${disabled}>
             ${renderControlMode(card, c)} ${renderInputEntities(card, c)}
             ${renderTiltSupport(card, c)}
             ${renderTiltMotorSection(card, c)}
           </fieldset>
         `
-      : calibrating
-        ? html`
+        : calibrating
+          ? html`
             <!-- The active-calibration panel (Cancel/Finish) must stay OUTSIDE
                  the disabled fieldset so its controls remain clickable while
                  calibrating; the timing table stays inside it so it locks. -->
@@ -133,7 +137,7 @@ export function renderConfigSections(card) {
               ${renderTimingTable(card, c)}
             </fieldset>
           `
-        : html`
+          : html`
             <!-- Not calibrating: position reset, the calibration controls and
                  the timing table all sit inside the disabled fieldset so they
                  lock together while saving, matching the device tab. Order:
@@ -143,18 +147,23 @@ export function renderConfigSections(card) {
               ${renderCalibration(card, calibrating)}
               ${renderTimingTable(card, c)}
             </fieldset>
-          `}
+          `
+    }
 
-    ${card._saving
-      ? html`<div class="save-bar"><span class="saving-indicator">${card._t("saving")}</span></div>`
-      : ""}
-    ${card._saveError
-      ? html`<div class="save-bar"><span class="save-error"
-          >${card._t("save_failed")}${card._saveErrorDetail
-            ? html` — ${card._saveErrorDetail}`
-            : ""}</span
+    ${
+      card._saving
+        ? html`<div class="save-bar"><span class="saving-indicator">${card._t("saving")}</span></div>`
+        : ""
+    }
+    ${
+      card._saveError
+        ? html`<div class="save-bar"><span class="save-error"
+          >${card._t("save_failed")}${
+            card._saveErrorDetail ? html` — ${card._saveErrorDetail}` : ""
+          }</span
         ></div>`
-      : ""}
+        : ""
+    }
   `;
 }
 
@@ -182,8 +191,9 @@ export function renderControlMode(card, c) {
           ${card._t("control_mode.toggle_opposite")}
         </option>
       </select>
-      ${showPulseTime
-        ? html`
+      ${
+        showPulseTime
+          ? html`
             <div class="inline-field">
               ${renderTextfield({
                 type: "number",
@@ -197,7 +207,8 @@ export function renderControlMode(card, c) {
               })}
             </div>
           `
-        : ""}
+          : ""
+      }
     </div>
   `;
 }
@@ -228,11 +239,13 @@ export function renderToggleWithHelp(card, labelKey, helperKey, checked, onChang
             }
           }}
         ></ha-icon>
-        ${open
-          ? html`<div class="info-popover" role="tooltip">
+        ${
+          open
+            ? html`<div class="info-popover" role="tooltip">
               ${card._t(helperKey)}
             </div>`
-          : ""}
+            : ""
+        }
       </span>
       <ha-switch
         class="toggle-switch"
@@ -260,16 +273,14 @@ export function renderInputEntities(card, c) {
           "entities.ignore_reported_position",
           "entities.ignore_reported_position_helper",
           !!c.ignore_reported_position,
-          (e) =>
-            card._updateLocal({ ignore_reported_position: e.target.checked }),
+          (e) => card._updateLocal({ ignore_reported_position: e.target.checked }),
         )}
         ${renderToggleWithHelp(
           card,
           "entities.force_time_based_position",
           "entities.force_time_based_position_helper",
           !!c.force_time_based_position,
-          (e) =>
-            card._updateLocal({ force_time_based_position: e.target.checked }),
+          (e) => card._updateLocal({ force_time_based_position: e.target.checked }),
         )}
         ${renderToggleWithHelp(
           card,
@@ -281,12 +292,8 @@ export function renderInputEntities(card, c) {
               reports_command_not_endpoint: e.target.checked,
             }),
         )}
-        ${renderToggleWithHelp(
-          card,
-          "entities.invert",
-          "entities.invert_helper",
-          !!c.invert,
-          (e) => card._updateLocal({ invert: e.target.checked }),
+        ${renderToggleWithHelp(card, "entities.invert", "entities.invert_helper", !!c.invert, (e) =>
+          card._updateLocal({ invert: e.target.checked }),
         )}
         ${renderToggleWithHelp(
           card,
@@ -325,46 +332,51 @@ export function renderInputEntities(card, c) {
           .value=${c.open_switch_entity_id || ""}
           .includeDomains=${switchPickerDomains(c.control_mode)}
           label=${card._switchLabel("entities.open_switch", c.control_mode)}
-          @value-changed=${(e) =>
-            card._onSwitchEntityChange("open_switch_entity_id", e)}
+          @value-changed=${(e) => card._onSwitchEntityChange("open_switch_entity_id", e)}
         ></ha-entity-picker>
         <ha-entity-picker
           .hass=${card.hass}
           .value=${c.close_switch_entity_id || ""}
           .includeDomains=${switchPickerDomains(c.control_mode)}
           label=${card._switchLabel("entities.close_switch", c.control_mode)}
-          @value-changed=${(e) =>
-            card._onSwitchEntityChange("close_switch_entity_id", e)}
+          @value-changed=${(e) => card._onSwitchEntityChange("close_switch_entity_id", e)}
         ></ha-entity-picker>
-        ${c.control_mode === "pulse" ? html`
+        ${
+          c.control_mode === "pulse"
+            ? html`
         <ha-entity-picker
           .hass=${card.hass}
           .value=${c.stop_switch_entity_id || ""}
           .includeDomains=${switchPickerDomains(c.control_mode)}
           label=${card._switchLabel("entities.stop_switch", c.control_mode)}
-          @value-changed=${(e) =>
-            card._onSwitchEntityChange("stop_switch_entity_id", e)}
+          @value-changed=${(e) => card._onSwitchEntityChange("stop_switch_entity_id", e)}
         ></ha-entity-picker>
-        ` : ""}
+        `
+            : ""
+        }
       </div>
-      ${c.control_mode === "toggle" || c.control_mode === "toggle_opposite"
-        ? renderToggleWithHelp(
-            card,
-            "relay_reports_off.label",
-            "relay_reports_off.helper",
-            c.relay_reports_off !== false,
-            (e) => card._updateLocal({ relay_reports_off: e.target.checked }),
-          )
-        : ""}
-      ${c.control_mode === "pulse"
-        ? renderToggleWithHelp(
-            card,
-            "send_endpoint_stop.label",
-            "send_endpoint_stop.helper",
-            c.send_endpoint_stop !== false,
-            (e) => card._updateLocal({ send_endpoint_stop: e.target.checked }),
-          )
-        : ""}
+      ${
+        c.control_mode === "toggle" || c.control_mode === "toggle_opposite"
+          ? renderToggleWithHelp(
+              card,
+              "relay_reports_off.label",
+              "relay_reports_off.helper",
+              c.relay_reports_off !== false,
+              (e) => card._updateLocal({ relay_reports_off: e.target.checked }),
+            )
+          : ""
+      }
+      ${
+        c.control_mode === "pulse"
+          ? renderToggleWithHelp(
+              card,
+              "send_endpoint_stop.label",
+              "send_endpoint_stop.helper",
+              c.send_endpoint_stop !== false,
+              (e) => card._updateLocal({ send_endpoint_stop: e.target.checked }),
+            )
+          : ""
+      }
       ${renderToggleWithHelp(
         card,
         "assumed_state.label",
@@ -401,8 +413,7 @@ export function renderTiltSupport(card, c) {
   // Inline and sequential modes drive the main open/close motor, so they
   // work on any wrapped cover and stay available regardless.
   const allowDualMotor =
-    c.control_mode !== "wrapped" ||
-    card._coverSupportsNativeTilt(c.cover_entity_id);
+    c.control_mode !== "wrapped" || card._coverSupportsNativeTilt(c.cover_entity_id);
   // The handlers reset dual_motor when it stops being backable, so in normal
   // UI flow allowDualMotor already covers it. Keep showing it when it is the
   // stored mode as a safety net for hand-edited configs or a wrapped cover
@@ -423,30 +434,33 @@ export function renderTiltSupport(card, c) {
         <option value="sequential_open" ?selected=${tiltMode === "sequential_open"}>
           ${card._t("tilt.sequential_open")}
         </option>
-        ${showDualMotor
-          ? html`
+        ${
+          showDualMotor
+            ? html`
               <option value="dual_motor" ?selected=${tiltMode === "dual_motor"}>
                 ${card._t("tilt.dual_motor")}
               </option>
             `
-          : ""}
+            : ""
+        }
         <option value="inline" ?selected=${tiltMode === "inline"}>
           ${card._t("tilt.inline")}
         </option>
       </select>
-      ${tiltMode === "sequential_close" || tiltMode === "dual_motor"
-        ? html`
+      ${
+        tiltMode === "sequential_close" || tiltMode === "dual_motor"
+          ? html`
             <div class="inline-field">
               <ha-formfield .label=${card._t("tilt.close_includes_tilt")}>
                 <ha-switch
                   .checked=${c.close_includes_tilt !== false}
-                  @change=${(e) =>
-                    card._updateLocal({ close_includes_tilt: e.target.checked })}
+                  @change=${(e) => card._updateLocal({ close_includes_tilt: e.target.checked })}
                 ></ha-switch>
               </ha-formfield>
             </div>
           `
-        : ""}
+          : ""
+      }
     </div>
   `;
 }
@@ -457,36 +471,41 @@ export function renderTiltMotorSection(card, c) {
   return html`
     <div class="section">
       <div class="field-label">${card._switchLabel("tilt_motor.label", c.control_mode)}</div>
-      ${c.control_mode !== "wrapped" ? html`
+      ${
+        c.control_mode !== "wrapped"
+          ? html`
       <div class="entity-grid">
         <ha-entity-picker
           .hass=${card.hass}
           .value=${c.tilt_open_switch || ""}
           .includeDomains=${switchPickerDomains(c.control_mode)}
           label=${card._switchLabel("tilt_motor.open_switch", c.control_mode)}
-          @value-changed=${(e) =>
-            card._onSwitchEntityChange("tilt_open_switch", e)}
+          @value-changed=${(e) => card._onSwitchEntityChange("tilt_open_switch", e)}
         ></ha-entity-picker>
         <ha-entity-picker
           .hass=${card.hass}
           .value=${c.tilt_close_switch || ""}
           .includeDomains=${switchPickerDomains(c.control_mode)}
           label=${card._switchLabel("tilt_motor.close_switch", c.control_mode)}
-          @value-changed=${(e) =>
-            card._onSwitchEntityChange("tilt_close_switch", e)}
+          @value-changed=${(e) => card._onSwitchEntityChange("tilt_close_switch", e)}
         ></ha-entity-picker>
-        ${c.control_mode === "pulse" ? html`
+        ${
+          c.control_mode === "pulse"
+            ? html`
         <ha-entity-picker
           .hass=${card.hass}
           .value=${c.tilt_stop_switch || ""}
           .includeDomains=${switchPickerDomains(c.control_mode)}
           label=${card._switchLabel("tilt_motor.stop_switch", c.control_mode)}
-          @value-changed=${(e) =>
-            card._onSwitchEntityChange("tilt_stop_switch", e)}
+          @value-changed=${(e) => card._onSwitchEntityChange("tilt_stop_switch", e)}
         ></ha-entity-picker>
-        ` : ""}
+        `
+            : ""
+        }
       </div>
-      ` : ""}
+      `
+          : ""
+      }
       <div class="dual-motor-config">
         ${renderTextfield({
           type: "number",
@@ -510,10 +529,7 @@ export function renderTiltMotorSection(card, c) {
           step: "1",
           label: card._t("tilt_motor.max_allowed_position"),
           hint: card._t("tilt_motor.max_allowed_helper"),
-          value:
-            c.max_tilt_allowed_position != null
-              ? String(c.max_tilt_allowed_position)
-              : "",
+          value: c.max_tilt_allowed_position != null ? String(c.max_tilt_allowed_position) : "",
           onChange: (e) => {
             const v = e.target.value.trim();
             card._updateLocal({
@@ -550,7 +566,11 @@ export function renderTimingRow(card, [labelKey, key, value, min = 0]) {
 }
 
 export function renderTimingTable(card, c) {
-  const hasTiltTimes = c.tilt_mode === "sequential_close" || c.tilt_mode === "sequential_open" || c.tilt_mode === "dual_motor" || c.tilt_mode === "inline";
+  const hasTiltTimes =
+    c.tilt_mode === "sequential_close" ||
+    c.tilt_mode === "sequential_open" ||
+    c.tilt_mode === "dual_motor" ||
+    c.tilt_mode === "inline";
 
   const travelRows = [
     ["timing.travel_time_close", "travel_time_close", c.travel_time_close, 0.1],
@@ -568,11 +588,7 @@ export function renderTimingTable(card, c) {
   const sendsEndpointStop =
     mode === "switch" || (mode === "pulse" && c.send_endpoint_stop !== false);
   if (sendsEndpointStop) {
-    travelRows.push([
-      "timing.endpoint_runon_time",
-      "endpoint_runon_time",
-      c.endpoint_runon_time,
-    ]);
+    travelRows.push(["timing.endpoint_runon_time", "endpoint_runon_time", c.endpoint_runon_time]);
   }
 
   const tiltRows = [
@@ -594,7 +610,9 @@ export function renderTimingTable(card, c) {
           ${travelRows.map((row) => renderTimingRow(card, row))}
         </tbody>
       </table>
-      ${hasTiltTimes ? html`
+      ${
+        hasTiltTimes
+          ? html`
       <table class="timing-table" style="margin-top: 8px;">
         <thead>
           <tr>
@@ -606,14 +624,20 @@ export function renderTimingTable(card, c) {
           ${tiltRows.map((row) => renderTimingRow(card, row))}
         </tbody>
       </table>
-      ` : ""}
+      `
+          : ""
+      }
     </div>
   `;
 }
 
 export function renderPositionReset(card) {
   const tiltMode = card._config?.tilt_mode || "none";
-  const hasIndependentTilt = tiltMode === "sequential_close" || tiltMode === "sequential_open" || tiltMode === "dual_motor" || tiltMode === "inline";
+  const hasIndependentTilt =
+    tiltMode === "sequential_close" ||
+    tiltMode === "sequential_open" ||
+    tiltMode === "dual_motor" ||
+    tiltMode === "inline";
 
   return html`
     <div class="section">
@@ -621,7 +645,9 @@ export function renderPositionReset(card) {
       <div class="helper-text">
         ${card._t("position.helper")}
       </div>
-      ${!card._hasTiltMotor() ? html`
+      ${
+        !card._hasTiltMotor()
+          ? html`
         <div class="cover-controls">
           <ha-button title=${card._t("controls.open")} @click=${() => card._onCoverCommand("open_cover")}>
             <ha-icon icon="mdi:window-shutter-open" style="--mdc-icon-size: 18px;"></ha-icon>
@@ -633,7 +659,8 @@ export function renderPositionReset(card) {
             <ha-icon icon="mdi:window-shutter" style="--mdc-icon-size: 18px;"></ha-icon>
           </ha-button>
         </div>
-      ` : html`
+      `
+          : html`
         <div class="cover-controls-wrapper">
           <div class="cover-controls">
             <span class="controls-label">${card._t("controls.cover_label")}</span>
@@ -660,7 +687,8 @@ export function renderPositionReset(card) {
             </ha-button>
           </div>
         </div>
-      `}
+      `
+      }
       <div class="cal-form">
         <div class="cal-field">
           <select
@@ -670,14 +698,16 @@ export function renderPositionReset(card) {
           >
             <option value="unknown" ?selected=${card._knownPosition === "unknown"}>${card._t("position.unknown")}</option>
             <option value="open" ?selected=${card._knownPosition === "open"}>${card._t("position.open")}</option>
-            ${hasIndependentTilt
-              ? html`
+            ${
+              hasIndependentTilt
+                ? html`
                   <option value="closed_tilt_open" ?selected=${card._knownPosition === "closed_tilt_open"}>${card._t("position.closed_tilt_open")}</option>
                   <option value="closed_tilt_closed" ?selected=${card._knownPosition === "closed_tilt_closed"}>${card._t("position.closed_tilt_closed")}</option>
                 `
-              : html`
+                : html`
                   <option value="closed" ?selected=${card._knownPosition === "closed"}>${card._t("position.closed")}</option>
-                `}
+                `
+            }
           </select>
         </div>
       </div>
@@ -689,14 +719,16 @@ export function renderCalibration(card, calibrating) {
   const state = card._getEntityState();
   const attrs = state?.attributes || {};
   const tiltMode = card._config?.tilt_mode || "none";
-  const hasTiltCalibration = tiltMode === "sequential_close" || tiltMode === "sequential_open" || tiltMode === "dual_motor" || tiltMode === "inline";
+  const hasTiltCalibration =
+    tiltMode === "sequential_close" ||
+    tiltMode === "sequential_open" ||
+    tiltMode === "dual_motor" ||
+    tiltMode === "inline";
 
-  const availableAttributes = TIMING_ATTRIBUTES.filter(
-    ([key]) => {
-      if (!hasTiltCalibration && key.startsWith("tilt_")) return false;
-      return true;
-    }
-  );
+  const availableAttributes = TIMING_ATTRIBUTES.filter(([key]) => {
+    if (!hasTiltCalibration && key.startsWith("tilt_")) return false;
+    return true;
+  });
 
   const c = card._config;
   const hasTravel = c?.travel_time_close || c?.travel_time_open;
@@ -758,8 +790,7 @@ export function renderCalibration(card, calibrating) {
     // finishing during the stepped phase records a hard-coded 0. Gate Finish
     // until the calibration reports its final step. Simple travel/tilt-time
     // tests have no stepped phase, so their Finish stays enabled throughout.
-    const isOverheadTest =
-      calAttr === "travel_startup_delay" || calAttr === "tilt_startup_delay";
+    const isOverheadTest = calAttr === "travel_startup_delay" || calAttr === "tilt_startup_delay";
     const finishDisabled = isOverheadTest && !attrs.calibration_final_step;
     return html`
       <div class="section calibration-active">
@@ -769,15 +800,17 @@ export function renderCalibration(card, calibrating) {
         </div>
         <div class="cal-active-body">
           <strong>${calLabel}</strong>
-          ${attrs.calibration_final_step
-            ? html`<span class="cal-step"
+          ${
+            attrs.calibration_final_step
+              ? html`<span class="cal-step"
                 >${card._t("calibration.final_step")}</span
               >`
-            : attrs.calibration_step
-              ? html`<span class="cal-step"
+              : attrs.calibration_step
+                ? html`<span class="cal-step"
                   >${card._t("calibration.step", { step: attrs.calibration_step })}</span
                 >`
-              : ""}
+                : ""
+          }
           <div class="cal-active-buttons">
             <ha-button @click=${() => card._onStopCalibration(true)}
               >${card._t("calibration.cancel")}</ha-button
@@ -805,7 +838,7 @@ export function renderCalibration(card, calibrating) {
           >
             ${availableAttributes.map(
               ([key, labelKey]) =>
-                html`<option value=${key} ?disabled=${disabledKeys.has(key)}>${card._t(labelKey)}</option>`
+                html`<option value=${key} ?disabled=${disabledKeys.has(key)}>${card._t(labelKey)}</option>`,
             )}
           </select>
         </div>
@@ -813,13 +846,15 @@ export function renderCalibration(card, calibrating) {
           >${card._t("calibration.start")}</ha-button
         >
       </div>
-      ${card._knownPosition === "unknown"
-        ? html`<div class="helper-text" style="margin-top: 8px;">
+      ${
+        card._knownPosition === "unknown"
+          ? html`<div class="helper-text" style="margin-top: 8px;">
             ${card._t("calibration.set_position_first")}
           </div>`
-        : html`<div class="helper-text" style="margin-top: 8px;">
+          : html`<div class="helper-text" style="margin-top: 8px;">
             ${card._getCalibrationHint()}
-          </div>`}
+          </div>`
+      }
     </div>
   `;
 }

--- a/custom_components/cover_time_based/frontend/cover-time-based-card.js
+++ b/custom_components/cover_time_based/frontend/cover-time-based-card.js
@@ -131,14 +131,10 @@ class CoverTimeBasedCard extends LitElement {
         try {
           await Promise.race([
             customElements.whenDefined("ha-entity-picker"),
-            new Promise((_, reject) =>
-              setTimeout(() => reject(new Error("timeout")), 10000)
-            ),
+            new Promise((_, reject) => setTimeout(() => reject(new Error("timeout")), 10000)),
           ]);
         } catch (_) {
-          console.warn(
-            "[cover-time-based-card] ha-entity-picker not available"
-          );
+          console.warn("[cover-time-based-card] ha-entity-picker not available");
         }
       }
 
@@ -242,20 +238,13 @@ class CoverTimeBasedCard extends LitElement {
         this.hass.callWS({ type: "config_entries/get", domain: DOMAIN }),
       ]);
       const validEntryIds = configEntries.map((e) => e.entry_id);
-      this._configEntryEntities = filterEntitiesByValidEntries(
-        registry,
-        validEntryIds,
-        DOMAIN
-      );
+      this._configEntryEntities = filterEntitiesByValidEntries(registry, validEntryIds, DOMAIN);
       // Restore before requesting the update so the populated picker and the
       // restored selection render together, rather than in two passes.
       this._restoreSelection();
       this.requestUpdate();
     } catch (err) {
-      console.error(
-        "Failed to load entity registry / config entries:",
-        err
-      );
+      console.error("Failed to load entity registry / config entries:", err);
       this._configEntryEntities = [];
       // _configEntryEntities isn't a reactive Lit property, so without this
       // the picker keeps showing whatever it last rendered (e.g. a stale
@@ -354,9 +343,7 @@ class CoverTimeBasedCard extends LitElement {
       // unrelated to YAML config and should say so generically instead of
       // sending the user off on a wild goose chase to "migrate" an entity
       // that is already fine.
-      this._loadError = this._t(
-        err?.code === "not_found" ? "yaml_warning" : "load_failed"
-      );
+      this._loadError = this._t(err?.code === "not_found" ? "yaml_warning" : "load_failed");
     } finally {
       // Only the newest request owns the spinner: an older one must not clear
       // it while a newer load is still running, but a request that was merely
@@ -385,7 +372,10 @@ class CoverTimeBasedCard extends LitElement {
   }
 
   async _autoSave() {
-    if (this._isCalibrating()) { this._scheduleAutoSave(); return; }
+    if (this._isCalibrating()) {
+      this._scheduleAutoSave();
+      return;
+    }
     if (!this._selectedEntity || !this.hass || !this._config) return;
     this._saving = true;
     this._saveError = false;
@@ -439,8 +429,8 @@ class CoverTimeBasedCard extends LitElement {
     if (attr === "travel_startup_delay") {
       effectiveAttr = pos === "open" ? "travel_time_close" : "travel_time_open";
     } else if (attr === "tilt_startup_delay") {
-      effectiveAttr = (pos === "closed_tilt_open" || pos === "open")
-        ? "tilt_time_close" : "tilt_time_open";
+      effectiveAttr =
+        pos === "closed_tilt_open" || pos === "open" ? "tilt_time_close" : "tilt_time_open";
     }
 
     if (attr === "min_movement_time") {
@@ -455,7 +445,8 @@ class CoverTimeBasedCard extends LitElement {
     if (c.control_mode === "wrapped") {
       if (!c.cover_entity_id) return false;
     } else if (c.control_mode === "pulse") {
-      if (!c.open_switch_entity_id || !c.close_switch_entity_id || !c.stop_switch_entity_id) return false;
+      if (!c.open_switch_entity_id || !c.close_switch_entity_id || !c.stop_switch_entity_id)
+        return false;
     } else {
       if (!c.open_switch_entity_id || !c.close_switch_entity_id) return false;
     }
@@ -721,11 +712,7 @@ class CoverTimeBasedCard extends LitElement {
 
   _onCreateNew() {
     // Navigate to helpers/add with domain param — HA auto-opens the config flow
-    window.history.pushState(
-      null,
-      "",
-      `/config/helpers/add?domain=${DOMAIN}`
-    );
+    window.history.pushState(null, "", `/config/helpers/add?domain=${DOMAIN}`);
     window.dispatchEvent(new Event("location-changed"));
   }
 

--- a/custom_components/cover_time_based/frontend/entity-filter.js
+++ b/custom_components/cover_time_based/frontend/entity-filter.js
@@ -9,19 +9,10 @@
  * set passed by the caller.
  */
 
-export function filterEntitiesByValidEntries(
-  entityRegistry,
-  validConfigEntryIds,
-  platform
-) {
+export function filterEntitiesByValidEntries(entityRegistry, validConfigEntryIds, platform) {
   const valid = new Set(validConfigEntryIds);
   return entityRegistry
-    .filter(
-      (e) =>
-        e.platform === platform &&
-        e.config_entry_id &&
-        valid.has(e.config_entry_id)
-    )
+    .filter((e) => e.platform === platform && e.config_entry_id && valid.has(e.config_entry_id))
     .map((e) => e.entity_id);
 }
 
@@ -135,8 +126,12 @@ export function clearedScriptEntities(mode, config) {
   if (mode === "pulse" || !config) return {};
   const updates = {};
   for (const key of [
-    "open_switch_entity_id", "close_switch_entity_id", "stop_switch_entity_id",
-    "tilt_open_switch", "tilt_close_switch", "tilt_stop_switch",
+    "open_switch_entity_id",
+    "close_switch_entity_id",
+    "stop_switch_entity_id",
+    "tilt_open_switch",
+    "tilt_close_switch",
+    "tilt_stop_switch",
   ]) {
     if (typeof config[key] === "string" && config[key].startsWith("script.")) {
       updates[key] = null;

--- a/custom_components/cover_time_based/frontend/language-banner.js
+++ b/custom_components/cover_time_based/frontend/language-banner.js
@@ -18,11 +18,9 @@ import { html } from "https://unpkg.com/lit-element@2.4.0/lit-element.js?module"
 import { isLanguageSupported, normaliseLocale } from "./translations.js";
 
 /** Upstream repository — the issue link must not point at a fork. */
-export const GITHUB_REPO_URL =
-  "https://github.com/Sese-Schneider/ha-cover-time-based";
+export const GITHUB_REPO_URL = "https://github.com/Sese-Schneider/ha-cover-time-based";
 
-export const LANG_DISMISSED_STORAGE_KEY =
-  "cover_time_based_card.dismissed_lang_requests";
+export const LANG_DISMISSED_STORAGE_KEY = "cover_time_based_card.dismissed_lang_requests";
 
 /**
  * The banner's copy, deliberately NOT in the translation table.
@@ -63,7 +61,7 @@ export function buildTranslationRequestUrl(code, displayName) {
   if (base !== code) {
     body.push(
       ``,
-      `A \`${base}\` catalogue would cover this — the card falls back to the base language.`
+      `A \`${base}\` catalogue would cover this — the card falls back to the base language.`,
     );
   }
   body.push(``, `- [ ] I'm happy to review the translation`);
@@ -121,10 +119,7 @@ export function persistLangDismissed(code) {
   try {
     const current = loadDismissedLangs();
     if (current.includes(code)) return;
-    window.localStorage.setItem(
-      LANG_DISMISSED_STORAGE_KEY,
-      JSON.stringify([...current, code])
-    );
+    window.localStorage.setItem(LANG_DISMISSED_STORAGE_KEY, JSON.stringify([...current, code]));
   } catch (_) {
     // storage unavailable — the dismissal simply isn't remembered
   }

--- a/custom_components/cover_time_based/frontend/translations.js
+++ b/custom_components/cover_time_based/frontend/translations.js
@@ -1,12 +1,13 @@
 export const EN = {
-  "header": "Cover Time Based Configuration",
-  "loading": "Loading...",
-  "saving": "Saving...",
-  "save_failed": "Save failed — value reverted",
-  "confirm_cancel_calibration": "A calibration is running. Cancel it and continue?",
-  "create_new": "+ Create new cover entity",
-  "yaml_warning": "This entity uses YAML configuration and cannot be configured from this card. Please migrate to the UI: Settings \u2192 Devices & Services \u2192 Helpers \u2192 Create Helper \u2192 Cover Time Based.",
-  "load_failed": "Failed to load configuration. Please try again.",
+  header: "Cover Time Based Configuration",
+  loading: "Loading...",
+  saving: "Saving...",
+  save_failed: "Save failed — value reverted",
+  confirm_cancel_calibration: "A calibration is running. Cancel it and continue?",
+  create_new: "+ Create new cover entity",
+  yaml_warning:
+    "This entity uses YAML configuration and cannot be configured from this card. Please migrate to the UI: Settings \u2192 Devices & Services \u2192 Helpers \u2192 Create Helper \u2192 Cover Time Based.",
+  load_failed: "Failed to load configuration. Please try again.",
   "tabs.device": "Device",
   "tabs.calibration": "Calibration",
   "control_mode.label": "Control Mode",
@@ -54,7 +55,8 @@ export const EN = {
   "tilt_motor.safe_position": "Safe tilt position",
   "tilt_motor.safe_position_helper": "Tilt moves here before travel (100 = fully open)",
   "tilt_motor.max_allowed_position": "Max tilt allowed position (optional)",
-  "tilt_motor.max_allowed_helper": "Tilt only allowed when cover position is at or below this value (0 = closed, 100 = open)",
+  "tilt_motor.max_allowed_helper":
+    "Tilt only allowed when cover position is at or below this value (0 = closed, 100 = open)",
   "tilt.close_includes_tilt": "Close cover also closes slats",
   "tilt.close_includes_tilt_helper": "When closing, slats tilt closed at the end of travel",
   "assumed_state.label": "Assumed state",
@@ -72,7 +74,7 @@ export const EN = {
   "recalibrate_before_position.label": "Fully open before moving to a position (Beta)",
   "recalibrate_before_position.helper":
     "For covers with no position feedback that a remote can also move. Drives the cover fully open before each position command, so the move starts from a known position instead of a drifted guess. Roughly doubles the travel of every move, and on inline or sequential tilt it moves the cover when you adjust the slats.",
-  "more_info": "More info",
+  more_info: "More info",
   "timing.travel_attribute_header": "Travel Attribute",
   "timing.tilt_attribute_header": "Tilt Attribute",
   "timing.value_header": "Value",
@@ -109,22 +111,38 @@ export const EN = {
   "controls.tilt_open": "Tilt open",
   "controls.tilt_stop": "Tilt stop",
   "controls.tilt_close": "Tilt close",
-  "hints.sequential_close.travel_time_close": "Start with cover fully open. Click Finish when the cover is fully closed, before the slats start tilting.",
-  "hints.sequential_close.travel_time_open": "Start with cover closed and slats open. Click Finish when the cover is fully open.",
-  "hints.sequential_close.tilt_time_close": "Start with cover closed but slats open. Click Finish when the slats are fully closed.",
-  "hints.sequential_close.tilt_time_open": "Start with cover and slats closed. Click Finish when the slats are open.",
-  "hints.sequential_open.travel_time_close": "Start with cover fully open and slats closed. Click Finish when the cover is fully closed, before the slats start tilting open.",
-  "hints.sequential_open.travel_time_open": "Start with cover closed and slats closed. Click Finish when the cover is fully open.",
-  "hints.sequential_open.tilt_time_close": "Start with cover closed but slats open. Click Finish when the slats are fully closed.",
-  "hints.sequential_open.tilt_time_open": "Start with cover and slats closed. Click Finish when the slats are fully open.",
-  "hints.dual_motor.travel_time_close": "Start with cover open and slats in safe position. Click Finish when the cover is fully closed.",
-  "hints.dual_motor.travel_time_open": "Start with cover closed and slats in safe position. Click Finish when the cover is fully open.",
-  "hints.dual_motor.tilt_time_close": "Start with cover closed and slats open. Click Finish when the slats are fully closed.",
-  "hints.dual_motor.tilt_time_open": "Start with both cover and slats closed. Click Finish when the slats are fully open.",
-  "hints.inline.travel_time_close": "Start with both cover and slats fully open. Click Finish when both are fully closed.",
-  "hints.inline.travel_time_open": "Start with both cover and slats fully closed. Click Finish when both are fully open.",
-  "hints.inline.tilt_time_close": "Start with slats fully open. Click Finish when the slats are fully closed.",
-  "hints.inline.tilt_time_open": "Start with slats fully closed. Click Finish when the slats are fully open.",
+  "hints.sequential_close.travel_time_close":
+    "Start with cover fully open. Click Finish when the cover is fully closed, before the slats start tilting.",
+  "hints.sequential_close.travel_time_open":
+    "Start with cover closed and slats open. Click Finish when the cover is fully open.",
+  "hints.sequential_close.tilt_time_close":
+    "Start with cover closed but slats open. Click Finish when the slats are fully closed.",
+  "hints.sequential_close.tilt_time_open":
+    "Start with cover and slats closed. Click Finish when the slats are open.",
+  "hints.sequential_open.travel_time_close":
+    "Start with cover fully open and slats closed. Click Finish when the cover is fully closed, before the slats start tilting open.",
+  "hints.sequential_open.travel_time_open":
+    "Start with cover closed and slats closed. Click Finish when the cover is fully open.",
+  "hints.sequential_open.tilt_time_close":
+    "Start with cover closed but slats open. Click Finish when the slats are fully closed.",
+  "hints.sequential_open.tilt_time_open":
+    "Start with cover and slats closed. Click Finish when the slats are fully open.",
+  "hints.dual_motor.travel_time_close":
+    "Start with cover open and slats in safe position. Click Finish when the cover is fully closed.",
+  "hints.dual_motor.travel_time_open":
+    "Start with cover closed and slats in safe position. Click Finish when the cover is fully open.",
+  "hints.dual_motor.tilt_time_close":
+    "Start with cover closed and slats open. Click Finish when the slats are fully closed.",
+  "hints.dual_motor.tilt_time_open":
+    "Start with both cover and slats closed. Click Finish when the slats are fully open.",
+  "hints.inline.travel_time_close":
+    "Start with both cover and slats fully open. Click Finish when both are fully closed.",
+  "hints.inline.travel_time_open":
+    "Start with both cover and slats fully closed. Click Finish when both are fully open.",
+  "hints.inline.tilt_time_close":
+    "Start with slats fully open. Click Finish when the slats are fully closed.",
+  "hints.inline.tilt_time_open":
+    "Start with slats fully closed. Click Finish when the slats are fully open.",
   "hints.none.travel_time_close": "Click Finish when the cover is fully closed.",
   "hints.none.travel_time_open": "Click Finish when the cover is fully open.",
   "hints.min_movement_time": "Click Finish as soon as you notice the cover moving.",
@@ -133,14 +151,15 @@ export const EN = {
 export const TRANSLATIONS = {
   en: EN,
   pt: {
-    "header": "Configuração de Estore Baseado em Tempo",
-    "loading": "A carregar...",
-    "saving": "A guardar...",
-    "save_failed": "Falha ao guardar — valor revertido",
-    "confirm_cancel_calibration": "Existe uma calibração em curso. Cancelar e continuar?",
-    "create_new": "+ Criar nova entidade de estore",
-    "yaml_warning": "Esta entidade utiliza configuração YAML e não pode ser configurada a partir deste cartão. Por favor, migre para a interface gráfica: Definições > Dispositivos e Serviços > Auxiliares > Criar Auxiliar > Estore Baseado em Tempo.",
-    "load_failed": "Falha ao carregar a configuração. Por favor, tente novamente.",
+    header: "Configuração de Estore Baseado em Tempo",
+    loading: "A carregar...",
+    saving: "A guardar...",
+    save_failed: "Falha ao guardar — valor revertido",
+    confirm_cancel_calibration: "Existe uma calibração em curso. Cancelar e continuar?",
+    create_new: "+ Criar nova entidade de estore",
+    yaml_warning:
+      "Esta entidade utiliza configuração YAML e não pode ser configurada a partir deste cartão. Por favor, migre para a interface gráfica: Definições > Dispositivos e Serviços > Auxiliares > Criar Auxiliar > Estore Baseado em Tempo.",
+    load_failed: "Falha ao carregar a configuração. Por favor, tente novamente.",
     "tabs.device": "Dispositivo",
     "tabs.calibration": "Calibração",
     "control_mode.label": "Modo de Controlo",
@@ -186,11 +205,14 @@ export const TRANSLATIONS = {
     "tilt_motor.close_switch_pulse": "Interruptor ou script de fechar inclinação",
     "tilt_motor.stop_switch_pulse": "Interruptor ou script de parar inclinação",
     "tilt_motor.safe_position": "Posição de inclinação segura",
-    "tilt_motor.safe_position_helper": "A inclinação move-se para aqui antes do deslocamento (100 = totalmente aberto)",
+    "tilt_motor.safe_position_helper":
+      "A inclinação move-se para aqui antes do deslocamento (100 = totalmente aberto)",
     "tilt_motor.max_allowed_position": "Posição máxima permitida de inclinação (opcional)",
-    "tilt_motor.max_allowed_helper": "A inclinação só é permitida quando a posição do estore está neste valor ou abaixo (0 = fechado, 100 = aberto)",
+    "tilt_motor.max_allowed_helper":
+      "A inclinação só é permitida quando a posição do estore está neste valor ou abaixo (0 = fechado, 100 = aberto)",
     "tilt.close_includes_tilt": "Fechar estore também fecha lâminas",
-    "tilt.close_includes_tilt_helper": "Ao fechar, as lâminas inclinam para fechado no fim do percurso",
+    "tilt.close_includes_tilt_helper":
+      "Ao fechar, as lâminas inclinam para fechado no fim do percurso",
     "assumed_state.label": "Estado assumido",
     "assumed_state.helper":
       "Quando ativo, o Home Assistant trata a posição como estimada e mantém ativos os controlos de abrir e fechar. Desative se confiar no cálculo por tempo e quiser que a interface desative as ações indisponíveis (por exemplo, fechar quando já está fechado).",
@@ -206,7 +228,7 @@ export const TRANSLATIONS = {
     "recalibrate_before_position.label": "Abrir totalmente antes de mover para uma posição (Beta)",
     "recalibrate_before_position.helper":
       "Para estores sem retorno de posição que também podem ser movidos por um telecomando. Antes de cada comando de definir posição, move primeiro o estore para totalmente aberto, para que o movimento comece a partir de uma posição conhecida em vez de uma estimativa desviada. Isto duplica, grosso modo, o tempo de deslocamento de cada movimento e, na inclinação durante o deslocamento ou na inclinação sequencial, ajustar as lâminas também move o estore.",
-    "more_info": "Mais informação",
+    more_info: "Mais informação",
     "timing.travel_attribute_header": "Atributo de deslocamento",
     "timing.tilt_attribute_header": "Atributo de inclinação",
     "timing.value_header": "Valor",
@@ -243,35 +265,53 @@ export const TRANSLATIONS = {
     "controls.tilt_open": "Inclinar abrir",
     "controls.tilt_stop": "Inclinar parar",
     "controls.tilt_close": "Inclinar fechar",
-    "hints.sequential_close.travel_time_close": "Comece com o estore totalmente aberto. Clique em Concluir quando o estore estiver totalmente fechado, antes de as lâminas começarem a inclinar.",
-    "hints.sequential_close.travel_time_open": "Comece com o estore fechado e as lâminas abertas. Clique em Concluir quando o estore estiver totalmente aberto.",
-    "hints.sequential_close.tilt_time_close": "Comece com o estore fechado mas as lâminas abertas. Clique em Concluir quando as lâminas estiverem totalmente fechadas.",
-    "hints.sequential_close.tilt_time_open": "Comece com o estore e as lâminas fechados. Clique em Concluir quando as lâminas estiverem abertas.",
-    "hints.sequential_open.travel_time_close": "Comece com o estore totalmente aberto e as lâminas fechadas. Clique em Concluir quando o estore estiver totalmente fechado, antes de as lâminas começarem a inclinar-se abertas.",
-    "hints.sequential_open.travel_time_open": "Comece com o estore fechado e as lâminas fechadas. Clique em Concluir quando o estore estiver totalmente aberto.",
-    "hints.sequential_open.tilt_time_close": "Comece com o estore fechado mas as lâminas abertas. Clique em Concluir quando as lâminas estiverem totalmente fechadas.",
-    "hints.sequential_open.tilt_time_open": "Comece com o estore e as lâminas fechados. Clique em Concluir quando as lâminas estiverem totalmente abertas.",
-    "hints.dual_motor.travel_time_close": "Comece com o estore aberto e as lâminas na posição segura. Clique em Concluir quando o estore estiver totalmente fechado.",
-    "hints.dual_motor.travel_time_open": "Comece com o estore fechado e as lâminas na posição segura. Clique em Concluir quando o estore estiver totalmente aberto.",
-    "hints.dual_motor.tilt_time_close": "Comece com o estore fechado e as lâminas abertas. Clique em Concluir quando as lâminas estiverem totalmente fechadas.",
-    "hints.dual_motor.tilt_time_open": "Comece com o estore e as lâminas fechados. Clique em Concluir quando as lâminas estiverem totalmente abertas.",
-    "hints.inline.travel_time_close": "Comece com o estore e as lâminas totalmente abertos. Clique em Concluir quando ambos estiverem totalmente fechados.",
-    "hints.inline.travel_time_open": "Comece com o estore e as lâminas totalmente fechados. Clique em Concluir quando ambos estiverem totalmente abertos.",
-    "hints.inline.tilt_time_close": "Comece com as lâminas totalmente abertas. Clique em Concluir quando as lâminas estiverem totalmente fechadas.",
-    "hints.inline.tilt_time_open": "Comece com as lâminas totalmente fechadas. Clique em Concluir quando as lâminas estiverem totalmente abertas.",
-    "hints.none.travel_time_close": "Clique em Concluir quando o estore estiver totalmente fechado.",
+    "hints.sequential_close.travel_time_close":
+      "Comece com o estore totalmente aberto. Clique em Concluir quando o estore estiver totalmente fechado, antes de as lâminas começarem a inclinar.",
+    "hints.sequential_close.travel_time_open":
+      "Comece com o estore fechado e as lâminas abertas. Clique em Concluir quando o estore estiver totalmente aberto.",
+    "hints.sequential_close.tilt_time_close":
+      "Comece com o estore fechado mas as lâminas abertas. Clique em Concluir quando as lâminas estiverem totalmente fechadas.",
+    "hints.sequential_close.tilt_time_open":
+      "Comece com o estore e as lâminas fechados. Clique em Concluir quando as lâminas estiverem abertas.",
+    "hints.sequential_open.travel_time_close":
+      "Comece com o estore totalmente aberto e as lâminas fechadas. Clique em Concluir quando o estore estiver totalmente fechado, antes de as lâminas começarem a inclinar-se abertas.",
+    "hints.sequential_open.travel_time_open":
+      "Comece com o estore fechado e as lâminas fechadas. Clique em Concluir quando o estore estiver totalmente aberto.",
+    "hints.sequential_open.tilt_time_close":
+      "Comece com o estore fechado mas as lâminas abertas. Clique em Concluir quando as lâminas estiverem totalmente fechadas.",
+    "hints.sequential_open.tilt_time_open":
+      "Comece com o estore e as lâminas fechados. Clique em Concluir quando as lâminas estiverem totalmente abertas.",
+    "hints.dual_motor.travel_time_close":
+      "Comece com o estore aberto e as lâminas na posição segura. Clique em Concluir quando o estore estiver totalmente fechado.",
+    "hints.dual_motor.travel_time_open":
+      "Comece com o estore fechado e as lâminas na posição segura. Clique em Concluir quando o estore estiver totalmente aberto.",
+    "hints.dual_motor.tilt_time_close":
+      "Comece com o estore fechado e as lâminas abertas. Clique em Concluir quando as lâminas estiverem totalmente fechadas.",
+    "hints.dual_motor.tilt_time_open":
+      "Comece com o estore e as lâminas fechados. Clique em Concluir quando as lâminas estiverem totalmente abertas.",
+    "hints.inline.travel_time_close":
+      "Comece com o estore e as lâminas totalmente abertos. Clique em Concluir quando ambos estiverem totalmente fechados.",
+    "hints.inline.travel_time_open":
+      "Comece com o estore e as lâminas totalmente fechados. Clique em Concluir quando ambos estiverem totalmente abertos.",
+    "hints.inline.tilt_time_close":
+      "Comece com as lâminas totalmente abertas. Clique em Concluir quando as lâminas estiverem totalmente fechadas.",
+    "hints.inline.tilt_time_open":
+      "Comece com as lâminas totalmente fechadas. Clique em Concluir quando as lâminas estiverem totalmente abertas.",
+    "hints.none.travel_time_close":
+      "Clique em Concluir quando o estore estiver totalmente fechado.",
     "hints.none.travel_time_open": "Clique em Concluir quando o estore estiver totalmente aberto.",
     "hints.min_movement_time": "Clique em Concluir assim que notar o estore a mover-se.",
   },
   pl: {
-    "header": "Konfiguracja rolet sterowanych czasowo",
-    "loading": "Ładowanie...",
-    "saving": "Zapisywanie...",
-    "save_failed": "Zapis nie powiódł się — wartość przywrócona",
-    "confirm_cancel_calibration": "Kalibracja jest w toku. Anulować ją i kontynuować?",
-    "create_new": "+ Utwórz nową encję rolety",
-    "yaml_warning": "Ta encja używa konfiguracji YAML i nie może być konfigurowana z tej karty. Proszę przeprowadzić migrację do interfejsu użytkownika: Ustawienia > Urządzenia i usługi > Pomocniki > Utwórz pomocnik > Roleta sterowana czasowo.",
-    "load_failed": "Nie udało się załadować konfiguracji. Spróbuj ponownie.",
+    header: "Konfiguracja rolet sterowanych czasowo",
+    loading: "Ładowanie...",
+    saving: "Zapisywanie...",
+    save_failed: "Zapis nie powiódł się — wartość przywrócona",
+    confirm_cancel_calibration: "Kalibracja jest w toku. Anulować ją i kontynuować?",
+    create_new: "+ Utwórz nową encję rolety",
+    yaml_warning:
+      "Ta encja używa konfiguracji YAML i nie może być konfigurowana z tej karty. Proszę przeprowadzić migrację do interfejsu użytkownika: Ustawienia > Urządzenia i usługi > Pomocniki > Utwórz pomocnik > Roleta sterowana czasowo.",
+    load_failed: "Nie udało się załadować konfiguracji. Spróbuj ponownie.",
     "tabs.device": "Urządzenie",
     "tabs.calibration": "Kalibracja",
     "control_mode.label": "Tryb sterowania",
@@ -317,11 +357,14 @@ export const TRANSLATIONS = {
     "tilt_motor.close_switch_pulse": "Przełącznik lub skrypt zamykania nachylenia",
     "tilt_motor.stop_switch_pulse": "Przełącznik lub skrypt zatrzymania nachylenia",
     "tilt_motor.safe_position": "Bezpieczna pozycja nachylenia",
-    "tilt_motor.safe_position_helper": "Nachylenie przesuwa się tu przed ruchem (100 = w pełni otwarte)",
+    "tilt_motor.safe_position_helper":
+      "Nachylenie przesuwa się tu przed ruchem (100 = w pełni otwarte)",
     "tilt_motor.max_allowed_position": "Maks. dozwolona pozycja nachylenia (opcjonalna)",
-    "tilt_motor.max_allowed_helper": "Nachylenie dozwolone tylko gdy pozycja rolety wynosi tyle lub mniej (0 = zamknięta, 100 = otwarta)",
+    "tilt_motor.max_allowed_helper":
+      "Nachylenie dozwolone tylko gdy pozycja rolety wynosi tyle lub mniej (0 = zamknięta, 100 = otwarta)",
     "tilt.close_includes_tilt": "Zamknięcie rolety zamyka również lamele",
-    "tilt.close_includes_tilt_helper": "Podczas zamykania lamele nachylają się do pozycji zamkniętej na końcu ruchu",
+    "tilt.close_includes_tilt_helper":
+      "Podczas zamykania lamele nachylają się do pozycji zamkniętej na końcu ruchu",
     "assumed_state.label": "Stan zakładany",
     "assumed_state.helper":
       "Gdy włączone, Home Assistant traktuje pozycję jako szacowaną i pozostawia aktywne przyciski otwierania i zamykania. Wyłącz, jeśli ufasz obliczeniom czasowym i chcesz, aby interfejs wyszarzał niedostępne akcje (np. zamknięcie, gdy roleta jest już zamknięta).",
@@ -331,15 +374,13 @@ export const TRANSLATIONS = {
     "send_endpoint_stop.label": "Wysyłaj sygnał zatrzymania na krańcach",
     "send_endpoint_stop.helper":
       "Gdy roleta osiągnie pełne otwarcie lub zamknięcie, wyślij impuls zatrzymania. Pozostaw włączone dla sterowników, które działają, dopóki nie otrzymają zatrzymania (w przeciwnym razie roleta blokuje się, a fizyczne przyciski przestają reagować). Wyłącz, jeśli silnik sam zatrzymuje się na krańcach, a dodatkowe zatrzymanie powoduje przejście do zaprogramowanej/ulubionej pozycji.",
-    "force_endpoint_redrive.label":
-      "Zawsze ponownie wysyłaj otwórz/zamknij na krańcach",
+    "force_endpoint_redrive.label": "Zawsze ponownie wysyłaj otwórz/zamknij na krańcach",
     "force_endpoint_redrive.helper":
       "Dla rolet bez informacji zwrotnej o pozycji, które mogą być sterowane również zewnętrznym pilotem, przez co Home Assistant może błędnie sądzić, że są już całkowicie otwarte lub zamknięte. Po włączeniu polecenie otwarcia lub zamknięcia jest zawsze wykonywane przez pełny czas ruchu, nawet jeśli Home Assistant sądzi, że roleta już tam jest — dzięki czemu polecenie na pewno dotrze do silnika. Pozostaw wyłączone dla rolet zgłaszających własną pozycję.",
-    "recalibrate_before_position.label":
-      "Otwórz w pełni przed przejściem do pozycji (Beta)",
+    "recalibrate_before_position.label": "Otwórz w pełni przed przejściem do pozycji (Beta)",
     "recalibrate_before_position.helper":
       "Dla rolet bez informacji zwrotnej o pozycji, które mogą być poruszane również pilotem. Przed każdym poleceniem ustawienia pozycji najpierw otwiera roletę w pełni, dzięki czemu ruch zaczyna się od znanej pozycji, a nie od nieaktualnego przybliżenia. Z grubsza podwaja czas ruchu przy każdym przesunięciu, a przy nachyleniu w trakcie ruchu lub nachyleniu sekwencyjnym regulacja listew porusza także samą roletę.",
-    "more_info": "Więcej informacji",
+    more_info: "Więcej informacji",
     "timing.travel_attribute_header": "Atrybut ruchu",
     "timing.tilt_attribute_header": "Atrybut nachylenia",
     "timing.value_header": "Wartość",
@@ -376,35 +417,52 @@ export const TRANSLATIONS = {
     "controls.tilt_open": "Otwórz nachylenie",
     "controls.tilt_stop": "Zatrzymaj nachylenie",
     "controls.tilt_close": "Zamknij nachylenie",
-    "hints.sequential_close.travel_time_close": "Zacznij z roletą w pełni otwartą. Kliknij Zakończ, gdy roleta jest w pełni zamknięta, zanim listwy zaczną się nachylać.",
-    "hints.sequential_close.travel_time_open": "Zacznij z zamkniętą roletą i otwartymi listwami. Kliknij Zakończ, gdy roleta jest w pełni otwarta.",
-    "hints.sequential_close.tilt_time_close": "Zacznij z zamkniętą roletą, ale otwartymi listwami. Kliknij Zakończ, gdy listwy są w pełni zamknięte.",
-    "hints.sequential_close.tilt_time_open": "Zacznij z zamkniętą roletą i zamkniętymi listwami. Kliknij Zakończ, gdy listwy są otwarte.",
-    "hints.sequential_open.travel_time_close": "Zacznij z roletą w pełni otwartą i zamkniętymi listwami. Kliknij Zakończ, gdy roleta jest w pełni zamknięta, zanim listwy zaczną się nachylać otwarte.",
-    "hints.sequential_open.travel_time_open": "Zacznij z zamkniętą roletą i zamkniętymi listwami. Kliknij Zakończ, gdy roleta jest w pełni otwarta.",
-    "hints.sequential_open.tilt_time_close": "Zacznij z zamkniętą roletą, ale otwartymi listwami. Kliknij Zakończ, gdy listwy są w pełni zamknięte.",
-    "hints.sequential_open.tilt_time_open": "Zacznij z zamkniętą roletą i zamkniętymi listwami. Kliknij Zakończ, gdy listwy są w pełni otwarte.",
-    "hints.dual_motor.travel_time_close": "Zacznij z otwartą roletą i listwami w bezpiecznej pozycji. Kliknij Zakończ, gdy roleta jest w pełni zamknięta.",
-    "hints.dual_motor.travel_time_open": "Zacznij z zamkniętą roletą i listwami w bezpiecznej pozycji. Kliknij Zakończ, gdy roleta jest w pełni otwarta.",
-    "hints.dual_motor.tilt_time_close": "Zacznij z zamkniętą roletą i otwartymi listwami. Kliknij Zakończ, gdy listwy są w pełni zamknięte.",
-    "hints.dual_motor.tilt_time_open": "Zacznij z zamkniętą roletą i zamkniętymi listwami. Kliknij Zakończ, gdy listwy są w pełni otwarte.",
-    "hints.inline.travel_time_close": "Zacznij z roletą i listwami w pełni otwartymi. Kliknij Zakończ, gdy obie są w pełni zamknięte.",
-    "hints.inline.travel_time_open": "Zacznij z roletą i listwami w pełni zamkniętymi. Kliknij Zakończ, gdy obie są w pełni otwarte.",
-    "hints.inline.tilt_time_close": "Zacznij z listwami w pełni otwartymi. Kliknij Zakończ, gdy listwy są w pełni zamknięte.",
-    "hints.inline.tilt_time_open": "Zacznij z listwami w pełni zamkniętymi. Kliknij Zakończ, gdy listwy są w pełni otwarte.",
+    "hints.sequential_close.travel_time_close":
+      "Zacznij z roletą w pełni otwartą. Kliknij Zakończ, gdy roleta jest w pełni zamknięta, zanim listwy zaczną się nachylać.",
+    "hints.sequential_close.travel_time_open":
+      "Zacznij z zamkniętą roletą i otwartymi listwami. Kliknij Zakończ, gdy roleta jest w pełni otwarta.",
+    "hints.sequential_close.tilt_time_close":
+      "Zacznij z zamkniętą roletą, ale otwartymi listwami. Kliknij Zakończ, gdy listwy są w pełni zamknięte.",
+    "hints.sequential_close.tilt_time_open":
+      "Zacznij z zamkniętą roletą i zamkniętymi listwami. Kliknij Zakończ, gdy listwy są otwarte.",
+    "hints.sequential_open.travel_time_close":
+      "Zacznij z roletą w pełni otwartą i zamkniętymi listwami. Kliknij Zakończ, gdy roleta jest w pełni zamknięta, zanim listwy zaczną się nachylać otwarte.",
+    "hints.sequential_open.travel_time_open":
+      "Zacznij z zamkniętą roletą i zamkniętymi listwami. Kliknij Zakończ, gdy roleta jest w pełni otwarta.",
+    "hints.sequential_open.tilt_time_close":
+      "Zacznij z zamkniętą roletą, ale otwartymi listwami. Kliknij Zakończ, gdy listwy są w pełni zamknięte.",
+    "hints.sequential_open.tilt_time_open":
+      "Zacznij z zamkniętą roletą i zamkniętymi listwami. Kliknij Zakończ, gdy listwy są w pełni otwarte.",
+    "hints.dual_motor.travel_time_close":
+      "Zacznij z otwartą roletą i listwami w bezpiecznej pozycji. Kliknij Zakończ, gdy roleta jest w pełni zamknięta.",
+    "hints.dual_motor.travel_time_open":
+      "Zacznij z zamkniętą roletą i listwami w bezpiecznej pozycji. Kliknij Zakończ, gdy roleta jest w pełni otwarta.",
+    "hints.dual_motor.tilt_time_close":
+      "Zacznij z zamkniętą roletą i otwartymi listwami. Kliknij Zakończ, gdy listwy są w pełni zamknięte.",
+    "hints.dual_motor.tilt_time_open":
+      "Zacznij z zamkniętą roletą i zamkniętymi listwami. Kliknij Zakończ, gdy listwy są w pełni otwarte.",
+    "hints.inline.travel_time_close":
+      "Zacznij z roletą i listwami w pełni otwartymi. Kliknij Zakończ, gdy obie są w pełni zamknięte.",
+    "hints.inline.travel_time_open":
+      "Zacznij z roletą i listwami w pełni zamkniętymi. Kliknij Zakończ, gdy obie są w pełni otwarte.",
+    "hints.inline.tilt_time_close":
+      "Zacznij z listwami w pełni otwartymi. Kliknij Zakończ, gdy listwy są w pełni zamknięte.",
+    "hints.inline.tilt_time_open":
+      "Zacznij z listwami w pełni zamkniętymi. Kliknij Zakończ, gdy listwy są w pełni otwarte.",
     "hints.none.travel_time_close": "Kliknij Zakończ, gdy roleta jest w pełni zamknięta.",
     "hints.none.travel_time_open": "Kliknij Zakończ, gdy roleta jest w pełni otwarta.",
     "hints.min_movement_time": "Kliknij Zakończ, gdy tylko zauważysz ruch rolety.",
   },
   de: {
-    "header": "Konfiguration von Cover Time Based",
-    "loading": "Wird geladen...",
-    "saving": "Wird gespeichert...",
-    "save_failed": "Speichern fehlgeschlagen — Wert zurückgesetzt",
-    "confirm_cancel_calibration": "Eine Kalibrierung läuft. Abbrechen und fortfahren?",
-    "create_new": "+ Neue Rollladen-Entität anlegen",
-    "yaml_warning": "Diese Entität verwendet eine YAML-Konfiguration und kann nicht über diese Karte konfiguriert werden. Bitte migriere sie auf die Benutzeroberfläche: Einstellungen → Geräte & Dienste → Helfer → Helfer erstellen → Cover Time Based.",
-    "load_failed": "Laden der Konfiguration fehlgeschlagen. Bitte versuche es erneut.",
+    header: "Konfiguration von Cover Time Based",
+    loading: "Wird geladen...",
+    saving: "Wird gespeichert...",
+    save_failed: "Speichern fehlgeschlagen — Wert zurückgesetzt",
+    confirm_cancel_calibration: "Eine Kalibrierung läuft. Abbrechen und fortfahren?",
+    create_new: "+ Neue Rollladen-Entität anlegen",
+    yaml_warning:
+      "Diese Entität verwendet eine YAML-Konfiguration und kann nicht über diese Karte konfiguriert werden. Bitte migriere sie auf die Benutzeroberfläche: Einstellungen → Geräte & Dienste → Helfer → Helfer erstellen → Cover Time Based.",
+    load_failed: "Laden der Konfiguration fehlgeschlagen. Bitte versuche es erneut.",
     "tabs.device": "Gerät",
     "tabs.calibration": "Kalibrierung",
     "control_mode.label": "Steuerungsmodus",
@@ -450,11 +508,14 @@ export const TRANSLATIONS = {
     "tilt_motor.close_switch_pulse": "Schalter oder Skript zum Schließen der Neigung",
     "tilt_motor.stop_switch_pulse": "Schalter oder Skript zum Stoppen der Neigung",
     "tilt_motor.safe_position": "Sichere Neigungsposition",
-    "tilt_motor.safe_position_helper": "Die Neigung fährt vor der Fahrt hierhin (100 = vollständig geöffnet)",
+    "tilt_motor.safe_position_helper":
+      "Die Neigung fährt vor der Fahrt hierhin (100 = vollständig geöffnet)",
     "tilt_motor.max_allowed_position": "Maximal erlaubte Neigungsposition (optional)",
-    "tilt_motor.max_allowed_helper": "Neigen ist nur erlaubt, wenn die Rollladenposition auf oder unter diesem Wert liegt (0 = geschlossen, 100 = offen)",
+    "tilt_motor.max_allowed_helper":
+      "Neigen ist nur erlaubt, wenn die Rollladenposition auf oder unter diesem Wert liegt (0 = geschlossen, 100 = offen)",
     "tilt.close_includes_tilt": "Schließen des Rollladens schließt auch die Lamellen",
-    "tilt.close_includes_tilt_helper": "Beim Schließen neigen sich die Lamellen am Ende der Fahrt zu",
+    "tilt.close_includes_tilt_helper":
+      "Beim Schließen neigen sich die Lamellen am Ende der Fahrt zu",
     "assumed_state.label": "Angenommener Zustand",
     "assumed_state.helper":
       "Wenn aktiviert, behandelt Home Assistant die Position als geschätzt und hält die Bedienelemente zum Öffnen und Schließen aktiv. Deaktiviere dies, wenn du der zeitbasierten Berechnung vertraust und möchtest, dass die Oberfläche nicht verfügbare Aktionen ausgraut (z. B. Schließen, wenn bereits geschlossen).",
@@ -467,10 +528,11 @@ export const TRANSLATIONS = {
     "force_endpoint_redrive.label": "Öffnen/Schließen an den Endlagen immer erneut senden",
     "force_endpoint_redrive.helper":
       "Für Rollläden ohne Positionsrückmeldung, die sich zusätzlich per externer Fernbedienung bewegen lassen, sodass Home Assistant fälschlich annehmen kann, sie seien bereits vollständig geöffnet oder geschlossen. Wenn aktiviert, wird ein Öffnen- oder Schließen-Befehl immer über die volle Fahrzeit ausgeführt, selbst wenn Home Assistant den Rollladen dort schon vermutet — so erreicht der Befehl garantiert den Motor. Für Rollläden, die ihre eigene Position melden, deaktiviert lassen.",
-    "recalibrate_before_position.label": "Vor einer Positionsfahrt zuerst vollständig öffnen (Beta)",
+    "recalibrate_before_position.label":
+      "Vor einer Positionsfahrt zuerst vollständig öffnen (Beta)",
     "recalibrate_before_position.helper":
       "Für Rollläden ohne Positionsrückmeldung, die sich auch per Fernbedienung bewegen lassen. Fährt den Rollladen vor jedem Positionsbefehl zuerst vollständig auf, sodass die Fahrt von einer bekannten Position statt von einer abgedrifteten Schätzung beginnt. Verdoppelt dadurch etwa die Fahrzeit jeder Fahrt, und bei Neigung während der Fahrt oder bei sequenzieller Neigung bewegt sich der Rollladen mit, sobald du die Lamellen verstellst.",
-    "more_info": "Weitere Informationen",
+    more_info: "Weitere Informationen",
     "timing.travel_attribute_header": "Fahrattribut",
     "timing.tilt_attribute_header": "Neigungsattribut",
     "timing.value_header": "Wert",
@@ -507,35 +569,55 @@ export const TRANSLATIONS = {
     "controls.tilt_open": "Neigung öffnen",
     "controls.tilt_stop": "Neigung stoppen",
     "controls.tilt_close": "Neigung schließen",
-    "hints.sequential_close.travel_time_close": "Beginne mit vollständig geöffnetem Rollladen. Klicke auf Fertig, wenn der Rollladen vollständig geschlossen ist, bevor sich die Lamellen zu neigen beginnen.",
-    "hints.sequential_close.travel_time_open": "Beginne mit geschlossenem Rollladen und offenen Lamellen. Klicke auf Fertig, wenn der Rollladen vollständig geöffnet ist.",
-    "hints.sequential_close.tilt_time_close": "Beginne mit geschlossenem Rollladen, aber offenen Lamellen. Klicke auf Fertig, wenn die Lamellen vollständig geschlossen sind.",
-    "hints.sequential_close.tilt_time_open": "Beginne mit geschlossenem Rollladen und geschlossenen Lamellen. Klicke auf Fertig, wenn die Lamellen offen sind.",
-    "hints.sequential_open.travel_time_close": "Beginne mit vollständig geöffnetem Rollladen und geschlossenen Lamellen. Klicke auf Fertig, wenn der Rollladen vollständig geschlossen ist, bevor sich die Lamellen zu öffnen beginnen.",
-    "hints.sequential_open.travel_time_open": "Beginne mit geschlossenem Rollladen und geschlossenen Lamellen. Klicke auf Fertig, wenn der Rollladen vollständig geöffnet ist.",
-    "hints.sequential_open.tilt_time_close": "Beginne mit geschlossenem Rollladen, aber offenen Lamellen. Klicke auf Fertig, wenn die Lamellen vollständig geschlossen sind.",
-    "hints.sequential_open.tilt_time_open": "Beginne mit geschlossenem Rollladen und geschlossenen Lamellen. Klicke auf Fertig, wenn die Lamellen vollständig offen sind.",
-    "hints.dual_motor.travel_time_close": "Beginne mit geöffnetem Rollladen und Lamellen in der sicheren Position. Klicke auf Fertig, wenn der Rollladen vollständig geschlossen ist.",
-    "hints.dual_motor.travel_time_open": "Beginne mit geschlossenem Rollladen und Lamellen in der sicheren Position. Klicke auf Fertig, wenn der Rollladen vollständig geöffnet ist.",
-    "hints.dual_motor.tilt_time_close": "Beginne mit geschlossenem Rollladen und offenen Lamellen. Klicke auf Fertig, wenn die Lamellen vollständig geschlossen sind.",
-    "hints.dual_motor.tilt_time_open": "Beginne mit geschlossenem Rollladen und geschlossenen Lamellen. Klicke auf Fertig, wenn die Lamellen vollständig offen sind.",
-    "hints.inline.travel_time_close": "Beginne mit vollständig geöffnetem Rollladen und offenen Lamellen. Klicke auf Fertig, wenn beide vollständig geschlossen sind.",
-    "hints.inline.travel_time_open": "Beginne mit vollständig geschlossenem Rollladen und geschlossenen Lamellen. Klicke auf Fertig, wenn beide vollständig geöffnet sind.",
-    "hints.inline.tilt_time_close": "Beginne mit vollständig offenen Lamellen. Klicke auf Fertig, wenn die Lamellen vollständig geschlossen sind.",
-    "hints.inline.tilt_time_open": "Beginne mit vollständig geschlossenen Lamellen. Klicke auf Fertig, wenn die Lamellen vollständig offen sind.",
-    "hints.none.travel_time_close": "Klicke auf Fertig, wenn der Rollladen vollständig geschlossen ist.",
-    "hints.none.travel_time_open": "Klicke auf Fertig, wenn der Rollladen vollständig geöffnet ist.",
-    "hints.min_movement_time": "Klicke auf Fertig, sobald du bemerkst, dass sich der Rollladen bewegt.",
+    "hints.sequential_close.travel_time_close":
+      "Beginne mit vollständig geöffnetem Rollladen. Klicke auf Fertig, wenn der Rollladen vollständig geschlossen ist, bevor sich die Lamellen zu neigen beginnen.",
+    "hints.sequential_close.travel_time_open":
+      "Beginne mit geschlossenem Rollladen und offenen Lamellen. Klicke auf Fertig, wenn der Rollladen vollständig geöffnet ist.",
+    "hints.sequential_close.tilt_time_close":
+      "Beginne mit geschlossenem Rollladen, aber offenen Lamellen. Klicke auf Fertig, wenn die Lamellen vollständig geschlossen sind.",
+    "hints.sequential_close.tilt_time_open":
+      "Beginne mit geschlossenem Rollladen und geschlossenen Lamellen. Klicke auf Fertig, wenn die Lamellen offen sind.",
+    "hints.sequential_open.travel_time_close":
+      "Beginne mit vollständig geöffnetem Rollladen und geschlossenen Lamellen. Klicke auf Fertig, wenn der Rollladen vollständig geschlossen ist, bevor sich die Lamellen zu öffnen beginnen.",
+    "hints.sequential_open.travel_time_open":
+      "Beginne mit geschlossenem Rollladen und geschlossenen Lamellen. Klicke auf Fertig, wenn der Rollladen vollständig geöffnet ist.",
+    "hints.sequential_open.tilt_time_close":
+      "Beginne mit geschlossenem Rollladen, aber offenen Lamellen. Klicke auf Fertig, wenn die Lamellen vollständig geschlossen sind.",
+    "hints.sequential_open.tilt_time_open":
+      "Beginne mit geschlossenem Rollladen und geschlossenen Lamellen. Klicke auf Fertig, wenn die Lamellen vollständig offen sind.",
+    "hints.dual_motor.travel_time_close":
+      "Beginne mit geöffnetem Rollladen und Lamellen in der sicheren Position. Klicke auf Fertig, wenn der Rollladen vollständig geschlossen ist.",
+    "hints.dual_motor.travel_time_open":
+      "Beginne mit geschlossenem Rollladen und Lamellen in der sicheren Position. Klicke auf Fertig, wenn der Rollladen vollständig geöffnet ist.",
+    "hints.dual_motor.tilt_time_close":
+      "Beginne mit geschlossenem Rollladen und offenen Lamellen. Klicke auf Fertig, wenn die Lamellen vollständig geschlossen sind.",
+    "hints.dual_motor.tilt_time_open":
+      "Beginne mit geschlossenem Rollladen und geschlossenen Lamellen. Klicke auf Fertig, wenn die Lamellen vollständig offen sind.",
+    "hints.inline.travel_time_close":
+      "Beginne mit vollständig geöffnetem Rollladen und offenen Lamellen. Klicke auf Fertig, wenn beide vollständig geschlossen sind.",
+    "hints.inline.travel_time_open":
+      "Beginne mit vollständig geschlossenem Rollladen und geschlossenen Lamellen. Klicke auf Fertig, wenn beide vollständig geöffnet sind.",
+    "hints.inline.tilt_time_close":
+      "Beginne mit vollständig offenen Lamellen. Klicke auf Fertig, wenn die Lamellen vollständig geschlossen sind.",
+    "hints.inline.tilt_time_open":
+      "Beginne mit vollständig geschlossenen Lamellen. Klicke auf Fertig, wenn die Lamellen vollständig offen sind.",
+    "hints.none.travel_time_close":
+      "Klicke auf Fertig, wenn der Rollladen vollständig geschlossen ist.",
+    "hints.none.travel_time_open":
+      "Klicke auf Fertig, wenn der Rollladen vollständig geöffnet ist.",
+    "hints.min_movement_time":
+      "Klicke auf Fertig, sobald du bemerkst, dass sich der Rollladen bewegt.",
   },
   it: {
-    "header": "Configurazione di Cover Time Based",
-    "loading": "Caricamento...",
-    "saving": "Salvataggio...",
-    "save_failed": "Salvataggio non riuscito — valore ripristinato",
-    "confirm_cancel_calibration": "È in corso una calibrazione. Annullarla e continuare?",
-    "create_new": "+ Crea una nuova entità tapparella",
-    "yaml_warning": "Questa entità utilizza la configurazione YAML e non può essere configurata da questa scheda. Esegui la migrazione all'interfaccia utente: Impostazioni → Dispositivi e servizi → Helper → Crea helper → Cover Time Based.",
-    "load_failed": "Caricamento della configurazione non riuscito. Riprova.",
+    header: "Configurazione di Cover Time Based",
+    loading: "Caricamento...",
+    saving: "Salvataggio...",
+    save_failed: "Salvataggio non riuscito — valore ripristinato",
+    confirm_cancel_calibration: "È in corso una calibrazione. Annullarla e continuare?",
+    create_new: "+ Crea una nuova entità tapparella",
+    yaml_warning:
+      "Questa entità utilizza la configurazione YAML e non può essere configurata da questa scheda. Esegui la migrazione all'interfaccia utente: Impostazioni → Dispositivi e servizi → Helper → Crea helper → Cover Time Based.",
+    load_failed: "Caricamento della configurazione non riuscito. Riprova.",
     "tabs.device": "Dispositivo",
     "tabs.calibration": "Calibrazione",
     "control_mode.label": "Modalità di controllo",
@@ -581,11 +663,14 @@ export const TRANSLATIONS = {
     "tilt_motor.close_switch_pulse": "Interruttore o script di chiusura dell'inclinazione",
     "tilt_motor.stop_switch_pulse": "Interruttore o script di arresto dell'inclinazione",
     "tilt_motor.safe_position": "Posizione di inclinazione sicura",
-    "tilt_motor.safe_position_helper": "L'inclinazione si porta qui prima della corsa (100 = completamente aperta)",
+    "tilt_motor.safe_position_helper":
+      "L'inclinazione si porta qui prima della corsa (100 = completamente aperta)",
     "tilt_motor.max_allowed_position": "Posizione di inclinazione massima consentita (facoltativa)",
-    "tilt_motor.max_allowed_helper": "L'inclinazione è consentita solo quando la posizione della tapparella è pari o inferiore a questo valore (0 = chiusa, 100 = aperta)",
+    "tilt_motor.max_allowed_helper":
+      "L'inclinazione è consentita solo quando la posizione della tapparella è pari o inferiore a questo valore (0 = chiusa, 100 = aperta)",
     "tilt.close_includes_tilt": "La chiusura della tapparella chiude anche le lamelle",
-    "tilt.close_includes_tilt_helper": "In chiusura, le lamelle si inclinano fino a chiudersi al termine della corsa",
+    "tilt.close_includes_tilt_helper":
+      "In chiusura, le lamelle si inclinano fino a chiudersi al termine della corsa",
     "assumed_state.label": "Stato presunto",
     "assumed_state.helper":
       "Quando è attivo, Home Assistant considera la posizione come stimata e mantiene attivi sia il comando di apertura sia quello di chiusura. Disattivalo se ti fidi del calcolo basato sul tempo e vuoi che l'interfaccia disattivi le azioni non disponibili (ad esempio chiudere quando è già chiusa).",
@@ -595,15 +680,13 @@ export const TRANSLATIONS = {
     "send_endpoint_stop.label": "Invia il segnale di arresto ai finecorsa",
     "send_endpoint_stop.helper":
       "Quando la tapparella raggiunge l'apertura o la chiusura completa, invia l'impulso di arresto. Mantienilo attivo per le centraline che continuano a funzionare finché non ricevono un arresto (altrimenti la tapparella si blocca e i pulsanti fisici smettono di rispondere). Disattivalo se il motore si ferma da solo ai finecorsa e un arresto aggiuntivo lo fa spostare su una posizione preimpostata/preferita.",
-    "force_endpoint_redrive.label":
-      "Invia sempre di nuovo apertura/chiusura ai finecorsa",
+    "force_endpoint_redrive.label": "Invia sempre di nuovo apertura/chiusura ai finecorsa",
     "force_endpoint_redrive.helper":
       "Per le tapparelle senza retroazione di posizione che possono essere azionate anche da un telecomando esterno, per cui Home Assistant potrebbe credere erroneamente che siano già completamente aperte o chiuse. Quando è attivo, un comando di apertura o chiusura viene sempre eseguito per l'intero tempo di corsa anche se Home Assistant ritiene che la tapparella si trovi già lì — garantendo che il comando raggiunga il motore. Lascialo disattivato per le tapparelle che riportano la propria posizione.",
-    "recalibrate_before_position.label":
-      "Apri completamente prima di spostare in posizione (Beta)",
+    "recalibrate_before_position.label": "Apri completamente prima di spostare in posizione (Beta)",
     "recalibrate_before_position.helper":
       "Per le tapparelle senza retroazione di posizione che possono essere spostate anche da un telecomando. Porta la tapparella in apertura completa prima di ogni comando di posizionamento, così il movimento parte da una posizione nota anziché da una stima alla deriva. Raddoppia circa il tempo di corsa di ogni movimento e, con l'inclinazione durante la corsa o quella sequenziale, muove la tapparella anche quando regoli le lamelle.",
-    "more_info": "Maggiori informazioni",
+    more_info: "Maggiori informazioni",
     "timing.travel_attribute_header": "Attributo di corsa",
     "timing.tilt_attribute_header": "Attributo di inclinazione",
     "timing.value_header": "Valore",
@@ -640,35 +723,52 @@ export const TRANSLATIONS = {
     "controls.tilt_open": "Apri inclinazione",
     "controls.tilt_stop": "Ferma inclinazione",
     "controls.tilt_close": "Chiudi inclinazione",
-    "hints.sequential_close.travel_time_close": "Parti con la tapparella completamente aperta. Clicca su Fine quando la tapparella è completamente chiusa, prima che le lamelle inizino a inclinarsi.",
-    "hints.sequential_close.travel_time_open": "Parti con la tapparella chiusa e le lamelle aperte. Clicca su Fine quando la tapparella è completamente aperta.",
-    "hints.sequential_close.tilt_time_close": "Parti con la tapparella chiusa ma le lamelle aperte. Clicca su Fine quando le lamelle sono completamente chiuse.",
-    "hints.sequential_close.tilt_time_open": "Parti con la tapparella e le lamelle chiuse. Clicca su Fine quando le lamelle sono aperte.",
-    "hints.sequential_open.travel_time_close": "Parti con la tapparella completamente aperta e le lamelle chiuse. Clicca su Fine quando la tapparella è completamente chiusa, prima che le lamelle inizino ad aprirsi.",
-    "hints.sequential_open.travel_time_open": "Parti con la tapparella chiusa e le lamelle chiuse. Clicca su Fine quando la tapparella è completamente aperta.",
-    "hints.sequential_open.tilt_time_close": "Parti con la tapparella chiusa ma le lamelle aperte. Clicca su Fine quando le lamelle sono completamente chiuse.",
-    "hints.sequential_open.tilt_time_open": "Parti con la tapparella e le lamelle chiuse. Clicca su Fine quando le lamelle sono completamente aperte.",
-    "hints.dual_motor.travel_time_close": "Parti con la tapparella aperta e le lamelle nella posizione sicura. Clicca su Fine quando la tapparella è completamente chiusa.",
-    "hints.dual_motor.travel_time_open": "Parti con la tapparella chiusa e le lamelle nella posizione sicura. Clicca su Fine quando la tapparella è completamente aperta.",
-    "hints.dual_motor.tilt_time_close": "Parti con la tapparella chiusa e le lamelle aperte. Clicca su Fine quando le lamelle sono completamente chiuse.",
-    "hints.dual_motor.tilt_time_open": "Parti con la tapparella e le lamelle entrambe chiuse. Clicca su Fine quando le lamelle sono completamente aperte.",
-    "hints.inline.travel_time_close": "Parti con la tapparella e le lamelle entrambe completamente aperte. Clicca su Fine quando entrambe sono completamente chiuse.",
-    "hints.inline.travel_time_open": "Parti con la tapparella e le lamelle entrambe completamente chiuse. Clicca su Fine quando entrambe sono completamente aperte.",
-    "hints.inline.tilt_time_close": "Parti con le lamelle completamente aperte. Clicca su Fine quando le lamelle sono completamente chiuse.",
-    "hints.inline.tilt_time_open": "Parti con le lamelle completamente chiuse. Clicca su Fine quando le lamelle sono completamente aperte.",
+    "hints.sequential_close.travel_time_close":
+      "Parti con la tapparella completamente aperta. Clicca su Fine quando la tapparella è completamente chiusa, prima che le lamelle inizino a inclinarsi.",
+    "hints.sequential_close.travel_time_open":
+      "Parti con la tapparella chiusa e le lamelle aperte. Clicca su Fine quando la tapparella è completamente aperta.",
+    "hints.sequential_close.tilt_time_close":
+      "Parti con la tapparella chiusa ma le lamelle aperte. Clicca su Fine quando le lamelle sono completamente chiuse.",
+    "hints.sequential_close.tilt_time_open":
+      "Parti con la tapparella e le lamelle chiuse. Clicca su Fine quando le lamelle sono aperte.",
+    "hints.sequential_open.travel_time_close":
+      "Parti con la tapparella completamente aperta e le lamelle chiuse. Clicca su Fine quando la tapparella è completamente chiusa, prima che le lamelle inizino ad aprirsi.",
+    "hints.sequential_open.travel_time_open":
+      "Parti con la tapparella chiusa e le lamelle chiuse. Clicca su Fine quando la tapparella è completamente aperta.",
+    "hints.sequential_open.tilt_time_close":
+      "Parti con la tapparella chiusa ma le lamelle aperte. Clicca su Fine quando le lamelle sono completamente chiuse.",
+    "hints.sequential_open.tilt_time_open":
+      "Parti con la tapparella e le lamelle chiuse. Clicca su Fine quando le lamelle sono completamente aperte.",
+    "hints.dual_motor.travel_time_close":
+      "Parti con la tapparella aperta e le lamelle nella posizione sicura. Clicca su Fine quando la tapparella è completamente chiusa.",
+    "hints.dual_motor.travel_time_open":
+      "Parti con la tapparella chiusa e le lamelle nella posizione sicura. Clicca su Fine quando la tapparella è completamente aperta.",
+    "hints.dual_motor.tilt_time_close":
+      "Parti con la tapparella chiusa e le lamelle aperte. Clicca su Fine quando le lamelle sono completamente chiuse.",
+    "hints.dual_motor.tilt_time_open":
+      "Parti con la tapparella e le lamelle entrambe chiuse. Clicca su Fine quando le lamelle sono completamente aperte.",
+    "hints.inline.travel_time_close":
+      "Parti con la tapparella e le lamelle entrambe completamente aperte. Clicca su Fine quando entrambe sono completamente chiuse.",
+    "hints.inline.travel_time_open":
+      "Parti con la tapparella e le lamelle entrambe completamente chiuse. Clicca su Fine quando entrambe sono completamente aperte.",
+    "hints.inline.tilt_time_close":
+      "Parti con le lamelle completamente aperte. Clicca su Fine quando le lamelle sono completamente chiuse.",
+    "hints.inline.tilt_time_open":
+      "Parti con le lamelle completamente chiuse. Clicca su Fine quando le lamelle sono completamente aperte.",
     "hints.none.travel_time_close": "Clicca su Fine quando la tapparella è completamente chiusa.",
     "hints.none.travel_time_open": "Clicca su Fine quando la tapparella è completamente aperta.",
     "hints.min_movement_time": "Clicca su Fine non appena noti che la tapparella si muove.",
   },
   nl: {
-    "header": "Configuratie van Cover Time Based",
-    "loading": "Laden...",
-    "saving": "Opslaan...",
-    "save_failed": "Opslaan mislukt — waarde teruggezet",
-    "confirm_cancel_calibration": "Er loopt een kalibratie. Deze annuleren en doorgaan?",
-    "create_new": "+ Nieuwe rolluikentiteit aanmaken",
-    "yaml_warning": "Deze entiteit gebruikt YAML-configuratie en kan niet vanuit deze kaart worden geconfigureerd. Migreer naar de gebruikersinterface: Instellingen → Apparaten en diensten → Helpers → Helper aanmaken → Cover Time Based.",
-    "load_failed": "Laden van de configuratie mislukt. Probeer het opnieuw.",
+    header: "Configuratie van Cover Time Based",
+    loading: "Laden...",
+    saving: "Opslaan...",
+    save_failed: "Opslaan mislukt — waarde teruggezet",
+    confirm_cancel_calibration: "Er loopt een kalibratie. Deze annuleren en doorgaan?",
+    create_new: "+ Nieuwe rolluikentiteit aanmaken",
+    yaml_warning:
+      "Deze entiteit gebruikt YAML-configuratie en kan niet vanuit deze kaart worden geconfigureerd. Migreer naar de gebruikersinterface: Instellingen → Apparaten en diensten → Helpers → Helper aanmaken → Cover Time Based.",
+    load_failed: "Laden van de configuratie mislukt. Probeer het opnieuw.",
     "tabs.device": "Apparaat",
     "tabs.calibration": "Kalibratie",
     "control_mode.label": "Besturingsmodus",
@@ -714,11 +814,14 @@ export const TRANSLATIONS = {
     "tilt_motor.close_switch_pulse": "Schakelaar of script voor kanteling sluiten",
     "tilt_motor.stop_switch_pulse": "Schakelaar of script voor kanteling stoppen",
     "tilt_motor.safe_position": "Veilige kantelpositie",
-    "tilt_motor.safe_position_helper": "De kanteling gaat hierheen vóór de beweging (100 = volledig open)",
+    "tilt_motor.safe_position_helper":
+      "De kanteling gaat hierheen vóór de beweging (100 = volledig open)",
     "tilt_motor.max_allowed_position": "Maximaal toegestane kantelpositie (optioneel)",
-    "tilt_motor.max_allowed_helper": "Kantelen is alleen toegestaan wanneer de rolluikpositie op of onder deze waarde ligt (0 = gesloten, 100 = open)",
+    "tilt_motor.max_allowed_helper":
+      "Kantelen is alleen toegestaan wanneer de rolluikpositie op of onder deze waarde ligt (0 = gesloten, 100 = open)",
     "tilt.close_includes_tilt": "Rolluik sluiten sluit ook de lamellen",
-    "tilt.close_includes_tilt_helper": "Bij het sluiten kantelen de lamellen dicht aan het einde van de beweging",
+    "tilt.close_includes_tilt_helper":
+      "Bij het sluiten kantelen de lamellen dicht aan het einde van de beweging",
     "assumed_state.label": "Aangenomen status",
     "assumed_state.helper":
       "Wanneer dit aanstaat, behandelt Home Assistant de positie als geschat en houdt het zowel de open- als de sluitknop actief. Schakel dit uit als je de tijdgebaseerde berekening vertrouwt en wilt dat de interface niet-beschikbare acties grijs maakt (bijvoorbeeld sluiten wanneer het rolluik al gesloten is).",
@@ -728,15 +831,14 @@ export const TRANSLATIONS = {
     "send_endpoint_stop.label": "Stopsignaal bij de eindstanden versturen",
     "send_endpoint_stop.helper":
       "Stuur de stoppuls zodra je rolluik volledig open of gesloten is. Laat dit aanstaan voor besturingen die blijven doorlopen totdat ze een stop ontvangen (anders blijft het rolluik hangen en reageren de fysieke knoppen niet meer). Schakel het uit als je motor bij zijn eindstanden vanzelf stopt en een extra stop hem naar een vooraf ingestelde favoriete positie laat bewegen.",
-    "force_endpoint_redrive.label":
-      "Openen/sluiten altijd opnieuw versturen bij de eindstanden",
+    "force_endpoint_redrive.label": "Openen/sluiten altijd opnieuw versturen bij de eindstanden",
     "force_endpoint_redrive.helper":
       "Voor rolluiken zonder positieterugkoppeling die ook met een externe afstandsbediening bediend kunnen worden, waardoor Home Assistant ten onrechte kan denken dat ze al volledig open of gesloten zijn. Wanneer dit aanstaat, wordt een open- of sluitcommando altijd gedurende de volledige looptijd uitgevoerd, ook als Home Assistant denkt dat het rolluik daar al staat — zo bereikt het commando gegarandeerd de motor. Laat dit uitstaan voor rolluiken die hun eigen positie rapporteren.",
     "recalibrate_before_position.label":
       "Volledig openen voordat naar een positie wordt bewogen (Beta)",
     "recalibrate_before_position.helper":
       "Voor rolluiken zonder positieterugkoppeling die ook door een afstandsbediening bewogen kunnen worden. Beweegt het rolluik vóór elk positiecommando eerst volledig open, zodat de beweging start vanaf een bekende positie in plaats van een afgedwaalde schatting. Verdubbelt daarmee ongeveer de looptijd van elke beweging, en bij kantelen tijdens de beweging of sequentieel kantelen beweegt het rolluik mee zodra je de lamellen verstelt.",
-    "more_info": "Meer informatie",
+    more_info: "Meer informatie",
     "timing.travel_attribute_header": "Loopattribuut",
     "timing.tilt_attribute_header": "Kantelattribuut",
     "timing.value_header": "Waarde",
@@ -773,35 +875,52 @@ export const TRANSLATIONS = {
     "controls.tilt_open": "Kanteling openen",
     "controls.tilt_stop": "Kanteling stoppen",
     "controls.tilt_close": "Kanteling sluiten",
-    "hints.sequential_close.travel_time_close": "Begin met het rolluik volledig open. Klik op Voltooien wanneer het rolluik volledig gesloten is, voordat de lamellen beginnen te kantelen.",
-    "hints.sequential_close.travel_time_open": "Begin met het rolluik gesloten en de lamellen open. Klik op Voltooien wanneer het rolluik volledig open is.",
-    "hints.sequential_close.tilt_time_close": "Begin met het rolluik gesloten maar de lamellen open. Klik op Voltooien wanneer de lamellen volledig gesloten zijn.",
-    "hints.sequential_close.tilt_time_open": "Begin met het rolluik en de lamellen gesloten. Klik op Voltooien wanneer de lamellen open zijn.",
-    "hints.sequential_open.travel_time_close": "Begin met het rolluik volledig open en de lamellen gesloten. Klik op Voltooien wanneer het rolluik volledig gesloten is, voordat de lamellen open beginnen te kantelen.",
-    "hints.sequential_open.travel_time_open": "Begin met het rolluik gesloten en de lamellen gesloten. Klik op Voltooien wanneer het rolluik volledig open is.",
-    "hints.sequential_open.tilt_time_close": "Begin met het rolluik gesloten maar de lamellen open. Klik op Voltooien wanneer de lamellen volledig gesloten zijn.",
-    "hints.sequential_open.tilt_time_open": "Begin met het rolluik en de lamellen gesloten. Klik op Voltooien wanneer de lamellen volledig open zijn.",
-    "hints.dual_motor.travel_time_close": "Begin met het rolluik open en de lamellen in de veilige positie. Klik op Voltooien wanneer het rolluik volledig gesloten is.",
-    "hints.dual_motor.travel_time_open": "Begin met het rolluik gesloten en de lamellen in de veilige positie. Klik op Voltooien wanneer het rolluik volledig open is.",
-    "hints.dual_motor.tilt_time_close": "Begin met het rolluik gesloten en de lamellen open. Klik op Voltooien wanneer de lamellen volledig gesloten zijn.",
-    "hints.dual_motor.tilt_time_open": "Begin met zowel het rolluik als de lamellen gesloten. Klik op Voltooien wanneer de lamellen volledig open zijn.",
-    "hints.inline.travel_time_close": "Begin met zowel het rolluik als de lamellen volledig open. Klik op Voltooien wanneer beide volledig gesloten zijn.",
-    "hints.inline.travel_time_open": "Begin met zowel het rolluik als de lamellen volledig gesloten. Klik op Voltooien wanneer beide volledig open zijn.",
-    "hints.inline.tilt_time_close": "Begin met de lamellen volledig open. Klik op Voltooien wanneer de lamellen volledig gesloten zijn.",
-    "hints.inline.tilt_time_open": "Begin met de lamellen volledig gesloten. Klik op Voltooien wanneer de lamellen volledig open zijn.",
+    "hints.sequential_close.travel_time_close":
+      "Begin met het rolluik volledig open. Klik op Voltooien wanneer het rolluik volledig gesloten is, voordat de lamellen beginnen te kantelen.",
+    "hints.sequential_close.travel_time_open":
+      "Begin met het rolluik gesloten en de lamellen open. Klik op Voltooien wanneer het rolluik volledig open is.",
+    "hints.sequential_close.tilt_time_close":
+      "Begin met het rolluik gesloten maar de lamellen open. Klik op Voltooien wanneer de lamellen volledig gesloten zijn.",
+    "hints.sequential_close.tilt_time_open":
+      "Begin met het rolluik en de lamellen gesloten. Klik op Voltooien wanneer de lamellen open zijn.",
+    "hints.sequential_open.travel_time_close":
+      "Begin met het rolluik volledig open en de lamellen gesloten. Klik op Voltooien wanneer het rolluik volledig gesloten is, voordat de lamellen open beginnen te kantelen.",
+    "hints.sequential_open.travel_time_open":
+      "Begin met het rolluik gesloten en de lamellen gesloten. Klik op Voltooien wanneer het rolluik volledig open is.",
+    "hints.sequential_open.tilt_time_close":
+      "Begin met het rolluik gesloten maar de lamellen open. Klik op Voltooien wanneer de lamellen volledig gesloten zijn.",
+    "hints.sequential_open.tilt_time_open":
+      "Begin met het rolluik en de lamellen gesloten. Klik op Voltooien wanneer de lamellen volledig open zijn.",
+    "hints.dual_motor.travel_time_close":
+      "Begin met het rolluik open en de lamellen in de veilige positie. Klik op Voltooien wanneer het rolluik volledig gesloten is.",
+    "hints.dual_motor.travel_time_open":
+      "Begin met het rolluik gesloten en de lamellen in de veilige positie. Klik op Voltooien wanneer het rolluik volledig open is.",
+    "hints.dual_motor.tilt_time_close":
+      "Begin met het rolluik gesloten en de lamellen open. Klik op Voltooien wanneer de lamellen volledig gesloten zijn.",
+    "hints.dual_motor.tilt_time_open":
+      "Begin met zowel het rolluik als de lamellen gesloten. Klik op Voltooien wanneer de lamellen volledig open zijn.",
+    "hints.inline.travel_time_close":
+      "Begin met zowel het rolluik als de lamellen volledig open. Klik op Voltooien wanneer beide volledig gesloten zijn.",
+    "hints.inline.travel_time_open":
+      "Begin met zowel het rolluik als de lamellen volledig gesloten. Klik op Voltooien wanneer beide volledig open zijn.",
+    "hints.inline.tilt_time_close":
+      "Begin met de lamellen volledig open. Klik op Voltooien wanneer de lamellen volledig gesloten zijn.",
+    "hints.inline.tilt_time_open":
+      "Begin met de lamellen volledig gesloten. Klik op Voltooien wanneer de lamellen volledig open zijn.",
     "hints.none.travel_time_close": "Klik op Voltooien wanneer het rolluik volledig gesloten is.",
     "hints.none.travel_time_open": "Klik op Voltooien wanneer het rolluik volledig open is.",
     "hints.min_movement_time": "Klik op Voltooien zodra je het rolluik ziet bewegen.",
   },
   fr: {
-    "header": "Configuration de Cover Time Based",
-    "loading": "Chargement...",
-    "saving": "Enregistrement...",
-    "save_failed": "Échec de l'enregistrement — valeur rétablie",
-    "confirm_cancel_calibration": "Un étalonnage est en cours. L'annuler et continuer\u00a0?",
-    "create_new": "+ Créer une nouvelle entité de volet",
-    "yaml_warning": "Cette entité utilise une configuration YAML et ne peut pas être configurée depuis cette carte. Veuillez migrer vers l'interface utilisateur\u00a0: Paramètres → Appareils et services → Entrées → Créer une entrée → Cover Time Based.",
-    "load_failed": "Échec du chargement de la configuration. Veuillez réessayer.",
+    header: "Configuration de Cover Time Based",
+    loading: "Chargement...",
+    saving: "Enregistrement...",
+    save_failed: "Échec de l'enregistrement — valeur rétablie",
+    confirm_cancel_calibration: "Un étalonnage est en cours. L'annuler et continuer\u00a0?",
+    create_new: "+ Créer une nouvelle entité de volet",
+    yaml_warning:
+      "Cette entité utilise une configuration YAML et ne peut pas être configurée depuis cette carte. Veuillez migrer vers l'interface utilisateur\u00a0: Paramètres → Appareils et services → Entrées → Créer une entrée → Cover Time Based.",
+    load_failed: "Échec du chargement de la configuration. Veuillez réessayer.",
     "tabs.device": "Appareil",
     "tabs.calibration": "Étalonnage",
     "control_mode.label": "Mode de commande",
@@ -847,11 +966,14 @@ export const TRANSLATIONS = {
     "tilt_motor.close_switch_pulse": "Interrupteur ou script de fermeture de l'inclinaison",
     "tilt_motor.stop_switch_pulse": "Interrupteur ou script d'arrêt de l'inclinaison",
     "tilt_motor.safe_position": "Position d'inclinaison de sécurité",
-    "tilt_motor.safe_position_helper": "L'inclinaison se place ici avant la course (100 = complètement ouverte)",
+    "tilt_motor.safe_position_helper":
+      "L'inclinaison se place ici avant la course (100 = complètement ouverte)",
     "tilt_motor.max_allowed_position": "Position d'inclinaison maximale autorisée (facultatif)",
-    "tilt_motor.max_allowed_helper": "L'inclinaison n'est autorisée que lorsque la position du volet est égale ou inférieure à cette valeur (0 = fermé, 100 = ouvert)",
+    "tilt_motor.max_allowed_helper":
+      "L'inclinaison n'est autorisée que lorsque la position du volet est égale ou inférieure à cette valeur (0 = fermé, 100 = ouvert)",
     "tilt.close_includes_tilt": "Fermer le volet ferme aussi les lames",
-    "tilt.close_includes_tilt_helper": "À la fermeture, les lames s'inclinent en position fermée en fin de course",
+    "tilt.close_includes_tilt_helper":
+      "À la fermeture, les lames s'inclinent en position fermée en fin de course",
     "assumed_state.label": "État supposé",
     "assumed_state.helper":
       "Lorsque cette option est activée, Home Assistant considère la position comme estimée et garde actives les commandes d'ouverture et de fermeture. Désactivez-la si vous faites confiance au calcul temporisé et souhaitez que l'interface grise les actions indisponibles (par exemple fermer alors que le volet est déjà fermé).",
@@ -867,7 +989,7 @@ export const TRANSLATIONS = {
     "recalibrate_before_position.label": "Ouvrir complètement avant d'aller à une position (Bêta)",
     "recalibrate_before_position.helper":
       "Pour les volets sans retour de position qu'une télécommande peut aussi actionner. Ouvre complètement le volet avant chaque commande de position, afin que le mouvement parte d'une position connue plutôt que d'une estimation partie à la dérive. Cela double à peu près la course de chaque mouvement et, avec une inclinaison pendant la course ou une inclinaison séquentielle, le volet bouge lorsque vous réglez les lames.",
-    "more_info": "Plus d'informations",
+    more_info: "Plus d'informations",
     "timing.travel_attribute_header": "Attribut de course",
     "timing.tilt_attribute_header": "Attribut d'inclinaison",
     "timing.value_header": "Valeur",
@@ -904,35 +1026,52 @@ export const TRANSLATIONS = {
     "controls.tilt_open": "Ouvrir l'inclinaison",
     "controls.tilt_stop": "Arrêter l'inclinaison",
     "controls.tilt_close": "Fermer l'inclinaison",
-    "hints.sequential_close.travel_time_close": "Commencez avec le volet complètement ouvert. Cliquez sur Terminer lorsque le volet est complètement fermé, avant que les lames ne commencent à s'incliner.",
-    "hints.sequential_close.travel_time_open": "Commencez avec le volet fermé et les lames ouvertes. Cliquez sur Terminer lorsque le volet est complètement ouvert.",
-    "hints.sequential_close.tilt_time_close": "Commencez avec le volet fermé mais les lames ouvertes. Cliquez sur Terminer lorsque les lames sont complètement fermées.",
-    "hints.sequential_close.tilt_time_open": "Commencez avec le volet et les lames fermés. Cliquez sur Terminer lorsque les lames sont ouvertes.",
-    "hints.sequential_open.travel_time_close": "Commencez avec le volet complètement ouvert et les lames fermées. Cliquez sur Terminer lorsque le volet est complètement fermé, avant que les lames ne commencent à s'ouvrir.",
-    "hints.sequential_open.travel_time_open": "Commencez avec le volet fermé et les lames fermées. Cliquez sur Terminer lorsque le volet est complètement ouvert.",
-    "hints.sequential_open.tilt_time_close": "Commencez avec le volet fermé mais les lames ouvertes. Cliquez sur Terminer lorsque les lames sont complètement fermées.",
-    "hints.sequential_open.tilt_time_open": "Commencez avec le volet et les lames fermés. Cliquez sur Terminer lorsque les lames sont complètement ouvertes.",
-    "hints.dual_motor.travel_time_close": "Commencez avec le volet ouvert et les lames en position de sécurité. Cliquez sur Terminer lorsque le volet est complètement fermé.",
-    "hints.dual_motor.travel_time_open": "Commencez avec le volet fermé et les lames en position de sécurité. Cliquez sur Terminer lorsque le volet est complètement ouvert.",
-    "hints.dual_motor.tilt_time_close": "Commencez avec le volet fermé et les lames ouvertes. Cliquez sur Terminer lorsque les lames sont complètement fermées.",
-    "hints.dual_motor.tilt_time_open": "Commencez avec le volet et les lames fermés. Cliquez sur Terminer lorsque les lames sont complètement ouvertes.",
-    "hints.inline.travel_time_close": "Commencez avec le volet et les lames complètement ouverts. Cliquez sur Terminer lorsque les deux sont complètement fermés.",
-    "hints.inline.travel_time_open": "Commencez avec le volet et les lames complètement fermés. Cliquez sur Terminer lorsque les deux sont complètement ouverts.",
-    "hints.inline.tilt_time_close": "Commencez avec les lames complètement ouvertes. Cliquez sur Terminer lorsque les lames sont complètement fermées.",
-    "hints.inline.tilt_time_open": "Commencez avec les lames complètement fermées. Cliquez sur Terminer lorsque les lames sont complètement ouvertes.",
+    "hints.sequential_close.travel_time_close":
+      "Commencez avec le volet complètement ouvert. Cliquez sur Terminer lorsque le volet est complètement fermé, avant que les lames ne commencent à s'incliner.",
+    "hints.sequential_close.travel_time_open":
+      "Commencez avec le volet fermé et les lames ouvertes. Cliquez sur Terminer lorsque le volet est complètement ouvert.",
+    "hints.sequential_close.tilt_time_close":
+      "Commencez avec le volet fermé mais les lames ouvertes. Cliquez sur Terminer lorsque les lames sont complètement fermées.",
+    "hints.sequential_close.tilt_time_open":
+      "Commencez avec le volet et les lames fermés. Cliquez sur Terminer lorsque les lames sont ouvertes.",
+    "hints.sequential_open.travel_time_close":
+      "Commencez avec le volet complètement ouvert et les lames fermées. Cliquez sur Terminer lorsque le volet est complètement fermé, avant que les lames ne commencent à s'ouvrir.",
+    "hints.sequential_open.travel_time_open":
+      "Commencez avec le volet fermé et les lames fermées. Cliquez sur Terminer lorsque le volet est complètement ouvert.",
+    "hints.sequential_open.tilt_time_close":
+      "Commencez avec le volet fermé mais les lames ouvertes. Cliquez sur Terminer lorsque les lames sont complètement fermées.",
+    "hints.sequential_open.tilt_time_open":
+      "Commencez avec le volet et les lames fermés. Cliquez sur Terminer lorsque les lames sont complètement ouvertes.",
+    "hints.dual_motor.travel_time_close":
+      "Commencez avec le volet ouvert et les lames en position de sécurité. Cliquez sur Terminer lorsque le volet est complètement fermé.",
+    "hints.dual_motor.travel_time_open":
+      "Commencez avec le volet fermé et les lames en position de sécurité. Cliquez sur Terminer lorsque le volet est complètement ouvert.",
+    "hints.dual_motor.tilt_time_close":
+      "Commencez avec le volet fermé et les lames ouvertes. Cliquez sur Terminer lorsque les lames sont complètement fermées.",
+    "hints.dual_motor.tilt_time_open":
+      "Commencez avec le volet et les lames fermés. Cliquez sur Terminer lorsque les lames sont complètement ouvertes.",
+    "hints.inline.travel_time_close":
+      "Commencez avec le volet et les lames complètement ouverts. Cliquez sur Terminer lorsque les deux sont complètement fermés.",
+    "hints.inline.travel_time_open":
+      "Commencez avec le volet et les lames complètement fermés. Cliquez sur Terminer lorsque les deux sont complètement ouverts.",
+    "hints.inline.tilt_time_close":
+      "Commencez avec les lames complètement ouvertes. Cliquez sur Terminer lorsque les lames sont complètement fermées.",
+    "hints.inline.tilt_time_open":
+      "Commencez avec les lames complètement fermées. Cliquez sur Terminer lorsque les lames sont complètement ouvertes.",
     "hints.none.travel_time_close": "Cliquez sur Terminer lorsque le volet est complètement fermé.",
     "hints.none.travel_time_open": "Cliquez sur Terminer lorsque le volet est complètement ouvert.",
     "hints.min_movement_time": "Cliquez sur Terminer dès que vous voyez le volet bouger.",
   },
   es: {
-    "header": "Configuración de Cover Time Based",
-    "loading": "Cargando...",
-    "saving": "Guardando...",
-    "save_failed": "Error al guardar — valor restaurado",
-    "confirm_cancel_calibration": "Hay una calibración en curso. ¿Cancelarla y continuar?",
-    "create_new": "+ Crear una nueva entidad de persiana",
-    "yaml_warning": "Esta entidad usa configuración YAML y no se puede configurar desde esta tarjeta. Migra a la interfaz de usuario: Configuración → Dispositivos y servicios → Ayudantes → Crear ayudante → Cover Time Based.",
-    "load_failed": "Error al cargar la configuración. Inténtalo de nuevo.",
+    header: "Configuración de Cover Time Based",
+    loading: "Cargando...",
+    saving: "Guardando...",
+    save_failed: "Error al guardar — valor restaurado",
+    confirm_cancel_calibration: "Hay una calibración en curso. ¿Cancelarla y continuar?",
+    create_new: "+ Crear una nueva entidad de persiana",
+    yaml_warning:
+      "Esta entidad usa configuración YAML y no se puede configurar desde esta tarjeta. Migra a la interfaz de usuario: Configuración → Dispositivos y servicios → Ayudantes → Crear ayudante → Cover Time Based.",
+    load_failed: "Error al cargar la configuración. Inténtalo de nuevo.",
     "tabs.device": "Dispositivo",
     "tabs.calibration": "Calibración",
     "control_mode.label": "Modo de control",
@@ -978,11 +1117,14 @@ export const TRANSLATIONS = {
     "tilt_motor.close_switch_pulse": "Interruptor o script de cierre de la inclinación",
     "tilt_motor.stop_switch_pulse": "Interruptor o script de parada de la inclinación",
     "tilt_motor.safe_position": "Posición de inclinación segura",
-    "tilt_motor.safe_position_helper": "La inclinación se mueve aquí antes del recorrido (100 = totalmente abierta)",
+    "tilt_motor.safe_position_helper":
+      "La inclinación se mueve aquí antes del recorrido (100 = totalmente abierta)",
     "tilt_motor.max_allowed_position": "Posición máxima de inclinación permitida (opcional)",
-    "tilt_motor.max_allowed_helper": "La inclinación solo se permite cuando la posición de la persiana es igual o inferior a este valor (0 = cerrada, 100 = abierta)",
+    "tilt_motor.max_allowed_helper":
+      "La inclinación solo se permite cuando la posición de la persiana es igual o inferior a este valor (0 = cerrada, 100 = abierta)",
     "tilt.close_includes_tilt": "Cerrar la persiana también cierra las lamas",
-    "tilt.close_includes_tilt_helper": "Al cerrar, las lamas se inclinan a cerrado al final del recorrido",
+    "tilt.close_includes_tilt_helper":
+      "Al cerrar, las lamas se inclinan a cerrado al final del recorrido",
     "assumed_state.label": "Estado supuesto",
     "assumed_state.helper":
       "Cuando está activado, Home Assistant trata la posición como estimada y mantiene activos los controles de apertura y cierre. Desactívalo si confías en el cálculo por tiempo y quieres que la interfaz atenúe las acciones no disponibles (por ejemplo, cerrar cuando ya está cerrada).",
@@ -998,7 +1140,7 @@ export const TRANSLATIONS = {
     "recalibrate_before_position.label": "Abrir totalmente antes de mover a una posición (Beta)",
     "recalibrate_before_position.helper":
       "Para persianas sin realimentación de posición que un mando a distancia también puede mover. Abre la persiana por completo antes de cada comando de posición, para que el movimiento parta de una posición conocida en lugar de una estimación desviada. Duplica aproximadamente el recorrido de cada movimiento y, con la inclinación durante el recorrido o la inclinación secuencial, mueve la persiana cuando ajustas las lamas.",
-    "more_info": "Más información",
+    more_info: "Más información",
     "timing.travel_attribute_header": "Atributo de recorrido",
     "timing.tilt_attribute_header": "Atributo de inclinación",
     "timing.value_header": "Valor",
@@ -1012,7 +1154,8 @@ export const TRANSLATIONS = {
     "timing.min_movement_time": "Tiempo mínimo de movimiento",
     "timing.endpoint_runon_time": "Tiempo de prolongación en los finales de carrera",
     "position.label": "Posición actual",
-    "position.helper": "Mueve la persiana a un final de carrera conocido y luego establece la posición.",
+    "position.helper":
+      "Mueve la persiana a un final de carrera conocido y luego establece la posición.",
     "position.unknown": "Desconocida",
     "position.open": "Totalmente abierta",
     "position.closed": "Totalmente cerrada",
@@ -1035,35 +1178,54 @@ export const TRANSLATIONS = {
     "controls.tilt_open": "Abrir la inclinación",
     "controls.tilt_stop": "Detener la inclinación",
     "controls.tilt_close": "Cerrar la inclinación",
-    "hints.sequential_close.travel_time_close": "Empieza con la persiana totalmente abierta. Haz clic en Terminar cuando la persiana esté totalmente cerrada, antes de que las lamas empiecen a inclinarse.",
-    "hints.sequential_close.travel_time_open": "Empieza con la persiana cerrada y las lamas abiertas. Haz clic en Terminar cuando la persiana esté totalmente abierta.",
-    "hints.sequential_close.tilt_time_close": "Empieza con la persiana cerrada pero las lamas abiertas. Haz clic en Terminar cuando las lamas estén totalmente cerradas.",
-    "hints.sequential_close.tilt_time_open": "Empieza con la persiana y las lamas cerradas. Haz clic en Terminar cuando las lamas estén abiertas.",
-    "hints.sequential_open.travel_time_close": "Empieza con la persiana totalmente abierta y las lamas cerradas. Haz clic en Terminar cuando la persiana esté totalmente cerrada, antes de que las lamas empiecen a inclinarse hacia abierto.",
-    "hints.sequential_open.travel_time_open": "Empieza con la persiana cerrada y las lamas cerradas. Haz clic en Terminar cuando la persiana esté totalmente abierta.",
-    "hints.sequential_open.tilt_time_close": "Empieza con la persiana cerrada pero las lamas abiertas. Haz clic en Terminar cuando las lamas estén totalmente cerradas.",
-    "hints.sequential_open.tilt_time_open": "Empieza con la persiana y las lamas cerradas. Haz clic en Terminar cuando las lamas estén totalmente abiertas.",
-    "hints.dual_motor.travel_time_close": "Empieza con la persiana abierta y las lamas en la posición segura. Haz clic en Terminar cuando la persiana esté totalmente cerrada.",
-    "hints.dual_motor.travel_time_open": "Empieza con la persiana cerrada y las lamas en la posición segura. Haz clic en Terminar cuando la persiana esté totalmente abierta.",
-    "hints.dual_motor.tilt_time_close": "Empieza con la persiana cerrada y las lamas abiertas. Haz clic en Terminar cuando las lamas estén totalmente cerradas.",
-    "hints.dual_motor.tilt_time_open": "Empieza con la persiana y las lamas cerradas. Haz clic en Terminar cuando las lamas estén totalmente abiertas.",
-    "hints.inline.travel_time_close": "Empieza con la persiana y las lamas totalmente abiertas. Haz clic en Terminar cuando ambas estén totalmente cerradas.",
-    "hints.inline.travel_time_open": "Empieza con la persiana y las lamas totalmente cerradas. Haz clic en Terminar cuando ambas estén totalmente abiertas.",
-    "hints.inline.tilt_time_close": "Empieza con las lamas totalmente abiertas. Haz clic en Terminar cuando las lamas estén totalmente cerradas.",
-    "hints.inline.tilt_time_open": "Empieza con las lamas totalmente cerradas. Haz clic en Terminar cuando las lamas estén totalmente abiertas.",
-    "hints.none.travel_time_close": "Haz clic en Terminar cuando la persiana esté totalmente cerrada.",
-    "hints.none.travel_time_open": "Haz clic en Terminar cuando la persiana esté totalmente abierta.",
+    "hints.sequential_close.travel_time_close":
+      "Empieza con la persiana totalmente abierta. Haz clic en Terminar cuando la persiana esté totalmente cerrada, antes de que las lamas empiecen a inclinarse.",
+    "hints.sequential_close.travel_time_open":
+      "Empieza con la persiana cerrada y las lamas abiertas. Haz clic en Terminar cuando la persiana esté totalmente abierta.",
+    "hints.sequential_close.tilt_time_close":
+      "Empieza con la persiana cerrada pero las lamas abiertas. Haz clic en Terminar cuando las lamas estén totalmente cerradas.",
+    "hints.sequential_close.tilt_time_open":
+      "Empieza con la persiana y las lamas cerradas. Haz clic en Terminar cuando las lamas estén abiertas.",
+    "hints.sequential_open.travel_time_close":
+      "Empieza con la persiana totalmente abierta y las lamas cerradas. Haz clic en Terminar cuando la persiana esté totalmente cerrada, antes de que las lamas empiecen a inclinarse hacia abierto.",
+    "hints.sequential_open.travel_time_open":
+      "Empieza con la persiana cerrada y las lamas cerradas. Haz clic en Terminar cuando la persiana esté totalmente abierta.",
+    "hints.sequential_open.tilt_time_close":
+      "Empieza con la persiana cerrada pero las lamas abiertas. Haz clic en Terminar cuando las lamas estén totalmente cerradas.",
+    "hints.sequential_open.tilt_time_open":
+      "Empieza con la persiana y las lamas cerradas. Haz clic en Terminar cuando las lamas estén totalmente abiertas.",
+    "hints.dual_motor.travel_time_close":
+      "Empieza con la persiana abierta y las lamas en la posición segura. Haz clic en Terminar cuando la persiana esté totalmente cerrada.",
+    "hints.dual_motor.travel_time_open":
+      "Empieza con la persiana cerrada y las lamas en la posición segura. Haz clic en Terminar cuando la persiana esté totalmente abierta.",
+    "hints.dual_motor.tilt_time_close":
+      "Empieza con la persiana cerrada y las lamas abiertas. Haz clic en Terminar cuando las lamas estén totalmente cerradas.",
+    "hints.dual_motor.tilt_time_open":
+      "Empieza con la persiana y las lamas cerradas. Haz clic en Terminar cuando las lamas estén totalmente abiertas.",
+    "hints.inline.travel_time_close":
+      "Empieza con la persiana y las lamas totalmente abiertas. Haz clic en Terminar cuando ambas estén totalmente cerradas.",
+    "hints.inline.travel_time_open":
+      "Empieza con la persiana y las lamas totalmente cerradas. Haz clic en Terminar cuando ambas estén totalmente abiertas.",
+    "hints.inline.tilt_time_close":
+      "Empieza con las lamas totalmente abiertas. Haz clic en Terminar cuando las lamas estén totalmente cerradas.",
+    "hints.inline.tilt_time_open":
+      "Empieza con las lamas totalmente cerradas. Haz clic en Terminar cuando las lamas estén totalmente abiertas.",
+    "hints.none.travel_time_close":
+      "Haz clic en Terminar cuando la persiana esté totalmente cerrada.",
+    "hints.none.travel_time_open":
+      "Haz clic en Terminar cuando la persiana esté totalmente abierta.",
     "hints.min_movement_time": "Haz clic en Terminar en cuanto notes que la persiana se mueve.",
   },
   ca: {
-    "header": "Configuració de Cover Time Based",
-    "loading": "Carregant...",
-    "saving": "Desant...",
-    "save_failed": "Error en desar — valor revertit",
-    "confirm_cancel_calibration": "Hi ha una calibració en curs. Vols cancel·lar-la i continuar?",
-    "create_new": "+ Crea una nova entitat de persiana",
-    "yaml_warning": "Aquesta entitat utilitza configuració YAML i no es pot configurar des d'aquesta targeta. Migra a la interfície d'usuari: Configuració → Dispositius i serveis → Ajudants → Crea ajudant → Cover Time Based.",
-    "load_failed": "No s'ha pogut carregar la configuració. Torna-ho a provar.",
+    header: "Configuració de Cover Time Based",
+    loading: "Carregant...",
+    saving: "Desant...",
+    save_failed: "Error en desar — valor revertit",
+    confirm_cancel_calibration: "Hi ha una calibració en curs. Vols cancel·lar-la i continuar?",
+    create_new: "+ Crea una nova entitat de persiana",
+    yaml_warning:
+      "Aquesta entitat utilitza configuració YAML i no es pot configurar des d'aquesta targeta. Migra a la interfície d'usuari: Configuració → Dispositius i serveis → Ajudants → Crea ajudant → Cover Time Based.",
+    load_failed: "No s'ha pogut carregar la configuració. Torna-ho a provar.",
     "tabs.device": "Dispositiu",
     "tabs.calibration": "Calibració",
     "control_mode.label": "Mode de control",
@@ -1109,11 +1271,14 @@ export const TRANSLATIONS = {
     "tilt_motor.close_switch_pulse": "Interruptor o script de tancament de la inclinació",
     "tilt_motor.stop_switch_pulse": "Interruptor o script d'aturada de la inclinació",
     "tilt_motor.safe_position": "Posició d'inclinació segura",
-    "tilt_motor.safe_position_helper": "La inclinació es mou aquí abans del recorregut (100 = totalment oberta)",
+    "tilt_motor.safe_position_helper":
+      "La inclinació es mou aquí abans del recorregut (100 = totalment oberta)",
     "tilt_motor.max_allowed_position": "Posició màxima d'inclinació permesa (opcional)",
-    "tilt_motor.max_allowed_helper": "La inclinació només es permet quan la posició de la persiana és igual o inferior a aquest valor (0 = tancada, 100 = oberta)",
+    "tilt_motor.max_allowed_helper":
+      "La inclinació només es permet quan la posició de la persiana és igual o inferior a aquest valor (0 = tancada, 100 = oberta)",
     "tilt.close_includes_tilt": "Tancar la persiana també tanca les lamel·les",
-    "tilt.close_includes_tilt_helper": "En tancar, les lamel·les s'inclinen a tancat al final del recorregut",
+    "tilt.close_includes_tilt_helper":
+      "En tancar, les lamel·les s'inclinen a tancat al final del recorregut",
     "assumed_state.label": "Estat suposat",
     "assumed_state.helper":
       "Quan està activat, Home Assistant tracta la posició com a estimada i manté actius els controls d'obertura i tancament. Desactiva-ho si confies en el càlcul per temps i vols que la interfície atenuï les accions no disponibles (per exemple, tancar quan ja està tancada).",
@@ -1129,7 +1294,7 @@ export const TRANSLATIONS = {
     "recalibrate_before_position.label": "Obre del tot abans de moure's a una posició (Beta)",
     "recalibrate_before_position.helper":
       "Per a persianes sense realimentació de posició que un comandament a distància també pot moure. Obre la persiana del tot abans de cada ordre de posició, perquè el moviment parteixi d'una posició coneguda en lloc d'una estimació desviada. Duplica aproximadament el recorregut de cada moviment i, amb la inclinació durant el recorregut o la inclinació seqüencial, mou la persiana quan ajustes les lamel·les.",
-    "more_info": "Més informació",
+    more_info: "Més informació",
     "timing.travel_attribute_header": "Atribut de recorregut",
     "timing.tilt_attribute_header": "Atribut d'inclinació",
     "timing.value_header": "Valor",
@@ -1143,7 +1308,8 @@ export const TRANSLATIONS = {
     "timing.min_movement_time": "Temps mínim de moviment",
     "timing.endpoint_runon_time": "Temps de prolongació als finals de cursa",
     "position.label": "Posició actual",
-    "position.helper": "Mou la persiana a un final de cursa conegut i després estableix la posició.",
+    "position.helper":
+      "Mou la persiana a un final de cursa conegut i després estableix la posició.",
     "position.unknown": "Desconeguda",
     "position.open": "Totalment oberta",
     "position.closed": "Totalment tancada",
@@ -1166,24 +1332,42 @@ export const TRANSLATIONS = {
     "controls.tilt_open": "Obre la inclinació",
     "controls.tilt_stop": "Atura la inclinació",
     "controls.tilt_close": "Tanca la inclinació",
-    "hints.sequential_close.travel_time_close": "Comença amb la persiana totalment oberta. Fes clic a Finalitza quan la persiana estigui totalment tancada, abans que les lamel·les comencin a inclinar-se.",
-    "hints.sequential_close.travel_time_open": "Comença amb la persiana tancada i les lamel·les obertes. Fes clic a Finalitza quan la persiana estigui totalment oberta.",
-    "hints.sequential_close.tilt_time_close": "Comença amb la persiana tancada però les lamel·les obertes. Fes clic a Finalitza quan les lamel·les estiguin totalment tancades.",
-    "hints.sequential_close.tilt_time_open": "Comença amb la persiana i les lamel·les tancades. Fes clic a Finalitza quan les lamel·les estiguin obertes.",
-    "hints.sequential_open.travel_time_close": "Comença amb la persiana totalment oberta i les lamel·les tancades. Fes clic a Finalitza quan la persiana estigui totalment tancada, abans que les lamel·les comencin a obrir-se.",
-    "hints.sequential_open.travel_time_open": "Comença amb la persiana tancada i les lamel·les tancades. Fes clic a Finalitza quan la persiana estigui totalment oberta.",
-    "hints.sequential_open.tilt_time_close": "Comença amb la persiana tancada però les lamel·les obertes. Fes clic a Finalitza quan les lamel·les estiguin totalment tancades.",
-    "hints.sequential_open.tilt_time_open": "Comença amb la persiana i les lamel·les tancades. Fes clic a Finalitza quan les lamel·les estiguin totalment obertes.",
-    "hints.dual_motor.travel_time_close": "Comença amb la persiana oberta i les lamel·les en la posició segura. Fes clic a Finalitza quan la persiana estigui totalment tancada.",
-    "hints.dual_motor.travel_time_open": "Comença amb la persiana tancada i les lamel·les en la posició segura. Fes clic a Finalitza quan la persiana estigui totalment oberta.",
-    "hints.dual_motor.tilt_time_close": "Comença amb la persiana tancada i les lamel·les obertes. Fes clic a Finalitza quan les lamel·les estiguin totalment tancades.",
-    "hints.dual_motor.tilt_time_open": "Comença amb la persiana i les lamel·les tancades. Fes clic a Finalitza quan les lamel·les estiguin totalment obertes.",
-    "hints.inline.travel_time_close": "Comença amb la persiana i les lamel·les totalment obertes. Fes clic a Finalitza quan totes dues estiguin totalment tancades.",
-    "hints.inline.travel_time_open": "Comença amb la persiana i les lamel·les totalment tancades. Fes clic a Finalitza quan totes dues estiguin totalment obertes.",
-    "hints.inline.tilt_time_close": "Comença amb les lamel·les totalment obertes. Fes clic a Finalitza quan les lamel·les estiguin totalment tancades.",
-    "hints.inline.tilt_time_open": "Comença amb les lamel·les totalment tancades. Fes clic a Finalitza quan les lamel·les estiguin totalment obertes.",
-    "hints.none.travel_time_close": "Fes clic a Finalitza quan la persiana estigui totalment tancada.",
-    "hints.none.travel_time_open": "Fes clic a Finalitza quan la persiana estigui totalment oberta.",
+    "hints.sequential_close.travel_time_close":
+      "Comença amb la persiana totalment oberta. Fes clic a Finalitza quan la persiana estigui totalment tancada, abans que les lamel·les comencin a inclinar-se.",
+    "hints.sequential_close.travel_time_open":
+      "Comença amb la persiana tancada i les lamel·les obertes. Fes clic a Finalitza quan la persiana estigui totalment oberta.",
+    "hints.sequential_close.tilt_time_close":
+      "Comença amb la persiana tancada però les lamel·les obertes. Fes clic a Finalitza quan les lamel·les estiguin totalment tancades.",
+    "hints.sequential_close.tilt_time_open":
+      "Comença amb la persiana i les lamel·les tancades. Fes clic a Finalitza quan les lamel·les estiguin obertes.",
+    "hints.sequential_open.travel_time_close":
+      "Comença amb la persiana totalment oberta i les lamel·les tancades. Fes clic a Finalitza quan la persiana estigui totalment tancada, abans que les lamel·les comencin a obrir-se.",
+    "hints.sequential_open.travel_time_open":
+      "Comença amb la persiana tancada i les lamel·les tancades. Fes clic a Finalitza quan la persiana estigui totalment oberta.",
+    "hints.sequential_open.tilt_time_close":
+      "Comença amb la persiana tancada però les lamel·les obertes. Fes clic a Finalitza quan les lamel·les estiguin totalment tancades.",
+    "hints.sequential_open.tilt_time_open":
+      "Comença amb la persiana i les lamel·les tancades. Fes clic a Finalitza quan les lamel·les estiguin totalment obertes.",
+    "hints.dual_motor.travel_time_close":
+      "Comença amb la persiana oberta i les lamel·les en la posició segura. Fes clic a Finalitza quan la persiana estigui totalment tancada.",
+    "hints.dual_motor.travel_time_open":
+      "Comença amb la persiana tancada i les lamel·les en la posició segura. Fes clic a Finalitza quan la persiana estigui totalment oberta.",
+    "hints.dual_motor.tilt_time_close":
+      "Comença amb la persiana tancada i les lamel·les obertes. Fes clic a Finalitza quan les lamel·les estiguin totalment tancades.",
+    "hints.dual_motor.tilt_time_open":
+      "Comença amb la persiana i les lamel·les tancades. Fes clic a Finalitza quan les lamel·les estiguin totalment obertes.",
+    "hints.inline.travel_time_close":
+      "Comença amb la persiana i les lamel·les totalment obertes. Fes clic a Finalitza quan totes dues estiguin totalment tancades.",
+    "hints.inline.travel_time_open":
+      "Comença amb la persiana i les lamel·les totalment tancades. Fes clic a Finalitza quan totes dues estiguin totalment obertes.",
+    "hints.inline.tilt_time_close":
+      "Comença amb les lamel·les totalment obertes. Fes clic a Finalitza quan les lamel·les estiguin totalment tancades.",
+    "hints.inline.tilt_time_open":
+      "Comença amb les lamel·les totalment tancades. Fes clic a Finalitza quan les lamel·les estiguin totalment obertes.",
+    "hints.none.travel_time_close":
+      "Fes clic a Finalitza quan la persiana estigui totalment tancada.",
+    "hints.none.travel_time_open":
+      "Fes clic a Finalitza quan la persiana estigui totalment oberta.",
     "hints.min_movement_time": "Fes clic a Finalitza tan bon punt notis que la persiana es mou.",
   },
 };

--- a/tests/frontend/calibration_finish_gate.test.mjs
+++ b/tests/frontend/calibration_finish_gate.test.mjs
@@ -39,8 +39,7 @@ const calibratingHass = (attrs) =>
 
 // The Finish button is the "unelevated" one in the active-calibration panel
 // (Cancel is not unelevated; the non-calibrating Start button is not shown).
-const finishButton = (c) =>
-  c.shadowRoot.querySelector(".cal-active-buttons ha-button[unelevated]");
+const finishButton = (c) => c.shadowRoot.querySelector(".cal-active-buttons ha-button[unelevated]");
 
 async function mountCalibrating(attrs) {
   return mountCard(calibratingHass(attrs), {

--- a/tests/frontend/card_calibration.test.mjs
+++ b/tests/frontend/card_calibration.test.mjs
@@ -38,12 +38,14 @@ test("_onStartCalibration sends start_calibration and flips _calibratingOverride
   card = await mountCard(hass, { selectedEntity: "cover.x" });
   card.shadowRoot.querySelector = () => ({ value: "travel_time_close" });
   await card._onStartCalibration();
-  expect(hass.callWS).toHaveBeenCalledWith(expect.objectContaining({
-    type: "cover_time_based/start_calibration",
-    entity_id: "cover.x",
-    attribute: "travel_time_close",
-    timeout: 300,
-  }));
+  expect(hass.callWS).toHaveBeenCalledWith(
+    expect.objectContaining({
+      type: "cover_time_based/start_calibration",
+      entity_id: "cover.x",
+      attribute: "travel_time_close",
+      timeout: 300,
+    }),
+  );
   expect(card._calibratingOverride).toBe(true);
 });
 
@@ -60,10 +62,12 @@ test("_onStartCalibration sends the attribute from the #cal-attribute select", a
   card = await mountCard(hass, { selectedEntity: "cover.y" });
   card.shadowRoot.querySelector = () => ({ value: "tilt_time_open" });
   await card._onStartCalibration();
-  expect(hass.callWS).toHaveBeenCalledWith(expect.objectContaining({
-    attribute: "tilt_time_open",
-    entity_id: "cover.y",
-  }));
+  expect(hass.callWS).toHaveBeenCalledWith(
+    expect.objectContaining({
+      attribute: "tilt_time_open",
+      entity_id: "cover.y",
+    }),
+  );
 });
 
 test("_onStartCalibration alerts on WS failure (window.alert is expected behavior)", async () => {
@@ -106,24 +110,27 @@ test("_onStartCalibration alert message contains the error text", async () => {
 
 // All 7 ATTRIBUTE_TO_CONFIG entries (attribute → config key):
 test.each([
-  ["travel_time_close",   "travel_time_close"],
-  ["tilt_time_open",      "tilt_time_open"],
-  ["travel_time_open",    "travel_time_open"],
-  ["tilt_time_close",     "tilt_time_close"],
-  ["travel_startup_delay","travel_startup_delay"],
-  ["tilt_startup_delay",  "tilt_startup_delay"],
-  ["min_movement_time",   "min_movement_time"],
-])("_onStopCalibration(false) applies %s → _config.%s via ATTRIBUTE_TO_CONFIG", async (attr, key) => {
-  const hass = makeHass({
-    ws: {
-      "cover_time_based/stop_calibration": () => ({ attribute: attr, value: 7.7 }),
-    },
-  });
-  card = await mountCard(hass, { selectedEntity: "cover.x", config: { control_mode: "switch" } });
-  const spy = vi.spyOn(card, "_updateLocal").mockImplementation(() => {});
-  await card._onStopCalibration(false);
-  expect(spy).toHaveBeenCalledWith(expect.objectContaining({ [key]: 7.7 }));
-});
+  ["travel_time_close", "travel_time_close"],
+  ["tilt_time_open", "tilt_time_open"],
+  ["travel_time_open", "travel_time_open"],
+  ["tilt_time_close", "tilt_time_close"],
+  ["travel_startup_delay", "travel_startup_delay"],
+  ["tilt_startup_delay", "tilt_startup_delay"],
+  ["min_movement_time", "min_movement_time"],
+])(
+  "_onStopCalibration(false) applies %s → _config.%s via ATTRIBUTE_TO_CONFIG",
+  async (attr, key) => {
+    const hass = makeHass({
+      ws: {
+        "cover_time_based/stop_calibration": () => ({ attribute: attr, value: 7.7 }),
+      },
+    });
+    card = await mountCard(hass, { selectedEntity: "cover.x", config: { control_mode: "switch" } });
+    const spy = vi.spyOn(card, "_updateLocal").mockImplementation(() => {});
+    await card._onStopCalibration(false);
+    expect(spy).toHaveBeenCalledWith(expect.objectContaining({ [key]: 7.7 }));
+  },
+);
 
 test("_onStopCalibration(false) sets _calibratingOverride to false", async () => {
   card = await mountCard(makeHass(), { selectedEntity: "cover.x" });
@@ -142,11 +149,13 @@ test("_onStopCalibration(true) cancels: sends stop_calibration with cancel:true"
   const hass = makeHass();
   card = await mountCard(hass, { selectedEntity: "cover.x" });
   await card._onStopCalibration(true);
-  expect(hass.callWS).toHaveBeenCalledWith(expect.objectContaining({
-    type: "cover_time_based/stop_calibration",
-    entity_id: "cover.x",
-    cancel: true,
-  }));
+  expect(hass.callWS).toHaveBeenCalledWith(
+    expect.objectContaining({
+      type: "cover_time_based/stop_calibration",
+      entity_id: "cover.x",
+      cancel: true,
+    }),
+  );
 });
 
 test("_onStopCalibration(true) sets _calibratingOverride to false", async () => {
@@ -217,7 +226,9 @@ test("finish-then-switch: A's calibration result is NOT written onto B (F2)", as
       "cover_time_based/get_config": ({ entity_id }) =>
         entity_id === "cover.b" ? { ...CROSSWRITE_CONFIG_B } : { ...CROSSWRITE_CONFIG_A },
       "cover_time_based/stop_calibration": () =>
-        new Promise((res) => { resolveStop = res; }),
+        new Promise((res) => {
+          resolveStop = res;
+        }),
     },
   });
   card = await mountCard(hass, { selectedEntity: "cover.a", config: { ...CROSSWRITE_CONFIG_A } });
@@ -235,7 +246,9 @@ test("finish-then-switch: A's calibration result is NOT written onto B (F2)", as
 
   // B's config loads (fast, as get_config usually is) before A's stop_calibration
   // call resolves.
-  await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
   await card.updateComplete;
   expect(card._selectedEntity).toBe("cover.b");
   expect(card._config.travel_time_close).toBe(7);
@@ -256,7 +269,9 @@ test("finish-then-switch: A's calibration result is NOT written onto B (F2)", as
       .map(([a]) => a)
       .filter((a) => a.type === "cover_time_based/update_config");
     // No autosave may target B while carrying A's measurement.
-    expect(saves.find((s) => s.entity_id === "cover.b" && s.travel_time_close === 99.9)).toBeUndefined();
+    expect(
+      saves.find((s) => s.entity_id === "cover.b" && s.travel_time_close === 99.9),
+    ).toBeUndefined();
   } finally {
     vi.useRealTimers();
   }
@@ -294,12 +309,12 @@ test("finish without switching: the result IS applied and autosaved to the calib
 // ---------------------------------------------------------------------------
 
 test.each([
-  ["open_cover",  "open"],
+  ["open_cover", "open"],
   ["close_cover", "close"],
-  ["stop_cover",  "stop"],
-  ["tilt_open",   "tilt_open"],
-  ["tilt_close",  "tilt_close"],
-  ["tilt_stop",   "tilt_stop"],
+  ["stop_cover", "stop"],
+  ["tilt_open", "tilt_open"],
+  ["tilt_close", "tilt_close"],
+  ["tilt_stop", "tilt_stop"],
 ])("_onCoverCommand maps %s → '%s'", async (action, command) => {
   const hass = makeHass();
   card = await mountCard(hass, { selectedEntity: "cover.x" });
@@ -349,15 +364,14 @@ test("_onPositionPresetChange='open' sets known position 100 (no tilt when tilt_
   const hass = makeHass();
   card = await mountCard(hass, { selectedEntity: "cover.x", config: { tilt_mode: "none" } });
   await card._onPositionPresetChange("open");
-  expect(hass.callService).toHaveBeenCalledWith(
-    "cover_time_based",
-    "set_known_position",
-    { entity_id: "cover.x", position: 100 }
-  );
+  expect(hass.callService).toHaveBeenCalledWith("cover_time_based", "set_known_position", {
+    entity_id: "cover.x",
+    position: 100,
+  });
   expect(hass.callService).not.toHaveBeenCalledWith(
     "cover_time_based",
     "set_known_tilt_position",
-    expect.anything()
+    expect.anything(),
   );
 });
 
@@ -365,96 +379,88 @@ test("_onPositionPresetChange='open' sets position 100 + tilt 100 when tilt is o
   const hass = makeHass();
   card = await mountCard(hass, { selectedEntity: "cover.x", config: { tilt_mode: "inline" } });
   await card._onPositionPresetChange("open");
-  expect(hass.callService).toHaveBeenCalledWith(
-    "cover_time_based",
-    "set_known_position",
-    { entity_id: "cover.x", position: 100 }
-  );
-  expect(hass.callService).toHaveBeenCalledWith(
-    "cover_time_based",
-    "set_known_tilt_position",
-    { entity_id: "cover.x", tilt_position: 100 }
-  );
+  expect(hass.callService).toHaveBeenCalledWith("cover_time_based", "set_known_position", {
+    entity_id: "cover.x",
+    position: 100,
+  });
+  expect(hass.callService).toHaveBeenCalledWith("cover_time_based", "set_known_tilt_position", {
+    entity_id: "cover.x",
+    tilt_position: 100,
+  });
 });
 
 test("_onPositionPresetChange='open' sets position 100 + tilt 100 for dual_motor tilt mode", async () => {
   const hass = makeHass();
   card = await mountCard(hass, { selectedEntity: "cover.x", config: { tilt_mode: "dual_motor" } });
   await card._onPositionPresetChange("open");
-  expect(hass.callService).toHaveBeenCalledWith(
-    "cover_time_based",
-    "set_known_position",
-    { entity_id: "cover.x", position: 100 }
-  );
-  expect(hass.callService).toHaveBeenCalledWith(
-    "cover_time_based",
-    "set_known_tilt_position",
-    { entity_id: "cover.x", tilt_position: 100 }
-  );
+  expect(hass.callService).toHaveBeenCalledWith("cover_time_based", "set_known_position", {
+    entity_id: "cover.x",
+    position: 100,
+  });
+  expect(hass.callService).toHaveBeenCalledWith("cover_time_based", "set_known_tilt_position", {
+    entity_id: "cover.x",
+    tilt_position: 100,
+  });
 });
 
 test("_onPositionPresetChange='closed' sets position 0, no tilt when tilt_mode:none", async () => {
   const hass = makeHass();
   card = await mountCard(hass, { selectedEntity: "cover.x", config: { tilt_mode: "none" } });
   await card._onPositionPresetChange("closed");
-  expect(hass.callService).toHaveBeenCalledWith(
-    "cover_time_based",
-    "set_known_position",
-    { entity_id: "cover.x", position: 0 }
-  );
+  expect(hass.callService).toHaveBeenCalledWith("cover_time_based", "set_known_position", {
+    entity_id: "cover.x",
+    position: 0,
+  });
   expect(hass.callService).not.toHaveBeenCalledWith(
     "cover_time_based",
     "set_known_tilt_position",
-    expect.anything()
+    expect.anything(),
   );
 });
 
 test("_onPositionPresetChange='closed' sets position 0 + tilt 0 when tilted", async () => {
   const hass = makeHass();
-  card = await mountCard(hass, { selectedEntity: "cover.x", config: { tilt_mode: "sequential_close" } });
+  card = await mountCard(hass, {
+    selectedEntity: "cover.x",
+    config: { tilt_mode: "sequential_close" },
+  });
   await card._onPositionPresetChange("closed");
-  expect(hass.callService).toHaveBeenCalledWith(
-    "cover_time_based",
-    "set_known_position",
-    { entity_id: "cover.x", position: 0 }
-  );
-  expect(hass.callService).toHaveBeenCalledWith(
-    "cover_time_based",
-    "set_known_tilt_position",
-    { entity_id: "cover.x", tilt_position: 0 }
-  );
+  expect(hass.callService).toHaveBeenCalledWith("cover_time_based", "set_known_position", {
+    entity_id: "cover.x",
+    position: 0,
+  });
+  expect(hass.callService).toHaveBeenCalledWith("cover_time_based", "set_known_tilt_position", {
+    entity_id: "cover.x",
+    tilt_position: 0,
+  });
 });
 
 test("_onPositionPresetChange='closed_tilt_open' sets position 0 + tilt 100", async () => {
   const hass = makeHass();
   card = await mountCard(hass, { selectedEntity: "cover.x", config: { tilt_mode: "inline" } });
   await card._onPositionPresetChange("closed_tilt_open");
-  expect(hass.callService).toHaveBeenCalledWith(
-    "cover_time_based",
-    "set_known_position",
-    { entity_id: "cover.x", position: 0 }
-  );
-  expect(hass.callService).toHaveBeenCalledWith(
-    "cover_time_based",
-    "set_known_tilt_position",
-    { entity_id: "cover.x", tilt_position: 100 }
-  );
+  expect(hass.callService).toHaveBeenCalledWith("cover_time_based", "set_known_position", {
+    entity_id: "cover.x",
+    position: 0,
+  });
+  expect(hass.callService).toHaveBeenCalledWith("cover_time_based", "set_known_tilt_position", {
+    entity_id: "cover.x",
+    tilt_position: 100,
+  });
 });
 
 test("_onPositionPresetChange='closed_tilt_closed' sets position 0 + tilt 0", async () => {
   const hass = makeHass();
   card = await mountCard(hass, { selectedEntity: "cover.x", config: { tilt_mode: "inline" } });
   await card._onPositionPresetChange("closed_tilt_closed");
-  expect(hass.callService).toHaveBeenCalledWith(
-    "cover_time_based",
-    "set_known_position",
-    { entity_id: "cover.x", position: 0 }
-  );
-  expect(hass.callService).toHaveBeenCalledWith(
-    "cover_time_based",
-    "set_known_tilt_position",
-    { entity_id: "cover.x", tilt_position: 0 }
-  );
+  expect(hass.callService).toHaveBeenCalledWith("cover_time_based", "set_known_position", {
+    entity_id: "cover.x",
+    position: 0,
+  });
+  expect(hass.callService).toHaveBeenCalledWith("cover_time_based", "set_known_tilt_position", {
+    entity_id: "cover.x",
+    tilt_position: 0,
+  });
 });
 
 test("_onPositionPresetChange='closed_tilt_open' sends tilt 100 regardless of config tilt_mode", async () => {
@@ -462,11 +468,10 @@ test("_onPositionPresetChange='closed_tilt_open' sends tilt 100 regardless of co
   const hass = makeHass();
   card = await mountCard(hass, { selectedEntity: "cover.x", config: { tilt_mode: "none" } });
   await card._onPositionPresetChange("closed_tilt_open");
-  expect(hass.callService).toHaveBeenCalledWith(
-    "cover_time_based",
-    "set_known_tilt_position",
-    { entity_id: "cover.x", tilt_position: 100 }
-  );
+  expect(hass.callService).toHaveBeenCalledWith("cover_time_based", "set_known_tilt_position", {
+    entity_id: "cover.x",
+    tilt_position: 100,
+  });
 });
 
 test("_onPositionPresetChange='closed_tilt_closed' sends tilt 0 regardless of config tilt_mode", async () => {
@@ -474,11 +479,10 @@ test("_onPositionPresetChange='closed_tilt_closed' sends tilt 0 regardless of co
   const hass = makeHass();
   card = await mountCard(hass, { selectedEntity: "cover.x", config: { tilt_mode: "none" } });
   await card._onPositionPresetChange("closed_tilt_closed");
-  expect(hass.callService).toHaveBeenCalledWith(
-    "cover_time_based",
-    "set_known_tilt_position",
-    { entity_id: "cover.x", tilt_position: 0 }
-  );
+  expect(hass.callService).toHaveBeenCalledWith("cover_time_based", "set_known_tilt_position", {
+    entity_id: "cover.x",
+    tilt_position: 0,
+  });
 });
 
 test("_onPositionPresetChange sets _knownPosition to the preset value", async () => {
@@ -491,7 +495,9 @@ test("_onPositionPresetChange sets _knownPosition to the preset value", async ()
 test("_onPositionPresetChange error path swallows the error (console.error is expected)", async () => {
   const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
   const hass = makeHass({
-    service: async () => { throw new Error("service failed"); },
+    service: async () => {
+      throw new Error("service failed");
+    },
   });
   card = await mountCard(hass, { selectedEntity: "cover.x", config: { tilt_mode: "none" } });
   // Must NOT throw
@@ -563,9 +569,7 @@ test("live entity picker: switching device clears _sawCalibrationActive alongsid
   card._sawCalibrationActive = true;
 
   const picker = card.shadowRoot.querySelector("ha-entity-picker");
-  picker.dispatchEvent(
-    new CustomEvent("value-changed", { detail: { value: "cover.b" } })
-  );
+  picker.dispatchEvent(new CustomEvent("value-changed", { detail: { value: "cover.b" } }));
 
   expect(card._calibratingOverride).toBeUndefined();
   expect(card._sawCalibrationActive).toBe(false);

--- a/tests/frontend/card_events.test.mjs
+++ b/tests/frontend/card_events.test.mjs
@@ -59,7 +59,10 @@ test("picker value-changed with a value sets _selectedEntity, nulls _config, cal
 });
 
 test("picker value-changed with empty value sets _selectedEntity but does NOT call _loadConfig", async () => {
-  card = await mountCard(makeHass(), { config: { control_mode: "switch" }, selectedEntity: "cover.x" });
+  card = await mountCard(makeHass(), {
+    config: { control_mode: "switch" },
+    selectedEntity: "cover.x",
+  });
   const loadSpy = vi.spyOn(card, "_loadConfig").mockResolvedValue(undefined);
   firePickerValueChanged(card, { value: "" });
   expect(card._selectedEntity).toBe("");
@@ -71,7 +74,10 @@ test("picker value-changed with the currently-selected entity is a no-op", async
   // The live handler short-circuits when the picker fires with the value it
   // already has (e.g. a spurious change event) — the dead _onEntityChange
   // method never had this guard at all.
-  card = await mountCard(makeHass(), { config: { control_mode: "switch" }, selectedEntity: "cover.x" });
+  card = await mountCard(makeHass(), {
+    config: { control_mode: "switch" },
+    selectedEntity: "cover.x",
+  });
   const loadSpy = vi.spyOn(card, "_loadConfig").mockResolvedValue(undefined);
   const flushSpy = vi.spyOn(card, "_flushAutoSave");
   firePickerValueChanged(card, { value: "cover.x" });
@@ -81,7 +87,10 @@ test("picker value-changed with the currently-selected entity is a no-op", async
 });
 
 test("picker value-changed to a new entity flushes the outgoing edit and resets load error/position/tab/calibration latches", async () => {
-  card = await mountCard(makeHass(), { config: { control_mode: "switch" }, selectedEntity: "cover.old" });
+  card = await mountCard(makeHass(), {
+    config: { control_mode: "switch" },
+    selectedEntity: "cover.old",
+  });
   const loadSpy = vi.spyOn(card, "_loadConfig").mockResolvedValue(undefined);
   const flushSpy = vi.spyOn(card, "_flushAutoSave").mockImplementation(() => {});
   card._loadError = "stale error";
@@ -105,7 +114,10 @@ test("picker value-changed to a new entity flushes the outgoing edit and resets 
 
 test("picker value-changed while calibrating and the user cancels the confirm reverts the picker and leaves the selection untouched", async () => {
   window.confirm = vi.fn(() => false);
-  card = await mountCard(makeHass(), { config: { control_mode: "switch" }, selectedEntity: "cover.x" });
+  card = await mountCard(makeHass(), {
+    config: { control_mode: "switch" },
+    selectedEntity: "cover.x",
+  });
   const stopSpy = vi.spyOn(card, "_onStopCalibration").mockResolvedValue(undefined);
   const loadSpy = vi.spyOn(card, "_loadConfig").mockResolvedValue(undefined);
   card._calibratingOverride = true; // _isCalibrating() === true
@@ -121,7 +133,10 @@ test("picker value-changed while calibrating and the user cancels the confirm re
 
 test("picker value-changed while calibrating and the user confirms stops calibration and proceeds with the swap", async () => {
   window.confirm = vi.fn(() => true);
-  card = await mountCard(makeHass(), { config: { control_mode: "switch" }, selectedEntity: "cover.x" });
+  card = await mountCard(makeHass(), {
+    config: { control_mode: "switch" },
+    selectedEntity: "cover.x",
+  });
   const stopSpy = vi.spyOn(card, "_onStopCalibration").mockResolvedValue(undefined);
   const loadSpy = vi.spyOn(card, "_loadConfig").mockResolvedValue(undefined);
   card._calibratingOverride = true; // _isCalibrating() === true
@@ -139,21 +154,25 @@ test("picker value-changed while calibrating and the user confirms stops calibra
 // ---------------------------------------------------------------------------
 
 test("_onControlModeChange to wrapped clears switch slots and resets dual_motor tilt", async () => {
-  card = await mountCard(makeHass(), { config: { control_mode: "switch", tilt_mode: "dual_motor" } });
+  card = await mountCard(makeHass(), {
+    config: { control_mode: "switch", tilt_mode: "dual_motor" },
+  });
   const updates = captureUpdates(card);
   card._onControlModeChange({ target: { value: "wrapped" } });
   expect(updates[0].control_mode).toBe("wrapped");
-  expect(updates[0].open_switch_entity_id).toBeNull();   // cleared by clearedEntitiesForMode
+  expect(updates[0].open_switch_entity_id).toBeNull(); // cleared by clearedEntitiesForMode
   expect(updates[0].close_switch_entity_id).toBeNull();
   expect(updates[0].stop_switch_entity_id).toBeNull();
   expect(updates[0].tilt_open_switch).toBeNull();
   expect(updates[0].tilt_close_switch).toBeNull();
   expect(updates[0].tilt_stop_switch).toBeNull();
-  expect(updates[0].tilt_mode).toBe("none");             // dual_motor reset on wrapped
+  expect(updates[0].tilt_mode).toBe("none"); // dual_motor reset on wrapped
 });
 
 test("_onControlModeChange to wrapped with non-dual_motor tilt does NOT reset tilt", async () => {
-  card = await mountCard(makeHass(), { config: { control_mode: "switch", tilt_mode: "sequential_close" } });
+  card = await mountCard(makeHass(), {
+    config: { control_mode: "switch", tilt_mode: "sequential_close" },
+  });
   const updates = captureUpdates(card);
   card._onControlModeChange({ target: { value: "wrapped" } });
   expect(updates[0].control_mode).toBe("wrapped");
@@ -166,8 +185,8 @@ test("_onControlModeChange to switch clears cover_entity_id and stop_switch_enti
   const updates = captureUpdates(card);
   card._onControlModeChange({ target: { value: "switch" } });
   expect(updates[0].control_mode).toBe("switch");
-  expect(updates[0].cover_entity_id).toBeNull();        // cleared by clearedEntitiesForMode
-  expect(updates[0].stop_switch_entity_id).toBeNull();   // non-pulse clears stop
+  expect(updates[0].cover_entity_id).toBeNull(); // cleared by clearedEntitiesForMode
+  expect(updates[0].stop_switch_entity_id).toBeNull(); // non-pulse clears stop
   expect(updates[0].tilt_stop_switch).toBeNull();
 });
 
@@ -230,9 +249,9 @@ test("_onControlModeChange staying on pulse does not touch script-valued slots",
 test("_onPulseTimeChange ignores sub-0.1 / NaN, accepts valid", async () => {
   card = await mountCard(makeHass(), { config: { control_mode: "pulse" } });
   const updates = captureUpdates(card);
-  card._onPulseTimeChange({ target: { value: "0.05" } });   // rejected (< 0.1)
-  card._onPulseTimeChange({ target: { value: "abc" } });    // rejected (NaN)
-  card._onPulseTimeChange({ target: { value: "1.5" } });    // accepted
+  card._onPulseTimeChange({ target: { value: "0.05" } }); // rejected (< 0.1)
+  card._onPulseTimeChange({ target: { value: "abc" } }); // rejected (NaN)
+  card._onPulseTimeChange({ target: { value: "1.5" } }); // accepted
   expect(updates).toEqual([{ pulse_time: 1.5 }]);
 });
 
@@ -269,7 +288,9 @@ test("_onSwitchEntityChange with a value sets the named field", async () => {
 });
 
 test("_onSwitchEntityChange with empty value nulls the named field", async () => {
-  card = await mountCard(makeHass(), { config: { control_mode: "switch", open_switch_entity_id: "switch.open" } });
+  card = await mountCard(makeHass(), {
+    config: { control_mode: "switch", open_switch_entity_id: "switch.open" },
+  });
   const updates = captureUpdates(card);
   card._onSwitchEntityChange("open_switch_entity_id", { detail: { value: "" } });
   expect(updates[0]).toEqual({ open_switch_entity_id: null });
@@ -350,7 +371,9 @@ test("_onCoverEntityChange without dual_motor tilt just sets cover_entity_id", a
       "cover.notilt": { state: "open", attributes: { supported_features: 0 } },
     },
   });
-  card = await mountCard(hass, { config: { control_mode: "wrapped", tilt_mode: "sequential_close" } });
+  card = await mountCard(hass, {
+    config: { control_mode: "wrapped", tilt_mode: "sequential_close" },
+  });
   const updates = captureUpdates(card);
   card._onCoverEntityChange({ detail: { value: "cover.notilt" } });
   expect(updates[0]).toEqual({ cover_entity_id: "cover.notilt" });
@@ -368,7 +391,9 @@ test("_onCoverEntityChange with empty value sets cover_entity_id to null", async
 // ---------------------------------------------------------------------------
 
 test("_onTiltModeChange='none' clears all tilt config", async () => {
-  card = await mountCard(makeHass(), { config: { control_mode: "switch", tilt_mode: "dual_motor" } });
+  card = await mountCard(makeHass(), {
+    config: { control_mode: "switch", tilt_mode: "dual_motor" },
+  });
   const updates = captureUpdates(card);
   card._onTiltModeChange({ target: { value: "none" } });
   expect(updates[0].tilt_mode).toBe("none");
@@ -404,7 +429,7 @@ test("_onTiltModeChange='sequential_close' clears dual_motor fields, defaults cl
   expect(updates[0].tilt_open_switch).toBeNull();
   expect(updates[0].tilt_close_switch).toBeNull();
   expect(updates[0].tilt_stop_switch).toBeNull();
-  expect(updates[0].close_includes_tilt).toBe(true);  // defaulted
+  expect(updates[0].close_includes_tilt).toBe(true); // defaulted
 });
 
 test("_onTiltModeChange='sequential_close' does NOT override existing close_includes_tilt when set to false", async () => {

--- a/tests/frontend/card_lifecycle.test.mjs
+++ b/tests/frontend/card_lifecycle.test.mjs
@@ -11,7 +11,7 @@
 
 import { test, expect, afterEach, vi } from "vitest";
 import { makeHass } from "./helpers/hass.mjs";
-import { mountCard } from "./helpers/mount.mjs";   // NOTE: no defineHaStubs in this file
+import { mountCard } from "./helpers/mount.mjs"; // NOTE: no defineHaStubs in this file
 
 let card;
 afterEach(() => {
@@ -66,7 +66,9 @@ test("_loadEntityList swallows errors and sets _configEntryEntities to []", asyn
   const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
   const hass = makeHass({
     ws: {
-      "config/entity_registry/list": () => { throw new Error("boom"); },
+      "config/entity_registry/list": () => {
+        throw new Error("boom");
+      },
     },
   });
   card = await mountCard(hass);
@@ -84,7 +86,9 @@ test("_loadEntityList error path re-renders so the (now-empty) picker replaces s
   const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
   const hass = makeHass({
     ws: {
-      "config/entity_registry/list": () => { throw new Error("boom"); },
+      "config/entity_registry/list": () => {
+        throw new Error("boom");
+      },
     },
   });
   card = await mountCard(hass);
@@ -134,7 +138,9 @@ test("_loadConfig on a transient/unknown WS failure sets _loadError to the gener
       // A plain Error with no .code — e.g. a dropped connection or an
       // unexpected server exception — is NOT "this entity has no config
       // entry", so it must not show the YAML-migration lecture.
-      "cover_time_based/get_config": () => { throw new Error("network fail"); },
+      "cover_time_based/get_config": () => {
+        throw new Error("network fail");
+      },
     },
   });
   card = await mountCard(hass);
@@ -179,11 +185,11 @@ test("_loadConfig returns early without calling callWS when _selectedEntity is e
   card = await mountCard(hass);
   // Reset call count after mount
   hass.callWS.mockClear();
-  card._selectedEntity = "";   // ensure no entity is selected
+  card._selectedEntity = ""; // ensure no entity is selected
   await card._loadConfig();
   // callWS should NOT have been called for get_config (or at all)
   const getConfigCalls = hass.callWS.mock.calls.filter(
-    ([arg]) => arg?.type === "cover_time_based/get_config"
+    ([arg]) => arg?.type === "cover_time_based/get_config",
   );
   expect(getConfigCalls).toHaveLength(0);
 });

--- a/tests/frontend/card_logic.test.mjs
+++ b/tests/frontend/card_logic.test.mjs
@@ -81,94 +81,116 @@ test("_hasRequiredEntities returns false for null config", async () => {
 test("_hasRequiredEntities wrapped: requires cover_entity_id", async () => {
   card = await mountCard(makeHass());
   expect(card._hasRequiredEntities({ control_mode: "wrapped" })).toBe(false);
-  expect(card._hasRequiredEntities({ control_mode: "wrapped", cover_entity_id: "cover.x" })).toBe(true);
+  expect(card._hasRequiredEntities({ control_mode: "wrapped", cover_entity_id: "cover.x" })).toBe(
+    true,
+  );
 });
 
 test("_hasRequiredEntities switch: requires open + close switches", async () => {
   card = await mountCard(makeHass());
-  expect(card._hasRequiredEntities({ control_mode: "switch", open_switch_entity_id: "s.o" })).toBe(false);
-  expect(card._hasRequiredEntities({
-    control_mode: "switch",
-    open_switch_entity_id: "s.o",
-    close_switch_entity_id: "s.c",
-  })).toBe(true);
+  expect(card._hasRequiredEntities({ control_mode: "switch", open_switch_entity_id: "s.o" })).toBe(
+    false,
+  );
+  expect(
+    card._hasRequiredEntities({
+      control_mode: "switch",
+      open_switch_entity_id: "s.o",
+      close_switch_entity_id: "s.c",
+    }),
+  ).toBe(true);
 });
 
 test("_hasRequiredEntities pulse: additionally requires stop switch", async () => {
   card = await mountCard(makeHass());
   // open + close but no stop → false
-  expect(card._hasRequiredEntities({
-    control_mode: "pulse",
-    open_switch_entity_id: "o",
-    close_switch_entity_id: "c",
-  })).toBe(false);
+  expect(
+    card._hasRequiredEntities({
+      control_mode: "pulse",
+      open_switch_entity_id: "o",
+      close_switch_entity_id: "c",
+    }),
+  ).toBe(false);
   // all three → true
-  expect(card._hasRequiredEntities({
-    control_mode: "pulse",
-    open_switch_entity_id: "o",
-    close_switch_entity_id: "c",
-    stop_switch_entity_id: "s",
-  })).toBe(true);
+  expect(
+    card._hasRequiredEntities({
+      control_mode: "pulse",
+      open_switch_entity_id: "o",
+      close_switch_entity_id: "c",
+      stop_switch_entity_id: "s",
+    }),
+  ).toBe(true);
 });
 
 test("_hasRequiredEntities toggle_opposite: requires only open+close (no stop switch)", async () => {
   card = await mountCard(makeHass());
   // open+close present, no stop switch -> ready
-  expect(card._hasRequiredEntities({
-    control_mode: "toggle_opposite",
-    open_switch_entity_id: "switch.o",
-    close_switch_entity_id: "switch.c",
-  })).toBe(true);
+  expect(
+    card._hasRequiredEntities({
+      control_mode: "toggle_opposite",
+      open_switch_entity_id: "switch.o",
+      close_switch_entity_id: "switch.c",
+    }),
+  ).toBe(true);
   // missing close -> not ready
-  expect(card._hasRequiredEntities({
-    control_mode: "toggle_opposite",
-    open_switch_entity_id: "switch.o",
-  })).toBe(false);
+  expect(
+    card._hasRequiredEntities({
+      control_mode: "toggle_opposite",
+      open_switch_entity_id: "switch.o",
+    }),
+  ).toBe(false);
 });
 
 test("_hasRequiredEntities dual_motor (non-wrapped): requires tilt_open + tilt_close", async () => {
   card = await mountCard(makeHass());
   // switch + dual_motor but no tilt switches → false
-  expect(card._hasRequiredEntities({
-    control_mode: "switch",
-    open_switch_entity_id: "o",
-    close_switch_entity_id: "c",
-    tilt_mode: "dual_motor",
-  })).toBe(false);
+  expect(
+    card._hasRequiredEntities({
+      control_mode: "switch",
+      open_switch_entity_id: "o",
+      close_switch_entity_id: "c",
+      tilt_mode: "dual_motor",
+    }),
+  ).toBe(false);
   // with tilt_open + tilt_close → true
-  expect(card._hasRequiredEntities({
-    control_mode: "switch",
-    open_switch_entity_id: "o",
-    close_switch_entity_id: "c",
-    tilt_mode: "dual_motor",
-    tilt_open_switch: "to",
-    tilt_close_switch: "tc",
-  })).toBe(true);
+  expect(
+    card._hasRequiredEntities({
+      control_mode: "switch",
+      open_switch_entity_id: "o",
+      close_switch_entity_id: "c",
+      tilt_mode: "dual_motor",
+      tilt_open_switch: "to",
+      tilt_close_switch: "tc",
+    }),
+  ).toBe(true);
 });
 
 test("_hasRequiredEntities dual_motor + pulse: also requires tilt_stop", async () => {
   card = await mountCard(makeHass());
   // pulse + dual_motor with tilt_open + tilt_close but no tilt_stop → false
-  expect(card._hasRequiredEntities({
-    control_mode: "pulse",
-    open_switch_entity_id: "o",
-    close_switch_entity_id: "c",
-    stop_switch_entity_id: "s",
-    tilt_mode: "dual_motor",
-    tilt_open_switch: "to",
-    tilt_close_switch: "tc",
-  })).toBe(false);
+  expect(
+    card._hasRequiredEntities({
+      control_mode: "pulse",
+      open_switch_entity_id: "o",
+      close_switch_entity_id: "c",
+      stop_switch_entity_id: "s",
+      tilt_mode: "dual_motor",
+      tilt_open_switch: "to",
+      tilt_close_switch: "tc",
+    }),
+  ).toBe(false);
   // with tilt_stop → true
-  expect(card._hasRequiredEntities({
-    control_mode: "pulse",
-    open_switch_entity_id: "o",
-    close_switch_entity_id: "c",
-    stop_switch_entity_id: "s",
-    tilt_mode: "dual_motor",
-    tilt_open_switch: "to",
-    tilt_close_switch: "tc",
-    tilt_stop_switch: "ts",
-  })).toBe(true);
+  expect(
+    card._hasRequiredEntities({
+      control_mode: "pulse",
+      open_switch_entity_id: "o",
+      close_switch_entity_id: "c",
+      stop_switch_entity_id: "s",
+      tilt_mode: "dual_motor",
+      tilt_open_switch: "to",
+      tilt_close_switch: "tc",
+      tilt_stop_switch: "ts",
+    }),
+  ).toBe(true);
 });
 
 // ---------------------------------------------------------------------------
@@ -254,7 +276,7 @@ test("F1: _autoSave re-schedules itself (via _scheduleAutoSave) instead of savin
   await card._autoSave();
 
   expect(hass.callWS).not.toHaveBeenCalledWith(
-    expect.objectContaining({ type: "cover_time_based/update_config" })
+    expect.objectContaining({ type: "cover_time_based/update_config" }),
   );
   expect(scheduleSpy).toHaveBeenCalledTimes(1);
 });
@@ -323,30 +345,39 @@ test("_isCalibrating returns true when _calibratingOverride === true", async () 
 });
 
 test("_isCalibrating returns false when _calibratingOverride === false", async () => {
-  card = await mountCard(makeHass({
-    states: { "cover.x": { state: "open", attributes: { calibration_active: true } } },
-  }), { selectedEntity: "cover.x" });
+  card = await mountCard(
+    makeHass({
+      states: { "cover.x": { state: "open", attributes: { calibration_active: true } } },
+    }),
+    { selectedEntity: "cover.x" },
+  );
   card._calibratingOverride = false;
   // Even though entity says calibration_active, override wins
   expect(card._isCalibrating()).toBe(false);
 });
 
 test("_isCalibrating reads entity calibration_active when override is undefined", async () => {
-  card = await mountCard(makeHass({
-    states: {
-      "cover.x": { state: "open", attributes: { calibration_active: true } },
-    },
-  }), { selectedEntity: "cover.x" });
+  card = await mountCard(
+    makeHass({
+      states: {
+        "cover.x": { state: "open", attributes: { calibration_active: true } },
+      },
+    }),
+    { selectedEntity: "cover.x" },
+  );
   // No _calibratingOverride set → should read from entity state
   expect(card._isCalibrating()).toBe(true);
 });
 
 test("_isCalibrating returns false when entity calibration_active is not true", async () => {
-  card = await mountCard(makeHass({
-    states: {
-      "cover.x": { state: "open", attributes: {} },
-    },
-  }), { selectedEntity: "cover.x" });
+  card = await mountCard(
+    makeHass({
+      states: {
+        "cover.x": { state: "open", attributes: {} },
+      },
+    }),
+    { selectedEntity: "cover.x" },
+  );
   expect(card._isCalibrating()).toBe(false);
 });
 
@@ -393,7 +424,9 @@ test("_getCalibrationHint tilt_startup_delay maps to tilt_time_close when knownP
   card.shadowRoot.querySelector = () => ({ value: "tilt_startup_delay" });
   const hint = card._getCalibrationHint();
   // effectiveAttr = tilt_time_close, tiltMode = dual_motor
-  expect(hint).toBe("Start with cover closed and slats open. Click Finish when the slats are fully closed.");
+  expect(hint).toBe(
+    "Start with cover closed and slats open. Click Finish when the slats are fully closed.",
+  );
 });
 
 test("_getCalibrationHint tilt_startup_delay maps to tilt_time_open when knownPosition=closed", async () => {
@@ -404,7 +437,9 @@ test("_getCalibrationHint tilt_startup_delay maps to tilt_time_open when knownPo
   card.shadowRoot.querySelector = () => ({ value: "tilt_startup_delay" });
   const hint = card._getCalibrationHint();
   // effectiveAttr = tilt_time_open, tiltMode = dual_motor
-  expect(hint).toBe("Start with both cover and slats closed. Click Finish when the slats are fully open.");
+  expect(hint).toBe(
+    "Start with both cover and slats closed. Click Finish when the slats are fully open.",
+  );
 });
 
 test("_getCalibrationHint returns tiltMode-specific hint for direct attributes", async () => {
@@ -414,7 +449,7 @@ test("_getCalibrationHint returns tiltMode-specific hint for direct attributes",
   card.shadowRoot.querySelector = () => ({ value: "travel_time_close" });
   const hint = card._getCalibrationHint();
   expect(hint).toBe(
-    "Start with cover fully open. Click Finish when the cover is fully closed, before the slats start tilting."
+    "Start with cover fully open. Click Finish when the cover is fully closed, before the slats start tilting.",
   );
 });
 
@@ -445,38 +480,46 @@ test("_coverSupportsNativeTilt returns false for entityId not in states", async 
 });
 
 test("_coverSupportsNativeTilt returns true when bit 16 (OPEN_TILT) is set", async () => {
-  card = await mountCard(makeHass({
-    states: {
-      "cover.tilt16": { state: "open", attributes: { supported_features: 16 } },
-    },
-  }));
+  card = await mountCard(
+    makeHass({
+      states: {
+        "cover.tilt16": { state: "open", attributes: { supported_features: 16 } },
+      },
+    }),
+  );
   expect(card._coverSupportsNativeTilt("cover.tilt16")).toBe(true);
 });
 
 test("_coverSupportsNativeTilt returns true when bit 32 (CLOSE_TILT) is set", async () => {
-  card = await mountCard(makeHass({
-    states: {
-      "cover.tilt32": { state: "open", attributes: { supported_features: 32 } },
-    },
-  }));
+  card = await mountCard(
+    makeHass({
+      states: {
+        "cover.tilt32": { state: "open", attributes: { supported_features: 32 } },
+      },
+    }),
+  );
   expect(card._coverSupportsNativeTilt("cover.tilt32")).toBe(true);
 });
 
 test("_coverSupportsNativeTilt returns true when both tilt bits set", async () => {
-  card = await mountCard(makeHass({
-    states: {
-      "cover.tilts": { state: "open", attributes: { supported_features: 48 } },
-    },
-  }));
+  card = await mountCard(
+    makeHass({
+      states: {
+        "cover.tilts": { state: "open", attributes: { supported_features: 48 } },
+      },
+    }),
+  );
   expect(card._coverSupportsNativeTilt("cover.tilts")).toBe(true);
 });
 
 test("_coverSupportsNativeTilt returns false when no tilt bits set", async () => {
-  card = await mountCard(makeHass({
-    states: {
-      "cover.notilt": { state: "open", attributes: { supported_features: 15 } },
-    },
-  }));
+  card = await mountCard(
+    makeHass({
+      states: {
+        "cover.notilt": { state: "open", attributes: { supported_features: 15 } },
+      },
+    }),
+  );
   expect(card._coverSupportsNativeTilt("cover.notilt")).toBe(false);
 });
 

--- a/tests/frontend/card_render.test.mjs
+++ b/tests/frontend/card_render.test.mjs
@@ -129,7 +129,11 @@ test("with no entity selected, .tabs is absent (no config sections)", async () =
 });
 
 test("with entity + config, config sections (.tabs) are rendered", async () => {
-  card = await mountCard(makeHass(), { selectedEntity: "cover.x", config: switchCfg(), activeTab: "device" });
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: switchCfg(),
+    activeTab: "device",
+  });
   expect(card.shadowRoot.querySelector(".tabs")).not.toBeNull();
 });
 
@@ -152,7 +156,11 @@ test("_renderConfigSections renders device tab as active by default", async () =
 });
 
 test("_renderConfigSections with activeTab=timing shows timing tab as active", async () => {
-  card = await mountCard(makeHass(), { selectedEntity: "cover.x", config: switchCfg(), activeTab: "timing" });
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: switchCfg(),
+    activeTab: "timing",
+  });
   const tabs = card.shadowRoot.querySelectorAll(".tab");
   expect(tabs[0].classList.contains("active")).toBe(false);
   expect(tabs[1].classList.contains("active")).toBe(true);
@@ -171,13 +179,21 @@ test("calibration tab is disabled when required entities are missing", async () 
 });
 
 test("calibration tab is NOT disabled when required entities are present", async () => {
-  card = await mountCard(makeHass(), { selectedEntity: "cover.x", config: switchCfg(), activeTab: "device" });
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: switchCfg(),
+    activeTab: "device",
+  });
   const tabs = card.shadowRoot.querySelectorAll(".tab");
   expect(tabs[1].disabled).toBe(false);
 });
 
 test("_saving=true renders .save-bar with .saving-indicator", async () => {
-  card = await mountCard(makeHass(), { selectedEntity: "cover.x", config: switchCfg(), activeTab: "device" });
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: switchCfg(),
+    activeTab: "device",
+  });
   card._saving = true;
   card.requestUpdate();
   await card.updateComplete;
@@ -188,7 +204,11 @@ test("_saving=true renders .save-bar with .saving-indicator", async () => {
 });
 
 test("_saveError=true renders .save-bar with .save-error", async () => {
-  card = await mountCard(makeHass(), { selectedEntity: "cover.x", config: switchCfg(), activeTab: "device" });
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: switchCfg(),
+    activeTab: "device",
+  });
   card._saveError = true;
   card.requestUpdate();
   await card.updateComplete;
@@ -199,7 +219,11 @@ test("_saveError=true renders .save-bar with .save-error", async () => {
 });
 
 test("no save-bar when neither _saving nor _saveError", async () => {
-  card = await mountCard(makeHass(), { selectedEntity: "cover.x", config: switchCfg(), activeTab: "device" });
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: switchCfg(),
+    activeTab: "device",
+  });
   expect(card.shadowRoot.querySelector(".save-bar")).toBeNull();
 });
 
@@ -207,7 +231,11 @@ test("no save-bar when neither _saving nor _saveError", async () => {
 // left in a switch slot after leaving pulse mode) — the server's detail
 // message is shown alongside the translated text so the cause is visible.
 test("_saveError with _saveErrorDetail shows the server's reason after the translated text", async () => {
-  card = await mountCard(makeHass(), { selectedEntity: "cover.x", config: switchCfg(), activeTab: "device" });
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: switchCfg(),
+    activeTab: "device",
+  });
   card._saveError = true;
   card._saveErrorDetail = "Script entities are only supported in pulse mode (got script.ir_open)";
   card.requestUpdate();
@@ -219,12 +247,16 @@ test("_saveError with _saveErrorDetail shows the server's reason after the trans
   expect(text).toContain("Script entities are only supported in pulse mode (got script.ir_open)");
   // The detail follows the translated text, not the other way round.
   expect(text.indexOf("Save failed")).toBeLessThan(
-    text.indexOf("Script entities are only supported")
+    text.indexOf("Script entities are only supported"),
   );
 });
 
 test("_saveError with empty _saveErrorDetail shows only the translated text", async () => {
-  card = await mountCard(makeHass(), { selectedEntity: "cover.x", config: switchCfg(), activeTab: "device" });
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: switchCfg(),
+    activeTab: "device",
+  });
   card._saveError = true;
   card._saveErrorDetail = "";
   card.requestUpdate();
@@ -234,11 +266,19 @@ test("_saveError with empty _saveErrorDetail shows only the translated text", as
 });
 
 test("device tab renders a fieldset, timing tab renders a borderless fieldset around the timing table", async () => {
-  card = await mountCard(makeHass(), { selectedEntity: "cover.x", config: switchCfg(), activeTab: "device" });
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: switchCfg(),
+    activeTab: "device",
+  });
   expect(card.shadowRoot.querySelector("fieldset")).not.toBeNull();
 
   card.remove();
-  card = await mountCard(makeHass(), { selectedEntity: "cover.x", config: switchCfg(), activeTab: "timing" });
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: switchCfg(),
+    activeTab: "timing",
+  });
   const fieldset = card.shadowRoot.querySelector("fieldset");
   expect(fieldset).not.toBeNull();
   expect(fieldset.classList.contains("borderless")).toBe(true);
@@ -292,7 +332,11 @@ test("entity info row shows the selectedEntity string", async () => {
 // ---------------------------------------------------------------------------
 
 test("control mode select has five options: wrapped/switch/pulse/toggle/toggle_opposite", async () => {
-  card = await mountCard(makeHass(), { selectedEntity: "cover.x", config: switchCfg(), activeTab: "device" });
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: switchCfg(),
+    activeTab: "device",
+  });
   const select = card.shadowRoot.querySelector("select.ha-select");
   expect(select).not.toBeNull();
   const values = [...select.options].map((o) => o.value);
@@ -305,42 +349,66 @@ test("control mode select has five options: wrapped/switch/pulse/toggle/toggle_o
 // not on opt.selected (the DOM property the native select manages internally).
 
 test("switch mode: 'switch' option has the selected attribute", async () => {
-  card = await mountCard(makeHass(), { selectedEntity: "cover.x", config: switchCfg(), activeTab: "device" });
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: switchCfg(),
+    activeTab: "device",
+  });
   const select = card.shadowRoot.querySelector("select.ha-select");
   const selectedOpt = [...select.options].find((o) => o.hasAttribute("selected"));
   expect(selectedOpt?.value).toBe("switch");
 });
 
 test("pulse mode: 'pulse' option has the selected attribute", async () => {
-  card = await mountCard(makeHass(), { selectedEntity: "cover.x", config: pulseCfg(), activeTab: "device" });
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: pulseCfg(),
+    activeTab: "device",
+  });
   const select = card.shadowRoot.querySelector("select.ha-select");
   const selectedOpt = [...select.options].find((o) => o.hasAttribute("selected"));
   expect(selectedOpt?.value).toBe("pulse");
 });
 
 test("toggle mode: 'toggle' option has the selected attribute", async () => {
-  card = await mountCard(makeHass(), { selectedEntity: "cover.x", config: toggleCfg(), activeTab: "device" });
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: toggleCfg(),
+    activeTab: "device",
+  });
   const select = card.shadowRoot.querySelector("select.ha-select");
   const selectedOpt = [...select.options].find((o) => o.hasAttribute("selected"));
   expect(selectedOpt?.value).toBe("toggle");
 });
 
 test("toggle_opposite mode: its option has the selected attribute", async () => {
-  card = await mountCard(makeHass(), { selectedEntity: "cover.x", config: toggleOppositeCfg(), activeTab: "device" });
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: toggleOppositeCfg(),
+    activeTab: "device",
+  });
   const select = card.shadowRoot.querySelector("select.ha-select");
   const selectedOpt = [...select.options].find((o) => o.hasAttribute("selected"));
   expect(selectedOpt?.value).toBe("toggle_opposite");
 });
 
 test("toggle_opposite mode shows the relay_reports_off toggle", async () => {
-  card = await mountCard(makeHass(), { selectedEntity: "cover.x", config: toggleOppositeCfg(), activeTab: "device" });
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: toggleOppositeCfg(),
+    activeTab: "device",
+  });
   const labels = [...card.shadowRoot.querySelectorAll(".toggle-label")].map((n) => n.textContent);
   // The relay_reports_off toggle label is present (same as toggle mode).
   expect(labels.some((t) => /report/i.test(t))).toBe(true);
 });
 
 test("wrapped mode: 'wrapped' option has the selected attribute", async () => {
-  card = await mountCard(makeHass(), { selectedEntity: "cover.x", config: wrappedCfg(), activeTab: "device" });
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: wrappedCfg(),
+    activeTab: "device",
+  });
   const select = card.shadowRoot.querySelector("select.ha-select");
   const selectedOpt = [...select.options].find((o) => o.hasAttribute("selected"));
   expect(selectedOpt?.value).toBe("wrapped");
@@ -356,12 +424,20 @@ test("pulse mode renders .inline-field (pulse-time) in control mode section", as
 });
 
 test("switch mode has no .inline-field (pulse-time absent)", async () => {
-  card = await mountCard(makeHass(), { selectedEntity: "cover.x", config: switchCfg(), activeTab: "device" });
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: switchCfg(),
+    activeTab: "device",
+  });
   expect(card.shadowRoot.querySelector(".inline-field")).toBeNull();
 });
 
 test("toggle mode has no .inline-field", async () => {
-  card = await mountCard(makeHass(), { selectedEntity: "cover.x", config: toggleCfg(), activeTab: "device" });
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: toggleCfg(),
+    activeTab: "device",
+  });
   expect(card.shadowRoot.querySelector(".inline-field")).toBeNull();
 });
 
@@ -370,13 +446,21 @@ test("toggle mode has no .inline-field", async () => {
 // ---------------------------------------------------------------------------
 
 test("_renderToggleWithHelp: .info-popover absent when _openHelp is null", async () => {
-  card = await mountCard(makeHass(), { selectedEntity: "cover.x", config: switchCfg(), activeTab: "device" });
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: switchCfg(),
+    activeTab: "device",
+  });
   expect(card._openHelp).toBeNull();
   expect(card.shadowRoot.querySelector(".info-popover")).toBeNull();
 });
 
 test("_renderToggleWithHelp: .info-popover present when _openHelp matches the helper key", async () => {
-  card = await mountCard(makeHass(), { selectedEntity: "cover.x", config: switchCfg(), activeTab: "device" });
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: switchCfg(),
+    activeTab: "device",
+  });
   card._openHelp = "assumed_state.helper";
   card.requestUpdate();
   await card.updateComplete;
@@ -384,7 +468,11 @@ test("_renderToggleWithHelp: .info-popover present when _openHelp matches the he
 });
 
 test("_renderToggleWithHelp: .info-popover absent when _openHelp is a different key", async () => {
-  card = await mountCard(makeHass(), { selectedEntity: "cover.x", config: switchCfg(), activeTab: "device" });
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: switchCfg(),
+    activeTab: "device",
+  });
   card._openHelp = "some.other.key";
   card.requestUpdate();
   await card.updateComplete;
@@ -393,7 +481,11 @@ test("_renderToggleWithHelp: .info-popover absent when _openHelp is a different 
 });
 
 test("wrapped mode: _openHelp=ignore_reported_position_helper shows the popover", async () => {
-  card = await mountCard(makeHass(), { selectedEntity: "cover.x", config: wrappedCfg(), activeTab: "device" });
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: wrappedCfg(),
+    activeTab: "device",
+  });
   card._openHelp = "entities.ignore_reported_position_helper";
   card.requestUpdate();
   await card.updateComplete;
@@ -405,7 +497,11 @@ test("wrapped mode: _openHelp=ignore_reported_position_helper shows the popover"
 // ---------------------------------------------------------------------------
 
 test("wrapped mode renders cover entity-picker (with includeDomains cover)", async () => {
-  card = await mountCard(makeHass(), { selectedEntity: "cover.x", config: wrappedCfg(), activeTab: "device" });
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: wrappedCfg(),
+    activeTab: "device",
+  });
   const pickers = card.shadowRoot.querySelectorAll("ha-entity-picker");
   // Exactly: top entity-picker + cover entity picker
   expect(pickers.length).toBe(2);
@@ -418,7 +514,11 @@ test("wrapped mode renders cover entity-picker (with includeDomains cover)", asy
 });
 
 test("wrapped mode renders ha-switch toggles (ignore-reported-position, force-time-based, reports-command-not-endpoint, invert, assumed-state, force-endpoint-redrive, recalibrate-before-position)", async () => {
-  card = await mountCard(makeHass(), { selectedEntity: "cover.x", config: wrappedCfg(), activeTab: "device" });
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: wrappedCfg(),
+    activeTab: "device",
+  });
   const toggles = card.shadowRoot.querySelectorAll("ha-switch.toggle-switch");
   // Exactly 7 toggles: ignore_reported_position, force_time_based_position,
   // reports_command_not_endpoint, invert, assumed_state, force_endpoint_redrive,
@@ -427,7 +527,11 @@ test("wrapped mode renders ha-switch toggles (ignore-reported-position, force-ti
 });
 
 test("wrapped mode: toggling reports-command-not-endpoint calls _updateLocal", async () => {
-  card = await mountCard(makeHass(), { selectedEntity: "cover.x", config: wrappedCfg(), activeTab: "device" });
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: wrappedCfg(),
+    activeTab: "device",
+  });
   const captured = [];
   card._updateLocal = (u) => captured.push(u);
   // Order in renderInputEntities: [0] ignore_reported_position,
@@ -440,7 +544,11 @@ test("wrapped mode: toggling reports-command-not-endpoint calls _updateLocal", a
 });
 
 test("wrapped mode: _openHelp=reports_command_not_endpoint_helper shows the popover", async () => {
-  card = await mountCard(makeHass(), { selectedEntity: "cover.x", config: wrappedCfg(), activeTab: "device" });
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: wrappedCfg(),
+    activeTab: "device",
+  });
   card._openHelp = "entities.reports_command_not_endpoint_helper";
   card.requestUpdate();
   await card.updateComplete;
@@ -448,38 +556,62 @@ test("wrapped mode: _openHelp=reports_command_not_endpoint_helper shows the popo
 });
 
 test("switch mode renders open + close switch pickers (no stop switch)", async () => {
-  card = await mountCard(makeHass(), { selectedEntity: "cover.x", config: switchCfg(), activeTab: "device" });
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: switchCfg(),
+    activeTab: "device",
+  });
   const pickers = card.shadowRoot.querySelectorAll("ha-entity-picker");
   // top picker + open switch + close switch = 3
   expect(pickers.length).toBe(3);
 });
 
 test("pulse mode renders open + close + stop switch pickers (3 extra + top picker = 4)", async () => {
-  card = await mountCard(makeHass(), { selectedEntity: "cover.x", config: pulseCfg(), activeTab: "device" });
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: pulseCfg(),
+    activeTab: "device",
+  });
   const pickers = card.shadowRoot.querySelectorAll("ha-entity-picker");
   // top picker + open + close + stop = 4
   expect(pickers.length).toBe(4);
 });
 
 test("toggle mode renders open + close switch pickers (no stop switch)", async () => {
-  card = await mountCard(makeHass(), { selectedEntity: "cover.x", config: toggleCfg(), activeTab: "device" });
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: toggleCfg(),
+    activeTab: "device",
+  });
   const pickers = card.shadowRoot.querySelectorAll("ha-entity-picker");
   // top picker + open + close = 3
   expect(pickers.length).toBe(3);
 });
 
 test("switch mode renders .entity-grid div", async () => {
-  card = await mountCard(makeHass(), { selectedEntity: "cover.x", config: switchCfg(), activeTab: "device" });
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: switchCfg(),
+    activeTab: "device",
+  });
   expect(card.shadowRoot.querySelector(".entity-grid")).not.toBeNull();
 });
 
 test("wrapped mode has no .entity-grid", async () => {
-  card = await mountCard(makeHass(), { selectedEntity: "cover.x", config: wrappedCfg(), activeTab: "device" });
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: wrappedCfg(),
+    activeTab: "device",
+  });
   expect(card.shadowRoot.querySelector(".entity-grid")).toBeNull();
 });
 
 test("switch mode shows assumed-state toggle", async () => {
-  card = await mountCard(makeHass(), { selectedEntity: "cover.x", config: switchCfg(), activeTab: "device" });
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: switchCfg(),
+    activeTab: "device",
+  });
   const toggles = card.shadowRoot.querySelectorAll("ha-switch.toggle-switch");
   // Exactly 3 toggles: assumed-state, force-endpoint-redrive and
   // recalibrate-before-position (switch mode has no other toggle-with-help)
@@ -491,7 +623,11 @@ test("switch mode shows assumed-state toggle", async () => {
 // ---------------------------------------------------------------------------
 
 test("tilt select always renders with at least 4 options (none/sequential_close/sequential_open/inline)", async () => {
-  card = await mountCard(makeHass(), { selectedEntity: "cover.x", config: switchCfg(), activeTab: "device" });
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: switchCfg(),
+    activeTab: "device",
+  });
   const selects = card.shadowRoot.querySelectorAll("select.ha-select");
   // First select = control_mode, second = tilt mode
   expect(selects.length).toBeGreaterThanOrEqual(2);
@@ -504,7 +640,11 @@ test("tilt select always renders with at least 4 options (none/sequential_close/
 });
 
 test("tilt select shows dual_motor option for non-wrapped mode", async () => {
-  card = await mountCard(makeHass(), { selectedEntity: "cover.x", config: switchCfg(), activeTab: "device" });
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: switchCfg(),
+    activeTab: "device",
+  });
   const selects = card.shadowRoot.querySelectorAll("select.ha-select");
   const tiltSelect = selects[1];
   const values = [...tiltSelect.options].map((o) => o.value);
@@ -515,7 +655,11 @@ test("tilt select shows dual_motor option for non-wrapped mode", async () => {
 // .selected property (native select state), for the same happy-dom reason as above.
 
 test("tilt mode none: 'none' option has the selected attribute", async () => {
-  card = await mountCard(makeHass(), { selectedEntity: "cover.x", config: switchCfg({ tilt_mode: "none" }), activeTab: "device" });
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: switchCfg({ tilt_mode: "none" }),
+    activeTab: "device",
+  });
   const selects = card.shadowRoot.querySelectorAll("select.ha-select");
   const tiltSelect = selects[1];
   const selectedOpt = [...tiltSelect.options].find((o) => o.hasAttribute("selected"));
@@ -616,12 +760,20 @@ test("tilt_mode=dual_motor + pulse renders tilt stop switch picker (6 pickers to
 });
 
 test("tilt_mode=none has no .dual-motor-config", async () => {
-  card = await mountCard(makeHass(), { selectedEntity: "cover.x", config: switchCfg({ tilt_mode: "none" }), activeTab: "device" });
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: switchCfg({ tilt_mode: "none" }),
+    activeTab: "device",
+  });
   expect(card.shadowRoot.querySelector(".dual-motor-config")).toBeNull();
 });
 
 test("tilt_mode=sequential_close has no .dual-motor-config", async () => {
-  card = await mountCard(makeHass(), { selectedEntity: "cover.x", config: switchCfg({ tilt_mode: "sequential_close" }), activeTab: "device" });
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: switchCfg({ tilt_mode: "sequential_close" }),
+    activeTab: "device",
+  });
   expect(card.shadowRoot.querySelector(".dual-motor-config")).toBeNull();
 });
 
@@ -641,12 +793,20 @@ test("tilt_mode=dual_motor + wrapped: shows .dual-motor-config but NO .entity-gr
 // ---------------------------------------------------------------------------
 
 test("timing tab renders .timing-table", async () => {
-  card = await mountCard(makeHass(), { selectedEntity: "cover.x", config: switchCfg(), activeTab: "timing" });
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: switchCfg(),
+    activeTab: "timing",
+  });
   expect(card.shadowRoot.querySelector(".timing-table")).not.toBeNull();
 });
 
 test("switch mode timing table includes endpoint_runon_time row (5 travel rows: travel_time_close, travel_time_open, travel_startup_delay, min_movement_time, endpoint_runon_time)", async () => {
-  card = await mountCard(makeHass(), { selectedEntity: "cover.x", config: switchCfg(), activeTab: "timing" });
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: switchCfg(),
+    activeTab: "timing",
+  });
   const inputs = card.shadowRoot.querySelectorAll("input.timing-input");
   // switch mode: travel_time_close, travel_time_open, travel_startup_delay, min_movement_time, endpoint_runon_time
   expect(inputs.length).toBe(5);
@@ -684,7 +844,11 @@ test("direction_change_delay row is gone, even for an entry that still stores it
 });
 
 test("timing row input has min attribute set (travel_time_close has min=0.1)", async () => {
-  card = await mountCard(makeHass(), { selectedEntity: "cover.x", config: switchCfg(), activeTab: "timing" });
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: switchCfg(),
+    activeTab: "timing",
+  });
   const inputs = card.shadowRoot.querySelectorAll("input.timing-input");
   // First input = travel_time_close, min should be "0.1"
   expect(inputs[0].getAttribute("min")).toBe("0.1");
@@ -712,7 +876,11 @@ test("timing table with tilt mode (inline) renders a second tilt timing table", 
 });
 
 test("timing table without tilt mode renders only one timing table", async () => {
-  card = await mountCard(makeHass(), { selectedEntity: "cover.x", config: switchCfg(), activeTab: "timing" });
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: switchCfg(),
+    activeTab: "timing",
+  });
   const tables = card.shadowRoot.querySelectorAll(".timing-table");
   expect(tables.length).toBe(1);
 });
@@ -804,13 +972,16 @@ test("position reset shows cover + tilt controls when _hasTiltMotor() is true (d
 });
 
 test("position section absent while calibrating", async () => {
-  card = await mountCard(makeHass({
-    states: { "cover.x": { state: "open", attributes: { calibration_active: true } } },
-  }), {
-    selectedEntity: "cover.x",
-    config: switchCfg(),
-    activeTab: "timing",
-  });
+  card = await mountCard(
+    makeHass({
+      states: { "cover.x": { state: "open", attributes: { calibration_active: true } } },
+    }),
+    {
+      selectedEntity: "cover.x",
+      config: switchCfg(),
+      activeTab: "timing",
+    },
+  );
   // _isCalibrating() returns true → _renderPositionReset is NOT called
   expect(card.shadowRoot.querySelector("#position-select")).toBeNull();
 });
@@ -821,18 +992,21 @@ test("position section absent while calibrating", async () => {
 // ---------------------------------------------------------------------------
 
 test("F1: while calibrating, every .timing-input is inside a disabled fieldset", async () => {
-  card = await mountCard(makeHass({
-    states: {
-      "cover.x": {
-        state: "open",
-        attributes: { calibration_active: true, calibration_attribute: "travel_time_close" },
+  card = await mountCard(
+    makeHass({
+      states: {
+        "cover.x": {
+          state: "open",
+          attributes: { calibration_active: true, calibration_attribute: "travel_time_close" },
+        },
       },
+    }),
+    {
+      selectedEntity: "cover.x",
+      config: switchCfg(),
+      activeTab: "timing",
     },
-  }), {
-    selectedEntity: "cover.x",
-    config: switchCfg(),
-    activeTab: "timing",
-  });
+  );
 
   expect(card._isCalibrating()).toBe(true);
   const inputs = [...card.shadowRoot.querySelectorAll(".timing-input")];
@@ -845,18 +1019,21 @@ test("F1: while calibrating, every .timing-input is inside a disabled fieldset",
 });
 
 test("F1: while calibrating, the Cancel/Finish calibration buttons stay OUTSIDE the disabled fieldset", async () => {
-  card = await mountCard(makeHass({
-    states: {
-      "cover.x": {
-        state: "open",
-        attributes: { calibration_active: true, calibration_attribute: "travel_time_close" },
+  card = await mountCard(
+    makeHass({
+      states: {
+        "cover.x": {
+          state: "open",
+          attributes: { calibration_active: true, calibration_attribute: "travel_time_close" },
+        },
       },
+    }),
+    {
+      selectedEntity: "cover.x",
+      config: switchCfg(),
+      activeTab: "timing",
     },
-  }), {
-    selectedEntity: "cover.x",
-    config: switchCfg(),
-    activeTab: "timing",
-  });
+  );
 
   const calActive = card.shadowRoot.querySelector(".calibration-active");
   expect(calActive).not.toBeNull();
@@ -944,9 +1121,7 @@ test("not calibrating: shows helper text 'set_position_first' when knownPosition
   });
   // helper-text div should contain "Set position to start calibration"
   const helperTexts = card.shadowRoot.querySelectorAll(".helper-text");
-  const setPositionText = [...helperTexts].find((el) =>
-    el.textContent.includes("Set position")
-  );
+  const setPositionText = [...helperTexts].find((el) => el.textContent.includes("Set position"));
   expect(setPositionText).not.toBeUndefined();
 });
 
@@ -980,13 +1155,21 @@ test("not calibrating: cal-attribute select shows tilt attributes when tilt_mode
 });
 
 test("calibrating: shows .calibration-active section with Cancel + Finish buttons", async () => {
-  card = await mountCard(makeHass({
-    states: { "cover.x": { state: "open", attributes: { calibration_active: true, calibration_attribute: "travel_time_close" } } },
-  }), {
-    selectedEntity: "cover.x",
-    config: switchCfg(),
-    activeTab: "timing",
-  });
+  card = await mountCard(
+    makeHass({
+      states: {
+        "cover.x": {
+          state: "open",
+          attributes: { calibration_active: true, calibration_attribute: "travel_time_close" },
+        },
+      },
+    }),
+    {
+      selectedEntity: "cover.x",
+      config: switchCfg(),
+      activeTab: "timing",
+    },
+  );
   const calActive = card.shadowRoot.querySelector(".calibration-active");
   expect(calActive).not.toBeNull();
   // Cancel + Finish buttons
@@ -998,62 +1181,92 @@ test("calibrating: shows .calibration-active section with Cancel + Finish button
 });
 
 test("calibrating: shows the calibrating attribute label", async () => {
-  card = await mountCard(makeHass({
-    states: { "cover.x": { state: "open", attributes: { calibration_active: true, calibration_attribute: "travel_time_close" } } },
-  }), {
-    selectedEntity: "cover.x",
-    config: switchCfg(),
-    activeTab: "timing",
-  });
+  card = await mountCard(
+    makeHass({
+      states: {
+        "cover.x": {
+          state: "open",
+          attributes: { calibration_active: true, calibration_attribute: "travel_time_close" },
+        },
+      },
+    }),
+    {
+      selectedEntity: "cover.x",
+      config: switchCfg(),
+      activeTab: "timing",
+    },
+  );
   const calActive = card.shadowRoot.querySelector(".calibration-active");
   // The label "Travel time (close)" should appear in the calibration section body
   expect(calActive.textContent).toContain("Travel time");
 });
 
 test("calibrating: shows .cal-step for calibration_step attribute", async () => {
-  card = await mountCard(makeHass({
-    states: {
-      "cover.x": {
-        state: "open",
-        attributes: { calibration_active: true, calibration_attribute: "travel_time_close", calibration_step: "2" },
+  card = await mountCard(
+    makeHass({
+      states: {
+        "cover.x": {
+          state: "open",
+          attributes: {
+            calibration_active: true,
+            calibration_attribute: "travel_time_close",
+            calibration_step: "2",
+          },
+        },
       },
+    }),
+    {
+      selectedEntity: "cover.x",
+      config: switchCfg(),
+      activeTab: "timing",
     },
-  }), {
-    selectedEntity: "cover.x",
-    config: switchCfg(),
-    activeTab: "timing",
-  });
+  );
   const calStep = card.shadowRoot.querySelector(".cal-step");
   expect(calStep).not.toBeNull();
   expect(calStep.textContent).toContain("Step 2");
 });
 
 test("calibrating: shows final_step span when calibration_final_step is truthy", async () => {
-  card = await mountCard(makeHass({
-    states: {
-      "cover.x": {
-        state: "open",
-        attributes: { calibration_active: true, calibration_attribute: "travel_time_close", calibration_final_step: true },
+  card = await mountCard(
+    makeHass({
+      states: {
+        "cover.x": {
+          state: "open",
+          attributes: {
+            calibration_active: true,
+            calibration_attribute: "travel_time_close",
+            calibration_final_step: true,
+          },
+        },
       },
+    }),
+    {
+      selectedEntity: "cover.x",
+      config: switchCfg(),
+      activeTab: "timing",
     },
-  }), {
-    selectedEntity: "cover.x",
-    config: switchCfg(),
-    activeTab: "timing",
-  });
+  );
   const calStep = card.shadowRoot.querySelector(".cal-step");
   expect(calStep).not.toBeNull();
   expect(calStep.textContent).toContain("Final step");
 });
 
 test("calibrating: no #cal-attribute select (start form is absent)", async () => {
-  card = await mountCard(makeHass({
-    states: { "cover.x": { state: "open", attributes: { calibration_active: true, calibration_attribute: "travel_time_close" } } },
-  }), {
-    selectedEntity: "cover.x",
-    config: switchCfg(),
-    activeTab: "timing",
-  });
+  card = await mountCard(
+    makeHass({
+      states: {
+        "cover.x": {
+          state: "open",
+          attributes: { calibration_active: true, calibration_attribute: "travel_time_close" },
+        },
+      },
+    }),
+    {
+      selectedEntity: "cover.x",
+      config: switchCfg(),
+      activeTab: "timing",
+    },
+  );
   expect(card.shadowRoot.querySelector("#cal-attribute")).toBeNull();
 });
 
@@ -1075,13 +1288,16 @@ test("calibrating via _calibratingOverride=true: shows calibration-active", asyn
 // ---------------------------------------------------------------------------
 
 test("device tab fieldset is disabled while calibrating", async () => {
-  card = await mountCard(makeHass({
-    states: { "cover.x": { state: "open", attributes: { calibration_active: true } } },
-  }), {
-    selectedEntity: "cover.x",
-    config: switchCfg(),
-    activeTab: "device",
-  });
+  card = await mountCard(
+    makeHass({
+      states: { "cover.x": { state: "open", attributes: { calibration_active: true } } },
+    }),
+    {
+      selectedEntity: "cover.x",
+      config: switchCfg(),
+      activeTab: "device",
+    },
+  );
   const fieldset = card.shadowRoot.querySelector("fieldset");
   expect(fieldset).not.toBeNull();
   expect(fieldset.disabled).toBe(true);
@@ -1364,7 +1580,7 @@ test("max_tilt_allowed_position ha-input @change with empty string sets field to
 
   const haInputs = card.shadowRoot.querySelectorAll(".dual-motor-config ha-input");
   const maxTiltInput = haInputs[1];
-  maxTiltInput.value = "  ";  // whitespace-only → trims to ""
+  maxTiltInput.value = "  "; // whitespace-only → trims to ""
   maxTiltInput.dispatchEvent(new Event("change", { bubbles: true }));
 
   expect(updates.length).toBeGreaterThan(0);

--- a/tests/frontend/card_save.test.mjs
+++ b/tests/frontend/card_save.test.mjs
@@ -144,7 +144,6 @@ test("_autoSave on failure with no err.message falls back to an empty _saveError
   const hass = makeHass({
     ws: {
       "cover_time_based/update_config": () => {
-        // eslint-disable-next-line no-throw-literal
         throw "boom"; // a non-Error throw has no .message
       },
       "cover_time_based/get_config": () => ({ control_mode: "toggle" }),

--- a/tests/frontend/card_save.test.mjs
+++ b/tests/frontend/card_save.test.mjs
@@ -50,7 +50,7 @@ test("_autoSave sends update_config with entry_id stripped and other fields incl
   });
   // entry_id must NOT appear in the payload
   expect(hass.callWS).not.toHaveBeenCalledWith(
-    expect.objectContaining({ entry_id: expect.anything() })
+    expect.objectContaining({ entry_id: expect.anything() }),
   );
   expect(card._saving).toBe(false);
 });
@@ -119,9 +119,7 @@ test("_autoSave on failure stores the server's error message in _saveErrorDetail
   const hass = makeHass({
     ws: {
       "cover_time_based/update_config": () => {
-        throw new Error(
-          "Script entities are only supported in pulse mode (got script.ir_open)"
-        );
+        throw new Error("Script entities are only supported in pulse mode (got script.ir_open)");
       },
       "cover_time_based/get_config": () => ({ control_mode: "toggle" }),
     },
@@ -135,7 +133,7 @@ test("_autoSave on failure stores the server's error message in _saveErrorDetail
   await card._autoSave();
 
   expect(card._saveErrorDetail).toBe(
-    "Script entities are only supported in pulse mode (got script.ir_open)"
+    "Script entities are only supported in pulse mode (got script.ir_open)",
   );
 });
 
@@ -198,7 +196,7 @@ test("_autoSave early-returns without a selected entity", async () => {
   await card._autoSave();
 
   expect(hass.callWS).not.toHaveBeenCalledWith(
-    expect.objectContaining({ type: "cover_time_based/update_config" })
+    expect.objectContaining({ type: "cover_time_based/update_config" }),
   );
 });
 
@@ -209,6 +207,6 @@ test("_autoSave early-returns when _config is null", async () => {
   await card._autoSave();
 
   expect(hass.callWS).not.toHaveBeenCalledWith(
-    expect.objectContaining({ type: "cover_time_based/update_config" })
+    expect.objectContaining({ type: "cover_time_based/update_config" }),
   );
 });

--- a/tests/frontend/card_selection_memory.test.mjs
+++ b/tests/frontend/card_selection_memory.test.mjs
@@ -68,7 +68,7 @@ test("restoring a remembered device loads its config", async () => {
     expect.objectContaining({
       type: "cover_time_based/get_config",
       entity_id: "cover.remembered",
-    })
+    }),
   );
 });
 
@@ -79,7 +79,7 @@ test("a remembered device that no longer exists is not restored", async () => {
   await card._entityListReady;
   expect(card._selectedEntity).toBe("");
   expect(hass.callWS).not.toHaveBeenCalledWith(
-    expect.objectContaining({ type: "cover_time_based/get_config" })
+    expect.objectContaining({ type: "cover_time_based/get_config" }),
   );
 });
 
@@ -107,7 +107,7 @@ test("a selection made while the entity list is in flight is not clobbered", asy
   // What distinguishes them is that the guarded restore bows out entirely and
   // never drives a config load of its own — loading is the picker's job.
   expect(hass.callWS).not.toHaveBeenCalledWith(
-    expect.objectContaining({ type: "cover_time_based/get_config" })
+    expect.objectContaining({ type: "cover_time_based/get_config" }),
   );
 });
 
@@ -120,7 +120,7 @@ test("a card detached mid-lookup does not restore or call out", async () => {
 
   expect(card._selectedEntity).toBe("");
   expect(hass.callWS).not.toHaveBeenCalledWith(
-    expect.objectContaining({ type: "cover_time_based/get_config" })
+    expect.objectContaining({ type: "cover_time_based/get_config" }),
   );
 });
 
@@ -234,9 +234,7 @@ test("selecting a device through the picker remembers it", async () => {
   card = await mountCard(hassWithEntities(["cover.picked"]));
   await card._entityListReady;
   const picker = card.shadowRoot.querySelector("ha-entity-picker");
-  picker.dispatchEvent(
-    new CustomEvent("value-changed", { detail: { value: "cover.picked" } })
-  );
+  picker.dispatchEvent(new CustomEvent("value-changed", { detail: { value: "cover.picked" } }));
   expect(loadSelectedEntity()).toBe("cover.picked");
 });
 
@@ -245,8 +243,6 @@ test("clearing the selection through the picker forgets it", async () => {
   card = await mountCard(hassWithEntities(["cover.picked"]));
   await card._entityListReady;
   const picker = card.shadowRoot.querySelector("ha-entity-picker");
-  picker.dispatchEvent(
-    new CustomEvent("value-changed", { detail: { value: "" } })
-  );
+  picker.dispatchEvent(new CustomEvent("value-changed", { detail: { value: "" } }));
   expect(loadSelectedEntity()).toBe("");
 });

--- a/tests/frontend/entity_filter.test.mjs
+++ b/tests/frontend/entity_filter.test.mjs
@@ -11,9 +11,7 @@ import { filterEntitiesByValidEntries } from "../../custom_components/cover_time
 const PLATFORM = "cover_time_based";
 
 test("includes entities backed by a live config entry", () => {
-  const registry = [
-    { entity_id: "cover.live", platform: PLATFORM, config_entry_id: "live_entry" },
-  ];
+  const registry = [{ entity_id: "cover.live", platform: PLATFORM, config_entry_id: "live_entry" }];
   const result = filterEntitiesByValidEntries(registry, ["live_entry"], PLATFORM);
   assert.deepEqual(result, ["cover.live"]);
 });

--- a/tests/frontend/helpers/hass.mjs
+++ b/tests/frontend/helpers/hass.mjs
@@ -10,13 +10,7 @@ const DEFAULT_WS = {
   "cover_time_based/raw_command": () => ({}),
 };
 
-export function makeHass({
-  states = {},
-  entities = {},
-  language = "en",
-  ws = {},
-  service,
-} = {}) {
+export function makeHass({ states = {}, entities = {}, language = "en", ws = {}, service } = {}) {
   const routes = { ...DEFAULT_WS, ...ws };
   return {
     states,

--- a/tests/frontend/helpers/mount.mjs
+++ b/tests/frontend/helpers/mount.mjs
@@ -1,7 +1,12 @@
 import "../../../custom_components/cover_time_based/frontend/cover-time-based-card.js";
 
 const HA_STUBS = [
-  "ha-card", "ha-entity-picker", "ha-switch", "ha-icon", "ha-input", "ha-textfield",
+  "ha-card",
+  "ha-entity-picker",
+  "ha-switch",
+  "ha-icon",
+  "ha-input",
+  "ha-textfield",
   "ha-icon-button",
 ];
 
@@ -16,7 +21,7 @@ export function defineHaStubs({ exclude = [] } = {}) {
 
 export async function mountCard(
   hass,
-  { config = null, selectedEntity = "", activeTab, knownPosition } = {}
+  { config = null, selectedEntity = "", activeTab, knownPosition } = {},
 ) {
   const el = document.createElement("cover-time-based-card");
   el._config = config;

--- a/tests/frontend/language_banner.test.mjs
+++ b/tests/frontend/language_banner.test.mjs
@@ -132,7 +132,7 @@ test("the banner names the language and links to a prefilled issue", async () =>
   expect(text).toContain(languageDisplayName(UNSHIPPED_LANG));
   const href = banner(el).querySelector("a").getAttribute("href");
   expect(href).toBe(
-    buildTranslationRequestUrl(UNSHIPPED_LANG, languageDisplayName(UNSHIPPED_LANG))
+    buildTranslationRequestUrl(UNSHIPPED_LANG, languageDisplayName(UNSHIPPED_LANG)),
   );
 });
 
@@ -171,9 +171,8 @@ test("languageDisplayName falls back to the raw code when Intl throws", () => {
 test("the issue body names the base language for a region variant", () => {
   // de-AT, de-DE and de all want one `de` catalogue. Without this, each files a
   // differently-titled issue and the maintainer can't tell which key to create.
-  const params = new URL(
-    buildTranslationRequestUrl("de-AT", "Österreichisches Deutsch")
-  ).searchParams;
+  const params = new URL(buildTranslationRequestUrl("de-AT", "Österreichisches Deutsch"))
+    .searchParams;
   expect(params.get("body")).toContain("de");
   expect(params.get("body")).toContain("base language");
 });

--- a/tests/frontend/switch_picker.test.mjs
+++ b/tests/frontend/switch_picker.test.mjs
@@ -39,10 +39,7 @@ test("non-pulse modes allow only the switch domain", () => {
 });
 
 test("pulse mode maps a label key to its _pulse variant", () => {
-  assert.equal(
-    switchLabelKey("entities.open_switch", "pulse"),
-    "entities.open_switch_pulse"
-  );
+  assert.equal(switchLabelKey("entities.open_switch", "pulse"), "entities.open_switch_pulse");
 });
 
 test("non-pulse modes use the base label key unchanged", () => {
@@ -101,10 +98,7 @@ test("clearedTiltConfig resets tilt mode and every tilt field", () => {
 test("coverHasNativeTilt reads the tilt feature bits", () => {
   assert.equal(coverHasNativeTilt({ attributes: { supported_features: 16 } }), true);
   assert.equal(coverHasNativeTilt({ attributes: { supported_features: 32 } }), true);
-  assert.equal(
-    coverHasNativeTilt({ attributes: { supported_features: 1 | 2 | 8 } }),
-    false
-  );
+  assert.equal(coverHasNativeTilt({ attributes: { supported_features: 1 | 2 | 8 } }), false);
   assert.equal(coverHasNativeTilt({ attributes: {} }), false);
   assert.equal(coverHasNativeTilt(null), false);
   assert.equal(coverHasNativeTilt(undefined), false);
@@ -114,18 +108,15 @@ test("coverConfirmedWithoutTilt only confirms for an available, tilt-less cover"
   // Positively lacks tilt and is available → safe to reset dual_motor.
   assert.equal(
     coverConfirmedWithoutTilt({ state: "open", attributes: { supported_features: 11 } }),
-    true
+    true,
   );
   // Has tilt → not "without tilt".
   assert.equal(
     coverConfirmedWithoutTilt({ state: "open", attributes: { supported_features: 16 } }),
-    false
+    false,
   );
   // Unavailable / unknown / missing → can't confirm; must NOT reset a valid config.
-  assert.equal(
-    coverConfirmedWithoutTilt({ state: "unavailable", attributes: {} }),
-    false
-  );
+  assert.equal(coverConfirmedWithoutTilt({ state: "unavailable", attributes: {} }), false);
   assert.equal(coverConfirmedWithoutTilt({ state: "unknown", attributes: {} }), false);
   assert.equal(coverConfirmedWithoutTilt(null), false);
   assert.equal(coverConfirmedWithoutTilt(undefined), false);

--- a/tests/frontend/textfield.test.mjs
+++ b/tests/frontend/textfield.test.mjs
@@ -14,10 +14,7 @@ const registry = (names) => ({
 });
 
 test("prefers ha-input when registered", () => {
-  assert.equal(
-    textfieldTagName(registry(["ha-input", "ha-textfield"])),
-    "ha-input",
-  );
+  assert.equal(textfieldTagName(registry(["ha-input", "ha-textfield"])), "ha-input");
 });
 
 test("returns ha-input even if ha-textfield is absent", () => {

--- a/tests/frontend/translation_parity.test.mjs
+++ b/tests/frontend/translation_parity.test.mjs
@@ -43,8 +43,6 @@ test.each(OTHER_LANGS)("%s has a non-blank value for every key", (lang) => {
 });
 
 test.each(OTHER_LANGS)("%s defines no key English lacks", (lang) => {
-  const stale = Object.keys(TRANSLATIONS[lang]).filter(
-    (k) => !Object.hasOwn(EN, k),
-  );
+  const stale = Object.keys(TRANSLATIONS[lang]).filter((k) => !Object.hasOwn(EN, k));
   expect(stale).toEqual([]);
 });

--- a/tests/frontend/translations.test.mjs
+++ b/tests/frontend/translations.test.mjs
@@ -56,9 +56,7 @@ test("translate falls back to English for an unshipped language", () => {
 });
 
 test("translate returns the key itself when no catalogue defines it", () => {
-  expect(translate("pt", "definitely.not.a.real.key")).toBe(
-    "definitely.not.a.real.key"
-  );
+  expect(translate("pt", "definitely.not.a.real.key")).toBe("definitely.not.a.real.key");
 });
 
 test("translate substitutes placeholders", () => {
@@ -80,15 +78,11 @@ test("isLanguageSupported is true for English so English users are never nudged"
 
 test("translate substitutes every occurrence of a repeated placeholder", () => {
   // A string repeating a placeholder must not leave the later ones raw.
-  expect(translate("en", "no.such.key.{a}.and.{a}", { a: "Z" })).toBe(
-    "no.such.key.Z.and.Z"
-  );
+  expect(translate("en", "no.such.key.{a}.and.{a}", { a: "Z" })).toBe("no.such.key.Z.and.Z");
 });
 
 test("translate treats $-patterns in a replacement value as literal text", () => {
   // String.replace interprets $&, $` and $' in the replacement — a display name
   // containing one must not be able to splice the surrounding string into itself.
-  expect(translate("en", "no.such.key.{a}", { a: "$& $` $'" })).toBe(
-    "no.such.key.$& $` $'"
-  );
+  expect(translate("en", "no.such.key.{a}", { a: "$& $` $'" })).toBe("no.such.key.$& $` $'");
 });


### PR DESCRIPTION
## What

The "one go" reformat, now that the tooling from #226 is in place. Three commits:

1. **`style: format all JS with Prettier`** — mechanical, behaviour-preserving reformat of every `.js`/`.mjs`/`.ts` file (`printWidth: 100`, `embeddedLanguageFormatting: off` so the Lit `html``` templates are left alone). No logic changes. Isolated in its own commit so it can go in `.git-blame-ignore-revs`.
2. **`chore: drop a stale eslint-disable directive`** — removes the one leftover lint warning (`// eslint-disable-next-line no-throw-literal` in a test, for a rule that isn't enabled).
3. **`ci: enforce Prettier + ESLint on the frontend job`** — adds `npm run format:check` and `npm run lint` to the existing frontend CI job (after the tests), so this doesn't drift again.

## Verification

- **415 frontend tests pass**, coverage **99.24%** (gate 90%).
- `npm run format:check` clean in a single pass; `npm run lint` clean (0 problems).
- Bulk of the diff is `translations.js` reflow + test files; the card source is largely JS-level spacing since template internals are untouched.

## Follow-up

Once this squash-merges, I'll add `.git-blame-ignore-revs` with the resulting commit SHA so `git blame` skips the reformat.

Builds on #226.