### PR TITLE
feat: debug-log tracker anchor changes to diagnose out-of-sync jumps (#231)

### DIFF
--- a/custom_components/cover_time_based/cover_base.py
+++ b/custom_components/cover_time_based/cover_base.py
@@ -228,11 +228,13 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         self.travel_calc = TravelCalculator(
             self._travel_time_close,
             self._travel_time_open,
+            name="travel",
         )
         if self._tilting_time_close is not None and self._tilting_time_open is not None:
             self.tilt_calc = TravelCalculator(
                 self._tilting_time_close,
                 self._tilting_time_open,
+                name="tilt",
             )
 
     def _log(self, msg, *args):
@@ -2501,6 +2503,17 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         """
 
         def start(base_timestamp=None, extra_delay=0.0):
+            self._log(
+                "_begin_movement.start :: target=%d from=%s coupled=%s base_ts=%s "
+                "extra_delay=%s self_initiated=%s external=%s",
+                target,
+                primary_calc.current_position(),
+                coupled_target,
+                base_timestamp,
+                extra_delay,
+                self._self_initiated_movement,
+                self._triggered_externally,
+            )
             primary_calc.start_travel(
                 target,
                 delay=pre_step_delay + extra_delay,
@@ -3763,6 +3776,19 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         """
         try:
             base_ts = await self._wait_for_relay_echo(entity_id, RELAY_FEEDBACK_TIMEOUT)
+            if base_ts is not None:
+                self._log(
+                    "_execute_with_relay_feedback :: %s confirmed (base_ts=%s)"
+                    " -> starting tracking",
+                    entity_id,
+                    base_ts,
+                )
+            else:
+                self._log(
+                    "_execute_with_relay_feedback :: %s did NOT confirm within"
+                    " timeout -> command-fire start",
+                    entity_id,
+                )
             start_callback(base_timestamp=base_ts, extra_delay=startup_delay or 0.0)
             self._startup_delay_task = None
         except asyncio.CancelledError:
@@ -3900,6 +3926,20 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
                 entity_id,
             )
             return
+        # Not our own echo, not stale: a genuine external transition. Logged
+        # with the live position because these are what re-drive tracking mid
+        # move (e.g. a flaky relay's spurious off/on), the prime suspect for an
+        # out-of-sync jump on a slow mesh (issue #231).
+        self._log(
+            "_async_switch_state_changed :: EXTERNAL %s %s->%s (pos=%s, "
+            "traveling=%s, self_initiated=%s) -> dispatching",
+            entity_id,
+            old_val,
+            new_val,
+            self.travel_calc.current_position(),
+            self.travel_calc.is_traveling(),
+            self._self_initiated_movement,
+        )
         self._triggered_externally = True
         try:
             if is_tilt:

--- a/custom_components/cover_time_based/travel_calculator.py
+++ b/custom_components/cover_time_based/travel_calculator.py
@@ -11,8 +11,11 @@ Home Assistant's cover position convention (0=closed, 100=open).
 
 from __future__ import annotations
 
+import logging
 import time
 from enum import Enum
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class TravelStatus(Enum):
@@ -32,6 +35,7 @@ class TravelCalculator:
     __slots__ = (
         "_last_known_position",
         "_last_known_position_timestamp",
+        "_name",
         "_position_confirmed",
         "_travel_to_position",
         "position_closed",
@@ -41,13 +45,18 @@ class TravelCalculator:
         "travel_time_up",
     )
 
-    def __init__(self, travel_time_down: float, travel_time_up: float) -> None:
+    def __init__(
+        self, travel_time_down: float, travel_time_up: float, name: str = ""
+    ) -> None:
         """Initialize TravelCalculator.
 
         Args:
             travel_time_down: Time in seconds to travel from open to closed.
             travel_time_up: Time in seconds to travel from closed to open.
+            name: Label used only in debug logs to tell the travel and tilt
+                calculators apart (issue #231 diagnostics).
         """
+        self._name = name
         self.travel_direction = TravelStatus.STOPPED
         self.travel_time_down = travel_time_down
         self.travel_time_up = travel_time_up
@@ -61,6 +70,27 @@ class TravelCalculator:
         self.position_closed: int = 0
         self.position_open: int = 100
 
