### PR TITLE
chore: release v4.12.0-rc.5

### DIFF
--- a/custom_components/cover_time_based/manifest.json
+++ b/custom_components/cover_time_based/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/Sese-Schneider/ha-cover-time-based/issues",
   "requirements": [],
-  "version": "4.12.0-rc.4"
+  "version": "4.12.0-rc.5"
 }


### PR DESCRIPTION
Release `v4.12.0-rc.5`: bumps the manifest version to `4.12.0-rc.5`.

After merge, push the tag to publish the GitHub Release:

```
git tag v4.12.0-rc.5
git push origin v4.12.0-rc.5
```

The release workflow publishes the GitHub Release. Roll `main` forward to the
next minor for development separately, via bin/bump-dev.sh.
