### PR TITLE
docs: refresh debug-logging steps for renamed HA UI + point issue links upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ HA's cover entity exposes close/open for travel and close-tilt/open-tilt for art
 - **External close** (physical switch or automation firing the close relay): the integration assumes the motor runs the **full journey** — it closes the cover and then continues to articulate the slats past cover-closed to the opposite extreme. Tracking follows both phases.
 - **External open**: the integration restores slats to the resting position and then travels to fully open (same as the HA UI open path).
 
-**External-switch assumption.** External close on sequential modes assumes a motor controller that latches on a pulse and runs to a mechanical end without stopping at the cover-closed position (common with pulse-mode relays and many off-the-shelf blind motors). If your external switch stops the motor at cover-closed instead — for example a latching switch that you release partway, or a motor that naturally halts at travel=0 — the reported tilt position will drift until the next sync. Please [open an issue](https://github.com/clintongormley/ha-cover-time-based/issues) describing your hardware so we can support it.
+**External-switch assumption.** External close on sequential modes assumes a motor controller that latches on a pulse and runs to a mechanical end without stopping at the cover-closed position (common with pulse-mode relays and many off-the-shelf blind motors). If your external switch stops the motor at cover-closed instead — for example a latching switch that you release partway, or a motor that naturally halts at travel=0 — the reported tilt position will drift until the next sync. Please [open an issue](https://github.com/Sese-Schneider/ha-cover-time-based/issues) describing your hardware so we can support it.
 
 ### Tilt Motor
 
@@ -389,7 +389,7 @@ Restart Home Assistant to apply.
 
 ## Reporting Issues
 
-If you encounter a bug or have a feature request, please open an issue on [GitHub](https://github.com/clintongormley/ha-cover-time-based/issues). Include debug logs if possible — they help diagnose problems much faster.
+If you encounter a bug or have a feature request, please open an issue on [GitHub](https://github.com/Sese-Schneider/ha-cover-time-based/issues). Include debug logs if possible — they help diagnose problems much faster.
 
 ## YAML configuration (deprecated)
 

--- a/README.md
+++ b/README.md
@@ -357,10 +357,10 @@ Stop an active calibration test and save the result.
 
 If something isn't working as expected, you can enable debug logging to see detailed information about what the integration is doing.
 
-### Via Developer Tools
+### Via Tools
 
-1. Go to **Developer Tools → Actions**.
-2. Search for **Logger: Set level** and select it.
+1. Go to **Tools → Actions**.
+2. Search for **Logger: Set logger level** and select it.
 3. Switch to YAML mode and enter:
 
 ```yaml


### PR DESCRIPTION
## What

Refresh the README's debug-logging steps for current Home Assistant terminology, and point the "open an issue" links at the canonical upstream repo.

### Renamed HA UI (Debugging section)

Verified against a running **HA 2026.8.2** instance (frontend + backend catalogues):

| Old (README) | New | Source of truth |
| --- | --- | --- |
| `### Via Developer Tools` | `### Via Tools` | frontend nav route `ui.components.navigation-picker.route.tools` = "Tools" |
| `Developer Tools → Actions` | `Tools → Actions` | same |
| `Logger: Set level` | `Logger: Set logger level` | backend `logger` `services.set_level.name` = "Set logger level" |

The **Actions** tab and the **Perform action** button were checked and are already correct in current HA, so they were left unchanged.

### Issue links → upstream

Both "open an issue" links in the README targeted the `clintongormley` fork. The `manifest.json` `issue_tracker` and every README badge already point to `Sese-Schneider`, so the issue links now do too.

## Testing

Documentation-only change. Terminology verified against the live HA 2026.8.2 frontend translation bundle and backend `strings.json` in a running container.