+    def _log_state(self, action: str) -> None:
+        """Debug-log an anchor mutation so the position timeline is traceable.
+
+        The tracked position is derived entirely from ``_last_known_position``,
+        ``_travel_to_position`` and ``_last_known_position_timestamp``; logging
+        every change to them makes an out-of-sync jump (e.g. the anchor snapping
+        back to an earlier position, issue #231) visible in the log.
+        """
+        if not _LOGGER.isEnabledFor(logging.DEBUG):
+            return
+        _LOGGER.debug(
+            "TravelCalculator[%s] %s :: known=%s target=%s ts=%.3f confirmed=%s dir=%s",
+            self._name,
+            action,
+            self._last_known_position,
+            self._travel_to_position,
+            self._last_known_position_timestamp,
+            self._position_confirmed,
+            self.travel_direction.name,
+        )
+
     def set_position(self, position: int) -> None:
         """Set position and target of cover."""
         self._travel_to_position = position
@@ -72,6 +102,7 @@ class TravelCalculator:
         self._last_known_position_timestamp = time.time()
         if position == self._travel_to_position:
             self._position_confirmed = True
+        self._log_state("update_position")
 
     def clear_position(self) -> None:
         """Clear position to unknown (e.g. after external movement)."""
@@ -79,6 +110,7 @@ class TravelCalculator:
         self._travel_to_position = None
         self._position_confirmed = False
         self.travel_direction = TravelStatus.STOPPED
+        self._log_state("clear_position")
 
     def snapshot(self) -> tuple:
         """Capture the mutable tracker state for exception-safe rollback.
@@ -104,6 +136,7 @@ class TravelCalculator:
             self._travel_to_position,
             self.travel_direction,
         ) = snapshot
+        self._log_state("restore")
 
     def stop(self) -> None:
         """Stop traveling."""
@@ -114,6 +147,7 @@ class TravelCalculator:
         self._travel_to_position = stop_position
         self._position_confirmed = False
         self.travel_direction = TravelStatus.STOPPED
+        self._log_state("stop")
 
     def start_travel(
         self,
@@ -150,6 +184,7 @@ class TravelCalculator:
             if _travel_to_position > self._last_known_position
             else TravelStatus.DIRECTION_DOWN
         )
+        self._log_state(f"start_travel(target={_travel_to_position}, delay={delay})")
 
     def start_travel_up(self) -> None:
         """Start traveling up (opening)."""


### PR DESCRIPTION
Diagnostic instrumentation for the rc2 report on #231 (a slow-mesh user seeing the tracked position jump back to an earlier value on a second move after the cover stops short).

## Why

The tracked position derives entirely from the travel calculator's anchor (`_last_known_position` / `_travel_to_position` / `_last_known_position_timestamp`). An out-of-sync **jump back to an earlier position** means that anchor was reset — but nothing in the normal move path does that. Reproduction of the clean path (move → echo → track; short-stop → re-command → echo → track) is smooth in both switch and toggle mode, and simple bad-mesh events (a spurious relay off/on) only re-anchor *forward*. So the trigger is a mesh-timing / echo-ordering interaction that isn't locally reproducible — it needs a real debug log from the affected device.

## What this adds (debug level only, gated, no behaviour change)

- **`TravelCalculator`** logs every anchor mutation — `set_position` / `update_position` / `start_travel` / `stop` / `restore` / `clear_position` — with the resulting `known` / `target` / `ts` / `confirmed` / `direction`, and a `name` ("travel" vs "tilt") so the two calculators are distinguishable. A reset of `known` back to the old value will be right there in the log, with the action that caused it.
- **`cover_base`** logs:
  - each tracking (re)start (`_begin_movement.start`) with its origin — `self_initiated` vs `external`, the base timestamp, from-position;
  - the relay-feedback confirm-vs-timeout outcome (`_execute_with_relay_feedback`);
  - every genuine external state transition (`EXTERNAL … -> dispatching`) with the live position — the prime suspect for a mid-move re-drive on a flaky relay.

Together these give a per-event timeline that pins which code path moves the anchor.

## Sample (from a local harness)

```
_execute_with_relay_feedback :: switch.open confirmed (base_ts=1009.0) -> starting tracking
_begin_movement.start :: target=100 from=30 base_ts=1009.0 self_initiated=True external=False
TravelCalculator[travel] start_travel(target=100, delay=0.0) :: known=30 target=100 ts=1009.000 dir=DIRECTION_UP
```

Full Python + frontend suites green, ruff/prettier/eslint clean, pre-push gates pass.