### PR TITLE
chore: release v4.12.0-rc.1

### DIFF
--- a/custom_components/cover_time_based/manifest.json
+++ b/custom_components/cover_time_based/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/Sese-Schneider/ha-cover-time-based/issues",
   "requirements": [],
-  "version": "4.12.0"
+  "version": "4.12.0-rc.1"
 }


### PR DESCRIPTION
Release `v4.12.0-rc.1`: bumps the manifest version to `4.12.0-rc.1`.

After merge, push the tag to publish the GitHub Release:

```
git tag v4.12.0-rc.1
git push origin v4.12.0-rc.1
```

The release workflow publishes the GitHub Release. Roll `main` forward to the
next minor for development separately, via bin/bump-dev.sh.
