### PR TITLE
chore: add .git-blame-ignore-revs for the Prettier reformat

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,7 @@
+# Commits that only reformat code (no behaviour change) — skipped by git blame.
+#
+# GitHub's blame view uses this file automatically. To use it locally:
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# style: reformat all JS with Prettier + enforce in CI (#227)
+979367188b836c0f9000bf0bb52347c25d0f7113


### PR DESCRIPTION
Records the #227 mechanical reformat commit (`9793671`) in `.git-blame-ignore-revs` so `git blame` attributes lines to their real authors instead of the reformat. GitHub's blame view honours this file automatically; locally, `git config blame.ignoreRevsFile .git-blame-ignore-revs`. Follow-up to #227.