### PR TITLE
feat: opt-in wait_for_relay_feedback — start tracking on the relay echo (#231)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 4.12.0 (unreleased)
+
+### Features
+
+- **Added a per-cover "Wait for relay confirmation before tracking" option** ([#231](https://github.com/Sese-Schneider/ha-cover-time-based/issues/231)): for **Switch (latching)** covers driven through a relay that reports its own state (e.g. a Zigbee or Z-Wave relay), the position timer can now start when the relay confirms it switched — its state-change echo — instead of the instant the command is queued. The relay command is sent without waiting for the relay, so on a slow or cold mesh it can take seconds to actually reach the motor; until now that variable delay was counted as travel and the tracked position ran ahead of the physical cover, resyncing only when driven to a fully-open or fully-closed endpoint. With the option on, the round-trip falls outside the tracked travel, and the fixed **Travel startup delay** goes back to meaning only the motor's mechanical spin-up. Calibration honours the same signal, so a travel or tilt **time** measured with the option on isn't inflated by the round-trip either. Off by default; it needs a relay that reports its real state (an optimistic/assumed switch is skipped, starting inline as before), and a relay that never confirms falls back to the previous behaviour after a short timeout. Applies to travel and tilt moves in **Switch** mode only.
+
 ## 4.11.0 (2026-08-04)
 
 ### Features

--- a/custom_components/cover_time_based/calibration.py
+++ b/custom_components/cover_time_based/calibration.py
@@ -44,4 +44,8 @@ class CalibrationState:
     saved_startup_delay: float | None = None
     timeout_task: Task | None = field(default=None, repr=False)
     automation_task: Task | None = field(default=None, repr=False)
+    # Waits for the driving relay's confirmation echo (wait_for_relay_feedback)
+    # to re-baseline the timing stamp, so a calibrated time excludes the Zigbee
+    # round-trip the tracker also excludes at runtime.
+    feedback_task: Task | None = field(default=None, repr=False)
     uses_tilt_motor: bool = False

--- a/custom_components/cover_time_based/const.py
+++ b/custom_components/cover_time_based/const.py
@@ -80,6 +80,12 @@ DEFAULT_SEND_ENDPOINT_STOP = True
 CONF_FORCE_ENDPOINT_REDRIVE = "force_endpoint_redrive"
 DEFAULT_FORCE_ENDPOINT_REDRIVE = False
 
+# When True, movement commands wait for the underlying relay to confirm its state
+# change before proceeding. Behaviour is implemented elsewhere; this constant is
+# the plumbed per-cover config option.
+CONF_WAIT_FOR_RELAY_FEEDBACK = "wait_for_relay_feedback"
+DEFAULT_WAIT_FOR_RELAY_FEEDBACK = False
+
 # All modes. When True, a set_cover_position command first drives the cover
 # fully open — a physical datum, since the motor stalls against its limit — and
 # only then moves to the requested position. For a cover with no position

--- a/custom_components/cover_time_based/cover.py
+++ b/custom_components/cover_time_based/cover.py
@@ -45,6 +45,7 @@ from .const import (
     CONF_TRAVEL_STARTUP_DELAY,
     CONF_TRAVEL_TIME_CLOSE,
     CONF_TRAVEL_TIME_OPEN,
+    CONF_WAIT_FOR_RELAY_FEEDBACK,
     DEFAULT_ASSUMED_STATE,
     DEFAULT_CLOSE_INCLUDES_TILT,
     DEFAULT_ENDPOINT_RUNON_TIME,
@@ -56,6 +57,7 @@ from .const import (
     DEFAULT_RELAY_REPORTS_OFF,
     DEFAULT_REPORTS_COMMAND_NOT_ENDPOINT,
     DEFAULT_SEND_ENDPOINT_STOP,
+    DEFAULT_WAIT_FOR_RELAY_FEEDBACK,
 )
 from .cover_base import CoverTimeBased  # noqa: F401
 from .helpers import resolve_entity
@@ -367,6 +369,9 @@ def _create_cover_from_options(options, device_id="", name=""):
         "assumed_state": options.get(CONF_ASSUMED_STATE, DEFAULT_ASSUMED_STATE),
         "force_endpoint_redrive": options.get(
             CONF_FORCE_ENDPOINT_REDRIVE, DEFAULT_FORCE_ENDPOINT_REDRIVE
+        ),
+        "wait_for_relay_feedback": options.get(
+            CONF_WAIT_FOR_RELAY_FEEDBACK, DEFAULT_WAIT_FOR_RELAY_FEEDBACK
         ),
         "recalibrate_before_position": options.get(
             CONF_RECALIBRATE_BEFORE_POSITION, DEFAULT_RECALIBRATE_BEFORE_POSITION

--- a/custom_components/cover_time_based/cover_base.py
+++ b/custom_components/cover_time_based/cover_base.py
@@ -46,6 +46,7 @@ from .const import (
     CONF_TRAVEL_STARTUP_DELAY,
     CONF_TRAVEL_TIME_CLOSE,
     CONF_TRAVEL_TIME_OPEN,
+    CONF_WAIT_FOR_RELAY_FEEDBACK,
     DIRECTION_CHANGE_DELAY,
 )
 from .cover_calibration import CalibrationMixin
@@ -60,6 +61,18 @@ from .tilt_strategies.planning import (
 from .travel_calculator import TravelCalculator, TravelStatus
 
 _LOGGER = logging.getLogger(__name__)
+
+# How long a feedback-gated move (wait_for_relay_feedback) waits for its relay's
+# ON confirmation echo before falling back to the inline command-fire start.
+# Generous relative to the few seconds a cold Zigbee mesh has been seen to take,
+# since the fallback only matters for a relay that never reports its state at all.
+RELAY_FEEDBACK_TIMEOUT = 10.0
+
+# Safety window the awaited relay's pending-echo count lives for while a feedback
+# wait is armed. Kept above RELAY_FEEDBACK_TIMEOUT so the timeout fires first: a
+# late echo is then still filtered as our own rather than reclassified as an
+# external press.
+RELAY_FEEDBACK_PENDING_TIMEOUT = 12.0
 
 # (task, cover) pairs for the external-state handlers currently running.
 #
@@ -118,12 +131,14 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         close_includes_tilt=True,
         assumed_state=True,
         force_endpoint_redrive=False,
+        wait_for_relay_feedback=False,
         recalibrate_before_position=False,
     ):
         """Initialize the cover."""
         self._unique_id = device_id
         self._assumed_state = assumed_state
         self._force_endpoint_redrive = force_endpoint_redrive
+        self._wait_for_relay_feedback = wait_for_relay_feedback
         self._recalibrate_before_position = recalibrate_before_position
 
         self._tilt_strategy = tilt_strategy
@@ -197,6 +212,18 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         self._pending_switch = {}
         self._pending_switch_timers = {}
         self._state_listener_unsubs = []
+        # Relay-feedback timing (wait_for_relay_feedback). Three short-lived
+        # fields spanning one deferred move:
+        #   _feedback_armed_entity — set by the _send_* that just energized a
+        #     relay OFF->ON; read and cleared by _begin_movement to decide
+        #     whether to defer tracking. Never outlives the send->begin hop.
+        #   _feedback_wait_entity / _feedback_wait_future — the relay whose ON
+        #     echo the deferred move (or a feedback-timed calibration drive) is
+        #     waiting on, and the future its confirming echo resolves. Live only
+        #     while the wait is in flight.
+        self._feedback_armed_entity: str | None = None
+        self._feedback_wait_entity: str | None = None
+        self._feedback_wait_future: asyncio.Future | None = None
 
         self.travel_calc = TravelCalculator(
             self._travel_time_close,
@@ -489,6 +516,7 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         if self._min_movement_time is not None:
             attr[CONF_MIN_MOVEMENT_TIME] = self._min_movement_time
         attr[CONF_FORCE_ENDPOINT_REDRIVE] = self._force_endpoint_redrive
+        attr[CONF_WAIT_FOR_RELAY_FEEDBACK] = self._wait_for_relay_feedback
         attr[CONF_RECALIBRATE_BEFORE_POSITION] = self._recalibrate_before_position
         if self._calibration is not None:
             attr["calibration_active"] = True
@@ -2472,13 +2500,35 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         delay so its position stays put until the pre-step finishes.
         """
 
-        def start():
-            primary_calc.start_travel(target, delay=pre_step_delay)
+        def start(base_timestamp=None, extra_delay=0.0):
+            primary_calc.start_travel(
+                target,
+                delay=pre_step_delay + extra_delay,
+                base_timestamp=base_timestamp,
+            )
             if coupled_target is not None:
-                coupled_calc.start_travel(int(coupled_target))
+                # extra_delay (mechanical startup delay) applies to the coupled
+                # calc too: the old sleep-based path delayed the whole start
+                # callback, offsetting both calcs equally. pre_step_delay is the
+                # primary's alone — the coupled calc IS the pre-step.
+                coupled_calc.start_travel(
+                    int(coupled_target),
+                    delay=extra_delay,
+                    base_timestamp=base_timestamp,
+                )
             self.start_auto_updater()
 
-        self._start_movement(startup_delay, start)
+        # A _send_* that just energized a relay OFF->ON under
+        # wait_for_relay_feedback parks the start here until that relay's ON echo
+        # (or a timeout), instead of the fixed startup-delay sleep. The variable
+        # Zigbee round-trip then falls outside the tracked travel (issue #231).
+        feedback_entity = self._consume_feedback_arm()
+        if feedback_entity is not None:
+            self._startup_delay_task = self.hass.async_create_task(
+                self._execute_with_relay_feedback(feedback_entity, start, startup_delay)
+            )
+        else:
+            self._start_movement(startup_delay, start)
 
     def _start_movement(self, startup_delay, start_callback):
         """Start position tracking, optionally after a motor startup delay.
@@ -2892,6 +2942,12 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         travel reversal parked in its settle gap just as a travel command does.
         """
         self._supersede_movement()
+        # A fresh move must not inherit a relay-feedback arm left set by an
+        # earlier operation that armed but never reached _begin_movement (e.g.
+        # an endpoint resync). Otherwise a following suppress_start_command
+        # redrive — which fires no _send_* to re-arm — would read the stale arm
+        # and wait for an ON echo its already-latched relay will never send.
+        self._feedback_armed_entity = None
         was_restoring = self._tilt_restore_active
         was_pre_stepping = (
             self._pending_travel_target is not None
@@ -3467,10 +3523,11 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         and only when the relay call will actually flip state. Otherwise
         the orphan pending count consumes the next real state change.
         """
+        self._feedback_armed_entity = None
         if self._switch_is_on(self._tilt_close_switch_id):
             self._mark_switch_pending(self._tilt_close_switch_id, 1)
         if not self._switch_is_on(self._tilt_open_switch_id):
-            self._mark_switch_pending(self._tilt_open_switch_id, 1)
+            self._mark_driving_relay_pending(self._tilt_open_switch_id)
         await self.hass.services.async_call(
             "homeassistant",
             "turn_off",
@@ -3489,10 +3546,11 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
 
         See _send_tilt_open for the pending-count rationale.
         """
+        self._feedback_armed_entity = None
         if self._switch_is_on(self._tilt_open_switch_id):
             self._mark_switch_pending(self._tilt_open_switch_id, 1)
         if not self._switch_is_on(self._tilt_close_switch_id):
-            self._mark_switch_pending(self._tilt_close_switch_id, 1)
+            self._mark_driving_relay_pending(self._tilt_close_switch_id)
         await self.hass.services.async_call(
             "homeassistant",
             "turn_off",
@@ -3542,8 +3600,69 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         state = self.hass.states.get(entity_id)
         return state is not None and state.state == "on"
 
-    def _mark_switch_pending(self, entity_id, expected_transitions):
-        """Mark a switch as having pending echo transitions to ignore."""
+    def _switch_is_optimistic(self, entity_id) -> bool:
+        """Whether the underlying switch reports optimistic (assumed) state.
+
+        An optimistic switch writes its new state immediately, before the
+        device confirms, so its state-change echo proves nothing about the
+        relay — a feedback-gated move must fall back to the inline start.
+        """
+        state = self.hass.states.get(entity_id)
+        return bool(state is not None and state.attributes.get("assumed_state"))
+
+    def _arm_relay_feedback(self, entity_id) -> bool:
+        """Arm a relay-feedback wait for a relay this move is energizing.
+
+        Records ``entity_id`` as the relay whose ON echo should start tracking,
+        and returns True, only when ``wait_for_relay_feedback`` is enabled and
+        the relay actually reports its state (not optimistic). Otherwise clears
+        the arm and returns False, so the caller falls back to the inline
+        command-fire start used everywhere today. Called from the ``_send_*``
+        method that flips the relay, and consumed by ``_begin_movement``.
+        """
+        self._feedback_armed_entity = None
+        if not self._wait_for_relay_feedback:
+            return False
+        if entity_id is None or self._switch_is_optimistic(entity_id):
+            return False
+        self._feedback_armed_entity = entity_id
+        return True
+
+    def _consume_feedback_arm(self):
+        """Read and clear the arm the preceding ``_send_*`` left, if any.
+
+        The single hand-off channel from a ``_send_*`` (which knows it energized
+        a relay) to the deferral point (``_begin_movement`` or a feedback-timed
+        calibration drive), consumed exactly once.
+        """
+        entity_id = self._feedback_armed_entity
+        self._feedback_armed_entity = None
+        return entity_id
+
+    def _mark_driving_relay_pending(self, entity_id):
+        """Mark the direction relay a move is energizing OFF->ON as pending.
+
+        Call only when the relay will actually flip (inside the
+        ``if not <relay>_is_on`` guard). Under ``wait_for_relay_feedback`` this
+        also arms the wait on the relay's ON echo and widens the echo's safety
+        window (``RELAY_FEEDBACK_PENDING_TIMEOUT``) so a slow confirmation is
+        still filtered as our own rather than read as an external press.
+        """
+        if self._arm_relay_feedback(entity_id):
+            self._mark_switch_pending(
+                entity_id, 1, timeout=RELAY_FEEDBACK_PENDING_TIMEOUT
+            )
+        else:
+            self._mark_switch_pending(entity_id, 1)
+
+    def _mark_switch_pending(self, entity_id, expected_transitions, timeout=5):
+        """Mark a switch as having pending echo transitions to ignore.
+
+        ``timeout`` is the safety window (seconds) after which a still-unmatched
+        count is cleared. The default matches a promptly-reporting relay; a
+        feedback-gated move extends it (RELAY_FEEDBACK_PENDING_TIMEOUT) so the
+        awaited echo stays classifiable as our own for the full feedback wait.
+        """
         self._pending_switch[entity_id] = (
             self._pending_switch.get(entity_id, 0) + expected_transitions
         )
@@ -3557,7 +3676,7 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         if entity_id in self._pending_switch_timers:
             self._pending_switch_timers[entity_id]()
 
-        # Safety timeout: clear pending after 5 seconds
+        # Safety timeout: clear pending after the window elapses
         @callback
         def _clear_pending(_now):
             if entity_id in self._pending_switch:
@@ -3566,8 +3685,76 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
             self._pending_switch_timers.pop(entity_id, None)
 
         self._pending_switch_timers[entity_id] = async_call_later(
-            self.hass, 5, _clear_pending
+            self.hass, timeout, _clear_pending
         )
+
+    def _resolve_relay_feedback(self, entity_id, new_val, new_state) -> None:
+        """Start a parked feedback-gated move when its relay confirms.
+
+        Called from the echo-filter branch of _async_switch_state_changed: the
+        relay reporting ON *is* the "motor now energized" signal. Resolves the
+        waiting future with the echo's ``last_changed`` timestamp so tracking
+        starts from when the relay actually switched, not when the listener ran.
+        """
+        future = self._feedback_wait_future
+        if (
+            future is not None
+            and not future.done()
+            and entity_id == self._feedback_wait_entity
+            and new_val == "on"
+        ):
+            last_changed = getattr(new_state, "last_changed", None)
+            base_ts = last_changed.timestamp() if last_changed is not None else None
+            self._log(
+                "_resolve_relay_feedback :: %s confirmed on (base_ts=%s)",
+                entity_id,
+                base_ts,
+            )
+            future.set_result(base_ts)
+
+    async def _wait_for_relay_echo(self, entity_id, timeout):
+        """Await ``entity_id``'s ON echo; return its last_changed ts, or None.
+
+        Returns None on timeout (relay never confirmed) so the caller falls back
+        to a command-fire timeline. Uses the running loop's future — the mock
+        hass in unit tests has no real ``hass.loop``.
+        """
+        future = asyncio.get_running_loop().create_future()
+        self._feedback_wait_entity = entity_id
+        self._feedback_wait_future = future
+        try:
+            return await asyncio.wait_for(future, timeout)
+        except TimeoutError:
+            self._log(
+                "_wait_for_relay_echo :: %s did not confirm within %ss",
+                entity_id,
+                timeout,
+            )
+            return None
+        finally:
+            self._feedback_wait_entity = None
+            self._feedback_wait_future = None
+
+    async def _execute_with_relay_feedback(
+        self, entity_id, start_callback, startup_delay
+    ):
+        """Defer tracking start until the relay confirms it switched (or timeout).
+
+        Runs as ``_startup_delay_task`` so every consumer of that task —
+        _movement_started, the reverse/same-direction conflict blocks, and
+        _cancel_startup_delay_task — treats a feedback wait exactly like a fixed
+        startup delay. On confirmation, tracking is timestamped from the echo;
+        the fixed mechanical ``startup_delay`` is then folded on top of the same
+        anchor. On timeout the move starts inline, as it does with the option off.
+        """
+        try:
+            base_ts = await self._wait_for_relay_echo(entity_id, RELAY_FEEDBACK_TIMEOUT)
+            start_callback(base_timestamp=base_ts, extra_delay=startup_delay or 0.0)
+            self._startup_delay_task = None
+        except asyncio.CancelledError:
+            self._log("_execute_with_relay_feedback :: cancelled")
+            self._startup_delay_task = None
+            raise
 
     def _unmark_switch_pending(self, entity_id, count=1):
         """Drop ``count`` pending echo transitions previously marked.
@@ -3648,6 +3835,10 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
                 "_async_switch_state_changed :: echo filtered, remaining=%s",
                 self._pending_switch.get(entity_id, 0),
             )
+            # This own-echo is also the relay confirming it switched: if a
+            # feedback-gated move is parked on this relay's ON transition, start
+            # its tracking now (issue #231). Harmless no-op otherwise.
+            self._resolve_relay_feedback(entity_id, new_val, new_state)
             return
 
         # Skip external state handling during calibration — calibration drives

--- a/custom_components/cover_time_based/cover_calibration.py
+++ b/custom_components/cover_time_based/cover_calibration.py
@@ -44,6 +44,10 @@ class CalibrationMixin:
         tilt_calc: TravelCalculator
 
         async def _async_handle_command(self, _command: str, *_args: Any) -> None: ...
+        def _consume_feedback_arm(self) -> str | None: ...
+        async def _wait_for_relay_echo(
+            self, entity_id: str, timeout: float
+        ) -> float | None: ...
         async def _send_stop(self) -> None: ...
         async def _send_tilt_open(self) -> None: ...
         async def _send_tilt_close(self) -> None: ...
@@ -163,6 +167,35 @@ class CalibrationMixin:
         else:
             await self._async_handle_command(move_command)
 
+    def _arm_calibration_feedback_timing(self, field: str) -> None:
+        """Re-baseline a calibration timing stamp on the relay's confirmation.
+
+        When wait_for_relay_feedback is on, the ``_send_*`` the drive just made
+        armed ``_feedback_armed_entity`` with the relay it energized. Wait for
+        that relay's ON echo (in the background) and re-stamp ``field``
+        (``started_at`` for a time test, ``continuous_start`` for the overhead
+        test) to the confirmation, so the Zigbee round-trip is excluded from the
+        measured time — the same delay the tracker now excludes at runtime.
+        """
+        entity_id = self._consume_feedback_arm()
+        if entity_id is None or self._calibration is None:
+            return
+        self._calibration.feedback_task = self.hass.async_create_task(
+            self._await_calibration_feedback(entity_id, field)
+        )
+
+    async def _await_calibration_feedback(self, entity_id: str, field: str) -> None:
+        from .cover_base import RELAY_FEEDBACK_TIMEOUT
+
+        confirmed = await self._wait_for_relay_echo(entity_id, RELAY_FEEDBACK_TIMEOUT)
+        # None means the relay never confirmed: keep the command-fire baseline,
+        # exactly as it behaves with the option off.
+        if confirmed is not None and self._calibration is not None:
+            setattr(self._calibration, field, time.monotonic())
+            _LOGGER.debug(
+                "calibration: %s re-baselined on %s confirmation", field, entity_id
+            )
+
     async def _calibration_stop(self) -> None:
         assert self._calibration is not None
         if self._calibration.uses_tilt_motor:
@@ -184,6 +217,7 @@ class CalibrationMixin:
             move_command = SERVICE_OPEN_COVER
         self._calibration.move_command = move_command
         await self._calibration_drive(move_command)
+        self._arm_calibration_feedback_timing("started_at")
 
     def _tilt_calibration_command(self, closing_tilt: bool) -> str:
         """Resolve the relay direction for tilt calibration.
@@ -311,6 +345,7 @@ class CalibrationMixin:
             self.async_write_ha_state()
             self._calibration.continuous_start = time.monotonic()
             await self._calibration_drive(move_command)
+            self._arm_calibration_feedback_timing("continuous_start")
 
             # Wait indefinitely until user calls stop_calibration
             while True:
@@ -372,6 +407,7 @@ class CalibrationMixin:
         for task in (
             self._calibration.timeout_task,
             self._calibration.automation_task,
+            self._calibration.feedback_task,
         ):
             if task is not None and not task.done():
                 task.cancel()

--- a/custom_components/cover_time_based/cover_switch_mode.py
+++ b/custom_components/cover_time_based/cover_switch_mode.py
@@ -145,10 +145,14 @@ class SwitchModeCover(SwitchCoverTimeBased):
         # when the relay is already ON — e.g. a continuation re-driving the
         # user's still-latched relay — and that orphan then swallows the next
         # real event (such as the user switching it off to stop).
+        # Only the driving relay turning ON confirms the motor is energized; the
+        # opposite relay's turn_off is just the interlock. _mark_driving_relay_pending
+        # marks that ON echo and, under feedback, arms the wait on it.
+        self._feedback_armed_entity = None
         if self._switch_is_on(self._close_switch_entity_id):
             self._mark_switch_pending(self._close_switch_entity_id, 1)
         if not self._switch_is_on(self._open_switch_entity_id):
-            self._mark_switch_pending(self._open_switch_entity_id, 1)
+            self._mark_driving_relay_pending(self._open_switch_entity_id)
         await self.hass.services.async_call(
             "homeassistant",
             "turn_off",
@@ -164,10 +168,11 @@ class SwitchModeCover(SwitchCoverTimeBased):
 
     async def _send_close(self) -> None:
         # See _send_open: mark only when the relay will actually flip state.
+        self._feedback_armed_entity = None
         if self._switch_is_on(self._open_switch_entity_id):
             self._mark_switch_pending(self._open_switch_entity_id, 1)
         if not self._switch_is_on(self._close_switch_entity_id):
-            self._mark_switch_pending(self._close_switch_entity_id, 1)
+            self._mark_driving_relay_pending(self._close_switch_entity_id)
         await self.hass.services.async_call(
             "homeassistant",
             "turn_off",

--- a/custom_components/cover_time_based/frontend/card-render.js
+++ b/custom_components/cover_time_based/frontend/card-render.js
@@ -391,6 +391,17 @@ export function renderInputEntities(card, c) {
         c.force_endpoint_redrive === true,
         (e) => card._updateLocal({ force_endpoint_redrive: e.target.checked }),
       )}
+      ${
+        (c.control_mode || "switch") === "switch"
+          ? renderToggleWithHelp(
+              card,
+              "wait_for_relay_feedback.label",
+              "wait_for_relay_feedback.helper",
+              c.wait_for_relay_feedback === true,
+              (e) => card._updateLocal({ wait_for_relay_feedback: e.target.checked }),
+            )
+          : ""
+      }
       ${renderToggleWithHelp(
         card,
         "recalibrate_before_position.label",

--- a/custom_components/cover_time_based/frontend/translations.js
+++ b/custom_components/cover_time_based/frontend/translations.js
@@ -71,6 +71,9 @@ export const EN = {
   "force_endpoint_redrive.label": "Always re-send open/close at the endpoints",
   "force_endpoint_redrive.helper":
     "For covers with no position feedback that can also be moved by an external remote, so Home Assistant may wrongly believe they are already fully open or closed. When on, an open or close command is always driven for the full travel time even if Home Assistant thinks the cover is already there — guaranteeing the command reaches the motor. Leave off for covers that report their own position.",
+  "wait_for_relay_feedback.label": "Wait for relay confirmation before tracking",
+  "wait_for_relay_feedback.helper":
+    "Switch mode only. Starts the position timer when the relay reports it switched on, instead of the moment the command is sent. On a slow or cold Zigbee/Z-Wave mesh the command can take seconds to reach the relay; without this, that delay is counted as travel and the tracked position runs ahead of the cover. Leave off unless the position drifts on covers whose relay responds slowly.",
   "recalibrate_before_position.label": "Fully open before moving to a position (Beta)",
   "recalibrate_before_position.helper":
     "For covers with no position feedback that a remote can also move. Drives the cover fully open before each position command, so the move starts from a known position instead of a drifted guess. Roughly doubles the travel of every move, and on inline or sequential tilt it moves the cover when you adjust the slats.",
@@ -225,6 +228,9 @@ export const TRANSLATIONS = {
     "force_endpoint_redrive.label": "Reenviar sempre abrir/fechar nos extremos",
     "force_endpoint_redrive.helper":
       "Para estores sem retorno de posição que também podem ser movidos por um telecomando externo, pelo que o Home Assistant pode julgar erradamente que já estão totalmente abertos ou fechados. Quando ativo, um comando de abrir ou fechar é sempre executado durante o tempo total de deslocamento, mesmo que o Home Assistant pense que o estore já lá está — garantindo que o comando chega ao motor. Deixe inativo para estores que reportam a sua própria posição.",
+    "wait_for_relay_feedback.label": "Aguardar confirmação do relé antes de rastrear",
+    "wait_for_relay_feedback.helper":
+      "Apenas no modo interruptor. Inicia o temporizador de posição quando o relé reporta que ligou, em vez do momento em que o comando é enviado. Numa malha Zigbee/Z-Wave lenta ou fria, o comando pode demorar segundos a chegar ao relé; sem esta opção, esse atraso é contado como deslocamento e a posição rastreada fica à frente do estore. Deixe inativo, a menos que a posição desvie em estores cujo relé responde lentamente.",
     "recalibrate_before_position.label": "Abrir totalmente antes de mover para uma posição (Beta)",
     "recalibrate_before_position.helper":
       "Para estores sem retorno de posição que também podem ser movidos por um telecomando. Antes de cada comando de definir posição, move primeiro o estore para totalmente aberto, para que o movimento comece a partir de uma posição conhecida em vez de uma estimativa desviada. Isto duplica, grosso modo, o tempo de deslocamento de cada movimento e, na inclinação durante o deslocamento ou na inclinação sequencial, ajustar as lâminas também move o estore.",
@@ -377,6 +383,9 @@ export const TRANSLATIONS = {
     "force_endpoint_redrive.label": "Zawsze ponownie wysyłaj otwórz/zamknij na krańcach",
     "force_endpoint_redrive.helper":
       "Dla rolet bez informacji zwrotnej o pozycji, które mogą być sterowane również zewnętrznym pilotem, przez co Home Assistant może błędnie sądzić, że są już całkowicie otwarte lub zamknięte. Po włączeniu polecenie otwarcia lub zamknięcia jest zawsze wykonywane przez pełny czas ruchu, nawet jeśli Home Assistant sądzi, że roleta już tam jest — dzięki czemu polecenie na pewno dotrze do silnika. Pozostaw wyłączone dla rolet zgłaszających własną pozycję.",
+    "wait_for_relay_feedback.label": "Czekaj na potwierdzenie przekaźnika przed śledzeniem",
+    "wait_for_relay_feedback.helper":
+      "Tylko w trybie przełącznika. Uruchamia licznik czasu pozycji, gdy przekaźnik zgłosi, że się włączył, zamiast w chwili wysłania polecenia. W wolnej lub wychłodzonej sieci Zigbee/Z-Wave polecenie może docierać do przekaźnika przez kilka sekund; bez tej opcji to opóźnienie jest liczone jako ruch, a śledzona pozycja wyprzedza roletę. Pozostaw wyłączone, chyba że pozycja dryfuje w roletach, których przekaźnik reaguje wolno.",
     "recalibrate_before_position.label": "Otwórz w pełni przed przejściem do pozycji (Beta)",
     "recalibrate_before_position.helper":
       "Dla rolet bez informacji zwrotnej o pozycji, które mogą być poruszane również pilotem. Przed każdym poleceniem ustawienia pozycji najpierw otwiera roletę w pełni, dzięki czemu ruch zaczyna się od znanej pozycji, a nie od nieaktualnego przybliżenia. Z grubsza podwaja czas ruchu przy każdym przesunięciu, a przy nachyleniu w trakcie ruchu lub nachyleniu sekwencyjnym regulacja listew porusza także samą roletę.",
@@ -528,6 +537,9 @@ export const TRANSLATIONS = {
     "force_endpoint_redrive.label": "Öffnen/Schließen an den Endlagen immer erneut senden",
     "force_endpoint_redrive.helper":
       "Für Rollläden ohne Positionsrückmeldung, die sich zusätzlich per externer Fernbedienung bewegen lassen, sodass Home Assistant fälschlich annehmen kann, sie seien bereits vollständig geöffnet oder geschlossen. Wenn aktiviert, wird ein Öffnen- oder Schließen-Befehl immer über die volle Fahrzeit ausgeführt, selbst wenn Home Assistant den Rollladen dort schon vermutet — so erreicht der Befehl garantiert den Motor. Für Rollläden, die ihre eigene Position melden, deaktiviert lassen.",
+    "wait_for_relay_feedback.label": "Vor dem Verfolgen auf die Relais-Bestätigung warten",
+    "wait_for_relay_feedback.helper":
+      "Nur im Schaltermodus. Startet den Positionszeitgeber, wenn das Relais sein Einschalten meldet, statt im Moment des Befehlsversands. In einem langsamen oder kalten Zigbee-/Z-Wave-Mesh kann der Befehl mehrere Sekunden bis zum Relais brauchen; ohne diese Option wird diese Verzögerung als Fahrt gezählt und die verfolgte Position läuft dem Rollladen voraus. Lass die Option aus, sofern die Position bei Rollläden mit langsam reagierendem Relais nicht abdriftet.",
     "recalibrate_before_position.label":
       "Vor einer Positionsfahrt zuerst vollständig öffnen (Beta)",
     "recalibrate_before_position.helper":
@@ -683,6 +695,9 @@ export const TRANSLATIONS = {
     "force_endpoint_redrive.label": "Invia sempre di nuovo apertura/chiusura ai finecorsa",
     "force_endpoint_redrive.helper":
       "Per le tapparelle senza retroazione di posizione che possono essere azionate anche da un telecomando esterno, per cui Home Assistant potrebbe credere erroneamente che siano già completamente aperte o chiuse. Quando è attivo, un comando di apertura o chiusura viene sempre eseguito per l'intero tempo di corsa anche se Home Assistant ritiene che la tapparella si trovi già lì — garantendo che il comando raggiunga il motore. Lascialo disattivato per le tapparelle che riportano la propria posizione.",
+    "wait_for_relay_feedback.label": "Attendi la conferma del relè prima di tracciare",
+    "wait_for_relay_feedback.helper":
+      "Solo in modalità interruttore. Avvia il timer di posizione quando il relè segnala di essersi acceso, anziché nel momento in cui viene inviato il comando. Su una rete mesh Zigbee/Z-Wave lenta o fredda il comando può impiegare alcuni secondi a raggiungere il relè; senza questa opzione, quel ritardo viene conteggiato come corsa e la posizione tracciata precede la tapparella. Lascialo disattivato, a meno che la posizione non vada alla deriva su tapparelle il cui relè risponde lentamente.",
     "recalibrate_before_position.label": "Apri completamente prima di spostare in posizione (Beta)",
     "recalibrate_before_position.helper":
       "Per le tapparelle senza retroazione di posizione che possono essere spostate anche da un telecomando. Porta la tapparella in apertura completa prima di ogni comando di posizionamento, così il movimento parte da una posizione nota anziché da una stima alla deriva. Raddoppia circa il tempo di corsa di ogni movimento e, con l'inclinazione durante la corsa o quella sequenziale, muove la tapparella anche quando regoli le lamelle.",
@@ -834,6 +849,9 @@ export const TRANSLATIONS = {
     "force_endpoint_redrive.label": "Openen/sluiten altijd opnieuw versturen bij de eindstanden",
     "force_endpoint_redrive.helper":
       "Voor rolluiken zonder positieterugkoppeling die ook met een externe afstandsbediening bediend kunnen worden, waardoor Home Assistant ten onrechte kan denken dat ze al volledig open of gesloten zijn. Wanneer dit aanstaat, wordt een open- of sluitcommando altijd gedurende de volledige looptijd uitgevoerd, ook als Home Assistant denkt dat het rolluik daar al staat — zo bereikt het commando gegarandeerd de motor. Laat dit uitstaan voor rolluiken die hun eigen positie rapporteren.",
+    "wait_for_relay_feedback.label": "Wacht op bevestiging van het relais voordat er gevolgd wordt",
+    "wait_for_relay_feedback.helper":
+      "Alleen in schakelaarmodus. Start de positietimer wanneer het relais meldt dat het is ingeschakeld, in plaats van op het moment dat het commando wordt verstuurd. Op een traag of koud Zigbee/Z-Wave-mesh kan het commando er seconden over doen om het relais te bereiken; zonder deze optie wordt die vertraging als beweging meegeteld en loopt de gevolgde positie voor op het rolluik. Laat dit uitstaan, tenzij de positie afwijkt bij rolluiken waarvan het relais traag reageert.",
     "recalibrate_before_position.label":
       "Volledig openen voordat naar een positie wordt bewogen (Beta)",
     "recalibrate_before_position.helper":
@@ -986,6 +1004,9 @@ export const TRANSLATIONS = {
     "force_endpoint_redrive.label": "Toujours renvoyer ouvrir/fermer en fin de course",
     "force_endpoint_redrive.helper":
       "Pour les volets sans retour de position qui peuvent aussi être actionnés par une télécommande externe, si bien que Home Assistant peut croire à tort qu'ils sont déjà complètement ouverts ou fermés. Lorsque cette option est activée, une commande d'ouverture ou de fermeture est toujours exécutée pendant la totalité du temps de course, même si Home Assistant pense que le volet y est déjà — ce qui garantit que la commande atteint le moteur. Laissez-la désactivée pour les volets qui rapportent leur propre position.",
+    "wait_for_relay_feedback.label": "Attendre la confirmation du relais avant le suivi",
+    "wait_for_relay_feedback.helper":
+      "Uniquement en mode interrupteur. Démarre le minuteur de position lorsque le relais signale qu'il s'est activé, plutôt qu'au moment où la commande est envoyée. Sur un réseau maillé Zigbee/Z-Wave lent ou froid, la commande peut mettre plusieurs secondes à atteindre le relais ; sans cette option, ce délai est compté comme de la course et la position suivie devance le volet. Laissez cette option désactivée, sauf si la position dérive sur des volets dont le relais répond lentement.",
     "recalibrate_before_position.label": "Ouvrir complètement avant d'aller à une position (Bêta)",
     "recalibrate_before_position.helper":
       "Pour les volets sans retour de position qu'une télécommande peut aussi actionner. Ouvre complètement le volet avant chaque commande de position, afin que le mouvement parte d'une position connue plutôt que d'une estimation partie à la dérive. Cela double à peu près la course de chaque mouvement et, avec une inclinaison pendant la course ou une inclinaison séquentielle, le volet bouge lorsque vous réglez les lames.",
@@ -1137,6 +1158,9 @@ export const TRANSLATIONS = {
     "force_endpoint_redrive.label": "Reenviar siempre abrir/cerrar en los finales de carrera",
     "force_endpoint_redrive.helper":
       "Para persianas sin realimentación de posición que también se pueden mover con un mando a distancia externo, de modo que Home Assistant puede creer erróneamente que ya están totalmente abiertas o cerradas. Cuando está activado, un comando de apertura o cierre siempre se ejecuta durante todo el tiempo de recorrido aunque Home Assistant crea que la persiana ya está ahí, lo que garantiza que el comando llega al motor. Déjalo desactivado para las persianas que informan de su propia posición.",
+    "wait_for_relay_feedback.label": "Esperar la confirmación del relé antes de rastrear",
+    "wait_for_relay_feedback.helper":
+      "Solo en modo interruptor. Inicia el temporizador de posición cuando el relé informa de que se ha encendido, en lugar del momento en que se envía el comando. En una red mallada Zigbee/Z-Wave lenta o fría, el comando puede tardar segundos en llegar al relé; sin esta opción, ese retardo se cuenta como recorrido y la posición rastreada se adelanta a la persiana. Déjalo desactivado, a menos que la posición se desvíe en persianas cuyo relé responde con lentitud.",
     "recalibrate_before_position.label": "Abrir totalmente antes de mover a una posición (Beta)",
     "recalibrate_before_position.helper":
       "Para persianas sin realimentación de posición que un mando a distancia también puede mover. Abre la persiana por completo antes de cada comando de posición, para que el movimiento parta de una posición conocida en lugar de una estimación desviada. Duplica aproximadamente el recorrido de cada movimiento y, con la inclinación durante el recorrido o la inclinación secuencial, mueve la persiana cuando ajustas las lamas.",
@@ -1291,6 +1315,9 @@ export const TRANSLATIONS = {
     "force_endpoint_redrive.label": "Torna a enviar sempre obrir/tancar als finals de cursa",
     "force_endpoint_redrive.helper":
       "Per a persianes sense realimentació de posició que també es poden moure amb un comandament a distància extern, de manera que Home Assistant pot creure erròniament que ja són totalment obertes o tancades. Quan està activat, una ordre d'obrir o tancar s'executa sempre durant tot el temps de recorregut encara que Home Assistant cregui que la persiana ja hi és, cosa que garanteix que l'ordre arriba al motor. Deixa-ho desactivat per a les persianes que informen de la seva pròpia posició.",
+    "wait_for_relay_feedback.label": "Espera la confirmació del relé abans de fer el seguiment",
+    "wait_for_relay_feedback.helper":
+      "Només en mode interruptor. Inicia el temporitzador de posició quan el relé informa que s'ha activat, en lloc del moment en què s'envia l'ordre. En una xarxa mallada Zigbee/Z-Wave lenta o freda, l'ordre pot trigar segons a arribar al relé; sense aquesta opció, aquest retard es compta com a recorregut i la posició seguida s'avança a la persiana. Deixa-ho desactivat, tret que la posició es desviï en persianes el relé de les quals respon amb lentitud.",
     "recalibrate_before_position.label": "Obre del tot abans de moure's a una posició (Beta)",
     "recalibrate_before_position.helper":
       "Per a persianes sense realimentació de posició que un comandament a distància també pot moure. Obre la persiana del tot abans de cada ordre de posició, perquè el moviment parteixi d'una posició coneguda en lloc d'una estimació desviada. Duplica aproximadament el recorregut de cada moviment i, amb la inclinació durant el recorregut o la inclinació seqüencial, mou la persiana quan ajustes les lamel·les.",

--- a/custom_components/cover_time_based/manifest.json
+++ b/custom_components/cover_time_based/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/Sese-Schneider/ha-cover-time-based/issues",
   "requirements": [],
-  "version": "4.11.0"
+  "version": "4.12.0"
 }

--- a/custom_components/cover_time_based/travel_calculator.py
+++ b/custom_components/cover_time_based/travel_calculator.py
@@ -115,7 +115,12 @@ class TravelCalculator:
         self._position_confirmed = False
         self.travel_direction = TravelStatus.STOPPED
 
-    def start_travel(self, _travel_to_position: int, delay: float = 0.0) -> None:
+    def start_travel(
+        self,
+        _travel_to_position: int,
+        delay: float = 0.0,
+        base_timestamp: float | None = None,
+    ) -> None:
         """Start traveling to position.
 
         Args:
@@ -123,12 +128,20 @@ class TravelCalculator:
             delay: Seconds to wait before tracking starts. Used for
                 sequential multi-step movements where a pre-step (e.g. tilt)
                 must complete before this calculator begins progressing.
+            base_timestamp: Unix timestamp the move actually began at, instead
+                of ``time.time()``. Used for relay-feedback timing, where the
+                motor got power at the switch echo's ``last_changed`` rather
+                than when the command was queued; the Zigbee round-trip then
+                falls outside the tracked travel. A base in the past means the
+                move is already partly complete; ``delay`` is still added on
+                top (e.g. mechanical spin-up folded into the same anchor).
         """
         if self._last_known_position is None:
             self.set_position(_travel_to_position)
             return
         self.stop()
-        self._last_known_position_timestamp = time.time() + delay
+        base = time.time() if base_timestamp is None else base_timestamp
+        self._last_known_position_timestamp = base + delay
         self._travel_to_position = _travel_to_position
         self._position_confirmed = False
 

--- a/custom_components/cover_time_based/websocket_api.py
+++ b/custom_components/cover_time_based/websocket_api.py
@@ -43,6 +43,7 @@ from .cover import (
     CONF_TRAVEL_STARTUP_DELAY,
     CONF_TRAVEL_TIME_CLOSE,
     CONF_TRAVEL_TIME_OPEN,
+    CONF_WAIT_FOR_RELAY_FEEDBACK,
     CONTROL_MODE_PULSE,
     CONTROL_MODE_SWITCH,
     CONTROL_MODE_TOGGLE,
@@ -60,6 +61,7 @@ from .cover import (
     DEFAULT_RELAY_REPORTS_OFF,
     DEFAULT_REPORTS_COMMAND_NOT_ENDPOINT,
     DEFAULT_SEND_ENDPOINT_STOP,
+    DEFAULT_WAIT_FOR_RELAY_FEEDBACK,
 )
 from .helpers import resolve_entity_or_none
 
@@ -72,6 +74,7 @@ _FIELD_MAP = {
     "relay_reports_off": CONF_RELAY_REPORTS_OFF,
     "send_endpoint_stop": CONF_SEND_ENDPOINT_STOP,
     "force_endpoint_redrive": CONF_FORCE_ENDPOINT_REDRIVE,
+    "wait_for_relay_feedback": CONF_WAIT_FOR_RELAY_FEEDBACK,
     "recalibrate_before_position": CONF_RECALIBRATE_BEFORE_POSITION,
     "open_switch_entity_id": CONF_OPEN_SWITCH_ENTITY_ID,
     "close_switch_entity_id": CONF_CLOSE_SWITCH_ENTITY_ID,
@@ -235,6 +238,9 @@ async def ws_get_config(
             "force_endpoint_redrive": options.get(
                 CONF_FORCE_ENDPOINT_REDRIVE, DEFAULT_FORCE_ENDPOINT_REDRIVE
             ),
+            "wait_for_relay_feedback": options.get(
+                CONF_WAIT_FOR_RELAY_FEEDBACK, DEFAULT_WAIT_FOR_RELAY_FEEDBACK
+            ),
             "recalibrate_before_position": options.get(
                 CONF_RECALIBRATE_BEFORE_POSITION, DEFAULT_RECALIBRATE_BEFORE_POSITION
             ),
@@ -261,6 +267,7 @@ async def ws_get_config(
         vol.Optional("relay_reports_off"): vol.Any(None, bool),
         vol.Optional("send_endpoint_stop"): vol.Any(None, bool),
         vol.Optional("force_endpoint_redrive"): vol.Any(None, bool),
+        vol.Optional("wait_for_relay_feedback"): vol.Any(None, bool),
         vol.Optional("recalibrate_before_position"): vol.Any(None, bool),
         vol.Optional("open_switch_entity_id"): vol.Any(str, None),
         vol.Optional("close_switch_entity_id"): vol.Any(str, None),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ from custom_components.cover_time_based.const import (
     CONF_RECALIBRATE_BEFORE_POSITION,
     CONF_REPORTS_COMMAND_NOT_ENDPOINT,
     CONF_SEND_ENDPOINT_STOP,
+    CONF_WAIT_FOR_RELAY_FEEDBACK,
 )
 from custom_components.cover_time_based.cover import (
     CONF_CLOSE_SWITCH_ENTITY_ID,
@@ -112,6 +113,7 @@ def make_cover(make_hass, _mock_position_store):
         force_time_based_position=None,
         reports_command_not_endpoint=None,
         force_endpoint_redrive=None,
+        wait_for_relay_feedback=None,
         recalibrate_before_position=None,
         invert=None,
     ):
@@ -177,6 +179,8 @@ def make_cover(make_hass, _mock_position_store):
             options[CONF_REPORTS_COMMAND_NOT_ENDPOINT] = reports_command_not_endpoint
         if force_endpoint_redrive is not None:
             options[CONF_FORCE_ENDPOINT_REDRIVE] = force_endpoint_redrive
+        if wait_for_relay_feedback is not None:
+            options[CONF_WAIT_FOR_RELAY_FEEDBACK] = wait_for_relay_feedback
         if recalibrate_before_position is not None:
             options[CONF_RECALIBRATE_BEFORE_POSITION] = recalibrate_before_position
         if invert is not None:

--- a/tests/frontend/card_render.test.mjs
+++ b/tests/frontend/card_render.test.mjs
@@ -613,9 +613,9 @@ test("switch mode shows assumed-state toggle", async () => {
     activeTab: "device",
   });
   const toggles = card.shadowRoot.querySelectorAll("ha-switch.toggle-switch");
-  // Exactly 3 toggles: assumed-state, force-endpoint-redrive and
-  // recalibrate-before-position (switch mode has no other toggle-with-help)
-  expect(toggles.length).toBe(3);
+  // Exactly 4 toggles: assumed-state, force-endpoint-redrive,
+  // wait-for-relay-feedback (switch-mode only) and recalibrate-before-position
+  expect(toggles.length).toBe(4);
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/frontend/wait_for_relay_feedback.test.mjs
+++ b/tests/frontend/wait_for_relay_feedback.test.mjs
@@ -1,0 +1,77 @@
+/**
+ * wait_for_relay_feedback (switch-mode "wait for relay confirmation") UI.
+ *
+ * The toggle renders only in switch (latching) mode — the default — and is
+ * hidden for wrapped / pulse / toggle modes. Default off.
+ *
+ * Run: npm run test:fe -- tests/frontend/wait_for_relay_feedback.test.mjs
+ */
+
+import { test, expect, afterEach, vi } from "vitest";
+import { makeHass } from "./helpers/hass.mjs";
+import { mountCard, defineHaStubs } from "./helpers/mount.mjs";
+
+defineHaStubs();
+let card;
+afterEach(() => {
+  vi.restoreAllMocks();
+  card?.remove();
+  card = null;
+});
+
+const LABEL = "Wait for relay confirmation before tracking";
+
+const cfg = (mode, over = {}) => ({
+  control_mode: mode,
+  open_switch_entity_id: "switch.o",
+  close_switch_entity_id: "switch.c",
+  stop_switch_entity_id: "switch.s",
+  cover_entity_id: "cover.real",
+  ...over,
+});
+
+function row(card) {
+  return [...card.shadowRoot.querySelectorAll(".toggle-with-help")].find(
+    (el) => el.querySelector(".toggle-label")?.textContent.trim() === LABEL,
+  );
+}
+
+// Switch is the default mode, so an unset control_mode must render it too.
+for (const mode of ["switch", undefined]) {
+  test(`wait_for_relay_feedback toggle renders for ${mode ?? "unset"} mode`, async () => {
+    card = await mountCard(makeHass(), {
+      selectedEntity: "cover.x",
+      config: cfg(mode),
+      activeTab: "device",
+    });
+    expect(row(card)).toBeTruthy();
+  });
+}
+
+// Gated to switch mode only — hidden everywhere else.
+for (const mode of ["wrapped", "pulse", "toggle", "toggle_opposite"]) {
+  test(`wait_for_relay_feedback toggle does not render for ${mode} mode`, async () => {
+    card = await mountCard(makeHass(), {
+      selectedEntity: "cover.x",
+      config: cfg(mode),
+      activeTab: "device",
+    });
+    expect(row(card)).toBeFalsy();
+  });
+}
+
+test("toggling wait_for_relay_feedback calls _updateLocal with true", async () => {
+  card = await mountCard(makeHass(), {
+    selectedEntity: "cover.x",
+    config: cfg("switch"),
+    activeTab: "device",
+  });
+  const captured = [];
+  card._updateLocal = (u) => captured.push(u);
+
+  const toggle = row(card).querySelector("ha-switch");
+  toggle.checked = true;
+  toggle.dispatchEvent(new Event("change"));
+
+  expect(captured).toEqual([{ wait_for_relay_feedback: true }]);
+});

--- a/tests/test_cover_factory.py
+++ b/tests/test_cover_factory.py
@@ -29,6 +29,7 @@ from custom_components.cover_time_based.cover import (
     CONF_TRAVEL_TIME_OPEN,
     CONF_TRAVELLING_TIME_DOWN,
     CONF_TRAVELLING_TIME_UP,
+    CONF_WAIT_FOR_RELAY_FEEDBACK,
     CONTROL_MODE_PULSE,
     CONTROL_MODE_SWITCH,
     CONTROL_MODE_TOGGLE,
@@ -249,6 +250,31 @@ class TestCreateCoverFromOptions:
         assert cover._tilting_time_close == 5.0
         assert cover._tilting_time_open == 4.0
         assert cover._min_movement_time == 0.5
+
+    def test_wait_for_relay_feedback_from_options(self):
+        cover = _create_cover_from_options(
+            {
+                CONF_CONTROL_MODE: CONTROL_MODE_SWITCH,
+                CONF_OPEN_SWITCH_ENTITY_ID: "switch.open",
+                CONF_CLOSE_SWITCH_ENTITY_ID: "switch.close",
+                CONF_WAIT_FOR_RELAY_FEEDBACK: True,
+            },
+            device_id="myid",
+            name="My Cover",
+        )
+        assert cover._wait_for_relay_feedback is True
+
+    def test_wait_for_relay_feedback_defaults_false(self):
+        cover = _create_cover_from_options(
+            {
+                CONF_CONTROL_MODE: CONTROL_MODE_SWITCH,
+                CONF_OPEN_SWITCH_ENTITY_ID: "switch.open",
+                CONF_CLOSE_SWITCH_ENTITY_ID: "switch.close",
+            },
+            device_id="myid",
+            name="My Cover",
+        )
+        assert cover._wait_for_relay_feedback is False
 
 
 # ===================================================================

--- a/tests/test_relay_feedback.py
+++ b/tests/test_relay_feedback.py
@@ -1,0 +1,528 @@
+"""Tests for the opt-in ``wait_for_relay_feedback`` behaviour (issue #231).
+
+When enabled (switch mode only), the travel/tilt timer starts when the relay
+confirms it switched — the state-change echo — instead of the instant the
+non-blocking command is queued. The variable Zigbee round-trip then falls
+outside the tracked travel, so the calculated position no longer drifts ahead
+of the physical cover on a slow/cold mesh.
+
+These tests drive real state-change events through ``_async_switch_state_changed``
+with an injected command->echo gap, rather than forcing internal flags — the
+way past regressions in this echo-handling area slipped past CI.
+"""
+
+import asyncio
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+from homeassistant.const import SERVICE_OPEN_COVER
+
+from custom_components.cover_time_based import cover_base
+from custom_components.cover_time_based.calibration import CalibrationState
+
+# A fixed, timezone-aware moment used as the relay echo's ``last_changed``.
+FIXED_ECHO = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+
+
+def _stub_switches(cover, *, on=(), optimistic=()):
+    """Make ``hass.states.get`` deterministic for the feedback guards.
+
+    Without this the conftest MagicMock hass returns a truthy MagicMock for
+    ``attributes.get("assumed_state")``, which would read every relay as
+    optimistic. Listed entities are ON and/or optimistic; everything else is a
+    plain OFF, non-optimistic switch.
+    """
+
+    def _get(entity_id):
+        st = MagicMock()
+        st.state = "on" if entity_id in on else "off"
+        st.attributes = {"assumed_state": True} if entity_id in optimistic else {}
+        return st
+
+    cover.hass.states.get = _get
+
+
+def _echo_event(entity_id, old, new, last_changed=FIXED_ECHO):
+    """Build a switch state-change event like HA fires, with a real datetime."""
+    old_s = MagicMock()
+    old_s.state = old
+    old_s.attributes = {}
+    new_s = MagicMock()
+    new_s.state = new
+    new_s.attributes = {}
+    new_s.last_changed = last_changed
+    event = MagicMock()
+    event.data = {"entity_id": entity_id, "old_state": old_s, "new_state": new_s}
+    return event
+
+
+class TestRelayFeedbackStart:
+    """The travel timer starts on the relay echo, not the queued command."""
+
+    @pytest.mark.asyncio
+    async def test_move_parks_until_relay_echo_then_tracks_from_last_changed(
+        self, make_cover
+    ):
+        cover = make_cover(
+            wait_for_relay_feedback=True, travel_time_open=30, travel_time_close=30
+        )
+        _stub_switches(cover)
+        cover.travel_calc.set_position(0)
+        echo_time = datetime.now(UTC)
+
+        with patch.object(cover, "async_write_ha_state"):
+            await cover.async_open_cover()
+            await asyncio.sleep(0)  # let the feedback task reach its await
+
+            # Command fired, but tracking is parked: position frozen at start.
+            assert cover.travel_calc.is_traveling() is False
+            assert cover.travel_calc.current_position() == 0
+            assert cover._startup_delay_task is not None
+            assert cover._feedback_wait_entity == "switch.open"
+
+            # The relay confirms it switched on.
+            await cover._async_switch_state_changed(
+                _echo_event("switch.open", "off", "on", echo_time)
+            )
+            await asyncio.sleep(0)  # let the feedback task resume
+
+        assert cover.travel_calc.is_traveling() is True
+        # Travel is timestamped from the echo's last_changed.
+        assert cover.travel_calc._last_known_position_timestamp == echo_time.timestamp()
+        assert cover._feedback_wait_entity is None
+
+    @pytest.mark.asyncio
+    async def test_command_to_echo_gap_is_not_counted_as_travel(self, make_cover):
+        """The variable Zigbee round-trip falls outside tracked travel.
+
+        A command fired at T0 whose relay only confirms at T0+3s must track as
+        if the move began at T0+3s: at the moment of confirmation the position
+        is still at the start, not 10% (3s of a 30s travel) along.
+        """
+        cover = make_cover(
+            wait_for_relay_feedback=True, travel_time_open=30, travel_time_close=30
+        )
+        _stub_switches(cover)
+        cover.travel_calc.set_position(0)
+
+        # Relay confirmed 3s after the command was queued.
+        echo_ts = 10_000.0
+        echo_time = datetime.fromtimestamp(echo_ts, UTC)
+
+        with patch.object(cover, "async_write_ha_state"):
+            await cover.async_open_cover()
+            await asyncio.sleep(0)
+            await cover._async_switch_state_changed(
+                _echo_event("switch.open", "off", "on", echo_time)
+            )
+            await asyncio.sleep(0)
+
+        # Evaluate position exactly at the confirmation instant.
+        with patch(
+            "custom_components.cover_time_based.travel_calculator.time"
+        ) as mock_time:
+            mock_time.time.return_value = echo_ts
+            # None of the 3s command->echo gap has been counted.
+            assert cover.travel_calc.current_position() == 0
+            # 6s later, only travel since the echo counts: 6/30 = 20%.
+            mock_time.time.return_value = echo_ts + 6
+            assert cover.travel_calc.current_position() == 20
+
+    @pytest.mark.asyncio
+    async def test_partial_move_parks_until_relay_echo(self, make_cover):
+        """A mid-position move gates on the echo through the same seam."""
+        cover = make_cover(
+            wait_for_relay_feedback=True, travel_time_open=30, travel_time_close=30
+        )
+        _stub_switches(cover)
+        cover.travel_calc.set_position(0)
+        echo_time = datetime.now(UTC)
+
+        with patch.object(cover, "async_write_ha_state"):
+            await cover.async_set_cover_position(position=60)
+            await asyncio.sleep(0)
+            assert cover.travel_calc.is_traveling() is False
+            assert cover._feedback_wait_entity == "switch.open"
+
+            await cover._async_switch_state_changed(
+                _echo_event("switch.open", "off", "on", echo_time)
+            )
+            await asyncio.sleep(0)
+
+        assert cover.travel_calc.is_traveling() is True
+        assert cover.travel_calc._travel_to_position == 60
+        assert cover.travel_calc._last_known_position_timestamp == echo_time.timestamp()
+
+    @pytest.mark.asyncio
+    async def test_disabled_starts_tracking_immediately(self, make_cover):
+        """With the option off, behaviour is unchanged: tracking starts inline."""
+        cover = make_cover(
+            wait_for_relay_feedback=False, travel_time_open=30, travel_time_close=30
+        )
+        _stub_switches(cover)
+        cover.travel_calc.set_position(0)
+
+        with patch.object(cover, "async_write_ha_state"):
+            await cover.async_open_cover()
+            await asyncio.sleep(0)
+
+        assert cover.travel_calc.is_traveling() is True
+        assert cover._feedback_wait_entity is None
+        assert cover._startup_delay_task is None
+
+
+class TestRelayFeedbackTilt:
+    """Dual-motor tilt moves gate on the tilt relay's echo, same mechanism."""
+
+    def _make_dual_motor(self, make_cover):
+        return make_cover(
+            wait_for_relay_feedback=True,
+            tilt_mode="dual_motor",
+            tilt_open_switch="switch.tilt_open",
+            tilt_close_switch="switch.tilt_close",
+            tilt_time_open=3,
+            tilt_time_close=3,
+        )
+
+    @pytest.mark.asyncio
+    async def test_tilt_move_parks_until_tilt_relay_echo(self, make_cover):
+        cover = self._make_dual_motor(make_cover)
+        _stub_switches(cover)
+        cover.travel_calc.set_position(0)
+        cover.tilt_calc.set_position(0)
+        echo_time = datetime.now(UTC)
+
+        with patch.object(cover, "async_write_ha_state"):
+            await cover.async_open_cover_tilt()
+            await asyncio.sleep(0)
+
+            # Parked on the tilt relay, not travel.
+            assert cover.tilt_calc.is_traveling() is False
+            assert cover._feedback_wait_entity == "switch.tilt_open"
+            assert cover._startup_delay_task is not None
+
+            await cover._async_switch_state_changed(
+                _echo_event("switch.tilt_open", "off", "on", echo_time)
+            )
+            await asyncio.sleep(0)
+
+        assert cover.tilt_calc.is_traveling() is True
+        assert cover.tilt_calc._last_known_position_timestamp == echo_time.timestamp()
+
+
+class TestRelayFeedbackCalibration:
+    """Calibration measures from the relay echo too, so a calibrated travel
+    time is not inflated by the Zigbee round-trip it excludes at runtime."""
+
+    @pytest.mark.asyncio
+    async def test_travel_time_calibration_excludes_command_to_echo_gap(
+        self, make_cover
+    ):
+        cover = make_cover(wait_for_relay_feedback=True)
+        _stub_switches(cover)
+        cover.travel_calc.set_position(100)  # open; calibrate the close travel
+
+        clock = {"t": 1000.0}
+        fake_time = MagicMock()
+        fake_time.monotonic = lambda: clock["t"]
+        with (
+            patch(
+                "custom_components.cover_time_based.cover_calibration.time", fake_time
+            ),
+            patch.object(cover, "async_write_ha_state"),
+        ):
+            await cover.start_calibration(
+                attribute="travel_time_close", timeout=600, direction="close"
+            )
+            await asyncio.sleep(0)  # let the feedback wait arm
+            # Normalise the construction baseline to "now".
+            cover._calibration.started_at = clock["t"]
+            assert cover._feedback_wait_entity == "switch.close"
+
+            # Relay only confirms 3s later (cold mesh).
+            clock["t"] = 1003.0
+            await cover._async_switch_state_changed(
+                _echo_event("switch.close", "off", "on")
+            )
+            await asyncio.sleep(0)
+            # The timer is re-baselined to the confirmation, dropping the 3s gap.
+            assert cover._calibration.started_at == 1003.0
+
+            # 20s of real travel, then the user stops at the endpoint.
+            clock["t"] = 1023.0
+            result = await cover.stop_calibration()
+
+        assert result["value"] == 20.0
+
+    @pytest.mark.asyncio
+    async def test_time_calibration_unaffected_when_option_off(self, make_cover):
+        """With the option off, calibration times from the command as before."""
+        cover = make_cover(wait_for_relay_feedback=False)
+        _stub_switches(cover)
+        cover.travel_calc.set_position(100)
+
+        clock = {"t": 1000.0}
+        fake_time = MagicMock()
+        fake_time.monotonic = lambda: clock["t"]
+        with (
+            patch(
+                "custom_components.cover_time_based.cover_calibration.time", fake_time
+            ),
+            patch.object(cover, "async_write_ha_state"),
+        ):
+            await cover.start_calibration(
+                attribute="travel_time_close", timeout=600, direction="close"
+            )
+            await asyncio.sleep(0)
+            cover._calibration.started_at = clock["t"]
+            # No feedback wait is armed.
+            assert cover._feedback_wait_entity is None
+
+            clock["t"] = 1003.0
+            await cover._async_switch_state_changed(
+                _echo_event("switch.close", "off", "on")
+            )
+            await asyncio.sleep(0)
+            # Baseline unchanged — the whole elapsed time is counted.
+            assert cover._calibration.started_at == 1000.0
+
+            clock["t"] = 1023.0
+            result = await cover.stop_calibration()
+
+        assert result["value"] == 23.0
+
+    @pytest.mark.asyncio
+    async def test_overhead_continuous_phase_rebaselines_on_echo(self, make_cover):
+        """The startup-delay (overhead) test times its continuous phase from the
+        relay echo too, so the Zigbee gap is not measured as motor overhead."""
+        cover = make_cover(wait_for_relay_feedback=True)
+        _stub_switches(cover)
+        cover._calibration = CalibrationState(
+            attribute="travel_startup_delay", timeout=600
+        )
+        cover._calibration.continuous_start = 500.0  # command-fire baseline
+        cover._calibration.move_command = SERVICE_OPEN_COVER
+
+        clock = {"t": 1000.0}
+        fake_time = MagicMock()
+        fake_time.monotonic = lambda: clock["t"]
+        try:
+            with (
+                patch(
+                    "custom_components.cover_time_based.cover_calibration.time",
+                    fake_time,
+                ),
+                patch.object(cover, "async_write_ha_state"),
+            ):
+                # The continuous-phase drive fires the relay and arms the timing.
+                await cover._calibration_drive(SERVICE_OPEN_COVER)
+                cover._arm_calibration_feedback_timing("continuous_start")
+                await asyncio.sleep(0)
+                assert cover._feedback_wait_entity == "switch.open"
+
+                clock["t"] = 1002.0
+                await cover._async_switch_state_changed(
+                    _echo_event("switch.open", "off", "on")
+                )
+                await asyncio.sleep(0)
+
+            assert cover._calibration.continuous_start == 1002.0
+        finally:
+            cover._calibration = None
+
+
+class TestRelayFeedbackCoupled:
+    """The mechanical startup delay applies to both calcs in the feedback path,
+    as it did when it was a plain sleep wrapping the whole start."""
+
+    @pytest.mark.asyncio
+    async def test_coupled_calc_also_waits_startup_delay(self, make_cover):
+        cover = make_cover(
+            wait_for_relay_feedback=True, tilt_time_open=10, tilt_time_close=10
+        )
+        _stub_switches(cover)
+        cover.travel_calc.set_position(0)
+        cover.tilt_calc.set_position(0)
+        echo_time = datetime.now(UTC)
+
+        # Arm and mark pending as a real _send_open would.
+        cover._feedback_armed_entity = "switch.open"
+        cover._mark_switch_pending("switch.open", 1)
+
+        with patch.object(cover, "async_write_ha_state"):
+            cover._begin_movement(100, 50, cover.travel_calc, cover.tilt_calc, 2.0, 0.0)
+            await asyncio.sleep(0)
+            await cover._async_switch_state_changed(
+                _echo_event("switch.open", "off", "on", echo_time)
+            )
+            await asyncio.sleep(0)
+
+        # Both anchors are the echo plus the mechanical spin-up, so the coupled
+        # tilt tracker doesn't run ahead of the travel it is coupled to.
+        expected = echo_time.timestamp() + 2.0
+        assert cover.travel_calc._last_known_position_timestamp == expected
+        assert cover.tilt_calc._last_known_position_timestamp == expected
+
+
+class TestRelayFeedbackGuards:
+    """Every guard degrades to today's inline command-fire start."""
+
+    @pytest.mark.asyncio
+    async def test_silent_relay_times_out_to_inline_start(self, make_cover):
+        cover = make_cover(wait_for_relay_feedback=True)
+        _stub_switches(cover)
+        cover.travel_calc.set_position(0)
+
+        with (
+            patch.object(cover_base, "RELAY_FEEDBACK_TIMEOUT", 0.02),
+            patch.object(cover, "async_write_ha_state"),
+        ):
+            await cover.async_open_cover()
+            await asyncio.sleep(0)
+            assert cover.travel_calc.is_traveling() is False  # parked
+            # No echo ever arrives; the wait times out and starts inline.
+            await asyncio.sleep(0.05)
+
+        assert cover.travel_calc.is_traveling() is True
+        assert cover._feedback_wait_entity is None
+        assert cover._startup_delay_task is None
+
+    @pytest.mark.asyncio
+    async def test_optimistic_switch_starts_inline(self, make_cover):
+        cover = make_cover(wait_for_relay_feedback=True)
+        _stub_switches(cover, optimistic=("switch.open",))
+        cover.travel_calc.set_position(0)
+
+        with patch.object(cover, "async_write_ha_state"):
+            await cover.async_open_cover()
+            await asyncio.sleep(0)
+
+        # Optimistic switch confirms nothing — do not wait on its echo.
+        assert cover.travel_calc.is_traveling() is True
+        assert cover._feedback_wait_entity is None
+
+    @pytest.mark.asyncio
+    async def test_suppress_redrive_ignores_stale_feedback_arm(self, make_cover):
+        """A move that reaches _begin_movement without a _send_* (a forced
+        redrive) must not inherit an arm left by an earlier resync."""
+        cover = make_cover(wait_for_relay_feedback=True)
+        _stub_switches(cover)
+        cover.travel_calc.set_position(0)
+        # Leftover arm as an endpoint resync would strand it.
+        cover._feedback_armed_entity = "switch.open"
+
+        with patch.object(cover, "async_write_ha_state"):
+            await cover._async_move_to_endpoint(100, suppress_start_command=True)
+            await asyncio.sleep(0)
+
+        # Cleared at funnel entry; the redrive tracks inline, not parked.
+        assert cover.travel_calc.is_traveling() is True
+        assert cover._feedback_wait_entity is None
+
+    @pytest.mark.asyncio
+    async def test_direction_relay_already_on_starts_inline(self, make_cover):
+        cover = make_cover(wait_for_relay_feedback=True)
+        _stub_switches(cover, on=("switch.open",))
+        cover.travel_calc.set_position(0)
+
+        with patch.object(cover, "async_write_ha_state"):
+            await cover.async_open_cover()
+            await asyncio.sleep(0)
+
+        # Relay already energized: the motor is already running, so waiting for
+        # an ON echo that will never come would be wrong.
+        assert cover.travel_calc.is_traveling() is True
+        assert cover._feedback_wait_entity is None
+
+    @pytest.mark.asyncio
+    async def test_external_press_starts_inline(self, make_cover):
+        """An external press already switched the relay — nothing to wait for."""
+        cover = make_cover(wait_for_relay_feedback=True)
+        _stub_switches(cover)
+        cover.travel_calc.set_position(0)
+
+        with patch.object(cover, "async_write_ha_state"):
+            # Genuine external open (no pending self-echo) through the listener.
+            await cover._async_switch_state_changed(
+                _echo_event("switch.open", "off", "on")
+            )
+            await asyncio.sleep(0)
+
+        assert cover._last_command is not None
+        assert cover.travel_calc.is_traveling() is True
+        assert cover._feedback_wait_entity is None
+
+    @pytest.mark.asyncio
+    async def test_reverse_during_wait_cancels_wait_and_stops(self, make_cover):
+        cover = make_cover(wait_for_relay_feedback=True)
+        _stub_switches(cover)
+        cover.travel_calc.set_position(50)
+
+        with patch.object(cover, "async_write_ha_state"):
+            await cover.async_open_cover()
+            await asyncio.sleep(0)
+            assert cover._startup_delay_task is not None  # parked, waiting
+
+            cover.hass.services.async_call.reset_mock()
+            await cover.async_close_cover()  # reverse before the echo lands
+            await asyncio.sleep(0)
+
+        # The parked open is abandoned and the motor stopped; no tracking begins.
+        assert cover._feedback_wait_entity is None
+        assert cover.travel_calc.is_traveling() is False
+        assert cover._last_command is None
+        # A STOP (turn_off both relays) was sent for the reversal.
+        sent = [c.args for c in cover.hass.services.async_call.call_args_list]
+        assert (
+            "homeassistant",
+            "turn_off",
+            {"entity_id": "switch.open"},
+            False,
+        ) in sent
+
+    @pytest.mark.asyncio
+    async def test_stop_during_wait_cancels_wait(self, make_cover):
+        cover = make_cover(wait_for_relay_feedback=True)
+        _stub_switches(cover)
+        cover.travel_calc.set_position(0)
+
+        with patch.object(cover, "async_write_ha_state"):
+            await cover.async_open_cover()
+            await asyncio.sleep(0)
+            assert cover._startup_delay_task is not None
+
+            await cover.async_stop_cover()
+            await asyncio.sleep(0)
+
+        assert cover._startup_delay_task is None
+        assert cover._feedback_wait_entity is None
+        assert cover.travel_calc.is_traveling() is False
+
+    @pytest.mark.asyncio
+    async def test_armed_relay_gets_extended_pending_window(self, make_cover):
+        """The awaited relay's echo stays classifiable as our own for the whole
+        feedback wait — so its pending window is the longer feedback timeout."""
+        cover = make_cover(wait_for_relay_feedback=True)
+        _stub_switches(cover)
+        cover.travel_calc.set_position(0)
+
+        with (
+            patch.object(
+                cover, "_mark_switch_pending", wraps=cover._mark_switch_pending
+            ) as spy,
+            patch.object(cover, "async_write_ha_state"),
+        ):
+            await cover.async_open_cover()
+            await asyncio.sleep(0)
+
+        open_calls = [c for c in spy.call_args_list if c.args[0] == "switch.open"]
+        assert open_calls, "open relay should have been marked pending"
+        assert (
+            open_calls[0].kwargs.get("timeout")
+            == cover_base.RELAY_FEEDBACK_PENDING_TIMEOUT
+        )
+        assert (
+            cover_base.RELAY_FEEDBACK_PENDING_TIMEOUT
+            > cover_base.RELAY_FEEDBACK_TIMEOUT
+        )

--- a/tests/test_travel_calculator.py
+++ b/tests/test_travel_calculator.py
@@ -108,3 +108,31 @@ class TestTravelCalculatorEdgeCases:
             mock_time.time.return_value = 1020.0
             pos = calc.current_position()
             assert pos == 100
+
+    def test_start_travel_base_timestamp_in_past_advances_position(self):
+        """start_travel(base_timestamp=...) anchors the move's start at that
+        timestamp instead of 'now'. A base already in the past means travel
+        that began then is already partly complete — this is how relay-feedback
+        timing starts tracking from the switch echo's last_changed."""
+        calc = TravelCalculator(travel_time_down=30, travel_time_up=30)
+        calc.set_position(0)
+        with patch(
+            "custom_components.cover_time_based.travel_calculator.time"
+        ) as mock_time:
+            mock_time.time.return_value = 1000.0
+            # Motor actually got power 15s ago — half of the 30s open travel.
+            calc.start_travel(100, base_timestamp=985.0)
+            assert calc.current_position() == 50
+
+    def test_start_travel_base_timestamp_in_future_holds_position(self):
+        """A base_timestamp in the future holds the start position until real
+        time reaches it (the fixed startup delay is folded in this way)."""
+        calc = TravelCalculator(travel_time_down=30, travel_time_up=30)
+        calc.set_position(0)
+        with patch(
+            "custom_components.cover_time_based.travel_calculator.time"
+        ) as mock_time:
+            mock_time.time.return_value = 1000.0
+            # Base 5s in the future: no progress yet.
+            calc.start_travel(100, base_timestamp=1005.0)
+            assert calc.current_position() == 0

--- a/tests/test_websocket_api.py
+++ b/tests/test_websocket_api.py
@@ -30,6 +30,7 @@ from custom_components.cover_time_based.cover import (
     CONF_TRAVEL_STARTUP_DELAY,
     CONF_TRAVEL_TIME_CLOSE,
     CONF_TRAVEL_TIME_OPEN,
+    CONF_WAIT_FOR_RELAY_FEEDBACK,
     CONTROL_MODE_PULSE,
     CONTROL_MODE_SWITCH,
     CONTROL_MODE_TOGGLE,
@@ -2594,6 +2595,97 @@ class TestForceEndpointRedriveRoundTrip:
             }
         )
         assert validated["force_endpoint_redrive"] is True
+
+
+class TestWaitForRelayFeedbackRoundTrip:
+    """wait_for_relay_feedback is returned in get_config and saved in update_config."""
+
+    @pytest.mark.asyncio
+    async def test_get_config_defaults_to_false(self):
+        hass, _, entity_reg = _make_hass(options={})
+        conn = _make_connection()
+
+        with patch(
+            "custom_components.cover_time_based.websocket_api.er.async_get",
+            return_value=entity_reg,
+        ):
+            await _ws_get_config(
+                hass,
+                conn,
+                {
+                    "id": 1,
+                    "type": "cover_time_based/get_config",
+                    "entity_id": ENTITY_ID,
+                },
+            )
+
+        result = conn.send_result.call_args[0][1]
+        assert result["wait_for_relay_feedback"] is False
+
+    @pytest.mark.asyncio
+    async def test_get_config_returns_stored_true(self):
+        hass, _, entity_reg = _make_hass(options={CONF_WAIT_FOR_RELAY_FEEDBACK: True})
+        conn = _make_connection()
+
+        with patch(
+            "custom_components.cover_time_based.websocket_api.er.async_get",
+            return_value=entity_reg,
+        ):
+            await _ws_get_config(
+                hass,
+                conn,
+                {
+                    "id": 1,
+                    "type": "cover_time_based/get_config",
+                    "entity_id": ENTITY_ID,
+                },
+            )
+
+        result = conn.send_result.call_args[0][1]
+        assert result["wait_for_relay_feedback"] is True
+
+    @pytest.mark.asyncio
+    async def test_update_config_saves_true(self):
+        hass, _, entity_reg = _make_hass(options={})
+        conn = _make_connection()
+
+        with patch(
+            "custom_components.cover_time_based.websocket_api.er.async_get",
+            return_value=entity_reg,
+        ):
+            await _ws_update_config(
+                hass,
+                conn,
+                {
+                    "id": 1,
+                    "type": "cover_time_based/update_config",
+                    "entity_id": ENTITY_ID,
+                    "wait_for_relay_feedback": True,
+                },
+            )
+
+        new_options = hass.config_entries.async_update_entry.call_args[1]["options"]
+        assert new_options[CONF_WAIT_FOR_RELAY_FEEDBACK] is True
+
+    def test_field_map_contains_wait_for_relay_feedback(self):
+        from custom_components.cover_time_based.websocket_api import _FIELD_MAP
+
+        assert _FIELD_MAP["wait_for_relay_feedback"] == CONF_WAIT_FOR_RELAY_FEEDBACK
+
+    def test_update_schema_accepts_wait_for_relay_feedback(self):
+        # Guards the schema/_FIELD_MAP pair: a real websocket update_config
+        # carrying `wait_for_relay_feedback` must validate, else persistence
+        # is silently rejected.
+        schema = ws_update_config._ws_schema
+        validated = schema(
+            {
+                "id": 1,
+                "type": "cover_time_based/update_config",
+                "entity_id": "cover.x",
+                "wait_for_relay_feedback": True,
+            }
+        )
+        assert validated["wait_for_relay_feedback"] is True
 
 
 class TestDirectionChangeDelayRemoved:


### PR DESCRIPTION
Closes #231.

## Problem

Position tracking drifts out of sync whenever the relay command is delayed. The travel timer starts the instant the non-blocking `homeassistant.turn_on/off` call is queued, but the physical cover only starts moving when the ZCL command actually reaches the relay. On a cold/idle Zigbee mesh that round-trip can take several seconds (the reporter saw up to 5s), and all of it is counted as travel the motor never spent moving — so the tracked position runs ahead of the real cover and only resyncs when driven to a fully-open/closed endpoint.

`travel_startup_delay` can't absorb this: it's one fixed constant describing the motor's mechanical spin-up, while the delay here is variable (0–5s on the same hardware).

## Solution

A new per-cover, **switch-mode-only**, opt-in boolean **`wait_for_relay_feedback`** (default off). When enabled, a move defers starting its position timer until the driving relay's **ON state-change echo** arrives — the same echo the code already receives and currently discards as its own — and timestamps travel from the echo's `last_changed`. The Zigbee round-trip then falls outside tracked travel, and `travel_startup_delay` goes back to meaning only mechanical spin-up, applied on top.

**Calibration honours the same signal**: a travel/tilt *time* (and the startup-delay *overhead* test's continuous phase) measured with the option on re-baselines on the relay echo, so a calibrated time isn't inflated by the round-trip either — keeping calibration consistent with runtime.

### Design

Modelled as a *feedback-driven variant of the existing startup-delay deferral*: the echo-wait runs as `_startup_delay_task` (awaiting a future resolved by the echo, with a timeout, instead of a fixed sleep). So `_movement_started`, the reverse/same-direction conflict blocks, `_cancel_startup_delay_task`, and `async_stop_cover` cancellation all treat it identically — no new bespoke lifecycle machinery in this fragile area.

### Guards — every one falls back to today's inline (command-fire) start

- option off · optimistic underlying switch (its own `assumed_state`) · direction relay already on · external trigger · echo timeout (silent relay)

The awaited relay's pending-echo safety window is widened above the wait timeout so a slow confirmation is still filtered as our own rather than reclassified as an external press.

Applies to travel and tilt moves (endpoint and partial), switch mode only.

## Testing

- New `tests/test_relay_feedback.py` (17 tests) drives **real state-change events** through `_async_switch_state_changed` with an injected command→echo gap — not by forcing internal flags — covering: start-on-echo, `last_changed` timestamping, the command→echo gap excluded, partial + dual-motor-tilt moves, every guard, reverse/stop-during-wait cancellation, a stale-arm regression, coupled-calc startup-delay, and travel-time + overhead calibration re-baseline.
- Frontend: new `wait_for_relay_feedback.test.mjs` (switch-mode-gated toggle render + save).
- Full suite green (Python + frontend), ruff/prettier/eslint clean, pre-push gates pass.

Developed TDD throughout, then put through an adversarial correctness review (one bug found + fixed — the coupled tilt calc wasn't receiving the mechanical startup delay) and a four-lens simplification pass (arm/mark duplication factored out).

> Note: this branch also carries the `4.12.0` development version bump, since upstream `main` is still at the `4.11.0` release commit.