### PR TITLE
fix: require an admin user for the card's websocket commands and calibration actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - **Serbian — Latin (`sr-Latn`) translation added.**
 - **Added a "Single button (cycling)" control mode** ([#245](https://github.com/Sese-Schneider/ha-cover-time-based/issues/245)) for motors with one control input, where each press cycles down → stop → up → stop. Also adds a `cover_time_based.resync` action, now available in every control mode.
 
+### Fixes
+
+- **The configuration card's backend websocket commands and the `start_calibration` / `stop_calibration` actions now require an administrator account**: they accepted any authenticated user, including read-only ones, and now return `unauthorized` for non-administrators, matching how Home Assistant itself gates configuration changes.
+
 ## 4.11.0 (2026-08-04)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ detail.
 ## The configuration card
 
 The configuration card is a visual interface for every setting, and it can
-measure your cover's timings for you. It has two tabs, **Device** and
+measure your cover's timings for you. You need an administrator account to use
+it; for anyone else its commands are rejected. It has two tabs, **Device** and
 **Calibration**; fill in the Device tab first, as the Calibration tab depends on
 it. The card remembers the last cover you were working on and reselects it next
 time the dashboard loads. (That memory is kept per browser rather than per Home

--- a/custom_components/cover_time_based/cover.py
+++ b/custom_components/cover_time_based/cover.py
@@ -15,6 +15,7 @@ from homeassistant.const import (
     CONF_NAME,
 )
 from homeassistant.core import HomeAssistant, SupportsResponse
+from homeassistant.exceptions import Unauthorized, UnknownUser
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
@@ -555,6 +556,27 @@ async def async_setup_entry(
     _register_services(platform)
 
 
+def _admin_only(hass, handler):
+    """Wrap a service handler so only an administrator reaches it.
+
+    An internal call carries no user and passes straight through, matching HA's
+    own ``async_register_admin_service`` — which cannot be used here because on
+    our minimum supported HA it has no ``supports_response`` parameter, and
+    stop_calibration returns a response.
+    """
+
+    async def wrapped(call):
+        if call.context.user_id:
+            user = await hass.auth.async_get_user(call.context.user_id)
+            if user is None:
+                raise UnknownUser(context=call.context)
+            if not user.is_admin:
+                raise Unauthorized(context=call.context)
+        return await handler(call)
+
+    return wrapped
+
+
 def _register_services(platform):
     """Register entity services on the given platform."""
     platform.async_register_entity_service(
@@ -569,6 +591,10 @@ def _register_services(platform):
 
     hass = platform.hass
 
+    # The calibration services drive relays and rewrite the config entry's
+    # options, so both go through _admin_only, like the websocket commands. The
+    # entity services above get their permission check from HA's entity-service
+    # machinery; these plain services would have none.
     if not hass.services.has_service(DOMAIN, SERVICE_START_CALIBRATION):
 
         async def _handle_start_calibration(call):
@@ -580,7 +606,7 @@ def _register_services(platform):
         hass.services.async_register(
             DOMAIN,
             SERVICE_START_CALIBRATION,
-            _handle_start_calibration,
+            _admin_only(hass, _handle_start_calibration),
             schema=vol.Schema(
                 {
                     vol.Required("entity_id"): cv.entity_id,
@@ -604,7 +630,7 @@ def _register_services(platform):
         hass.services.async_register(
             DOMAIN,
             SERVICE_STOP_CALIBRATION,
-            _handle_stop_calibration,
+            _admin_only(hass, _handle_stop_calibration),
             schema=vol.Schema(
                 {
                     vol.Required("entity_id"): cv.entity_id,

--- a/custom_components/cover_time_based/frontend/cover-time-based-card.js
+++ b/custom_components/cover_time_based/frontend/cover-time-based-card.js
@@ -338,12 +338,19 @@ class CoverTimeBasedCard extends LitElement {
       this._config = null;
       // Only a genuinely unconfigured entity (the backend's ws_get_config
       // sends error code "not_found" when the entity has no config entry —
-      // see websocket_api.py) warrants the YAML-migration lecture. Any other
-      // failure (a dropped connection, a transient server error, ...) is
-      // unrelated to YAML config and should say so generically instead of
-      // sending the user off on a wild goose chase to "migrate" an entity
-      // that is already fine.
-      this._loadError = this._t(err?.code === "not_found" ? "yaml_warning" : "load_failed");
+      // see websocket_api.py) warrants the YAML-migration lecture, and only a
+      // non-administrator gets "unauthorized" from the backend's require_admin,
+      // for whom "try again" would never succeed. Any other failure (a dropped
+      // connection, a transient server error, ...) is unrelated to YAML config
+      // and should say so generically instead of sending the user off on a wild
+      // goose chase to "migrate" an entity that is already fine.
+      const messageKey = { not_found: "yaml_warning", unauthorized: "admin_required" };
+      const code = err?.code;
+      this._loadError = this._t(
+        // hasOwn, not a bare lookup: a code like "constructor" would otherwise
+        // resolve to an inherited Object.prototype member.
+        Object.hasOwn(messageKey, code) ? messageKey[code] : "load_failed",
+      );
     } finally {
       // Only the newest request owns the spinner: an older one must not clear
       // it while a newer load is still running, but a request that was merely

--- a/custom_components/cover_time_based/frontend/translations.js
+++ b/custom_components/cover_time_based/frontend/translations.js
@@ -8,6 +8,8 @@ export const EN = {
   yaml_warning:
     "This entity uses YAML configuration and cannot be configured from this card. Please migrate to the UI: Settings \u2192 Devices & Services \u2192 Helpers \u2192 Create Helper \u2192 Cover Time Based.",
   load_failed: "Failed to load configuration. Please try again.",
+  admin_required:
+    "This card needs an administrator account. Sign in as an administrator to configure covers.",
   "tabs.device": "Device",
   "tabs.calibration": "Calibration",
   "control_mode.label": "Control Mode",
@@ -179,6 +181,8 @@ export const TRANSLATIONS = {
     yaml_warning:
       "Esta entidade utiliza configuração YAML e não pode ser configurada a partir deste cartão. Por favor, migre para a interface gráfica: Definições > Dispositivos e Serviços > Auxiliares > Criar Auxiliar > Estore Baseado em Tempo.",
     load_failed: "Falha ao carregar a configuração. Por favor, tente novamente.",
+    admin_required:
+      "Este cartão requer uma conta de administrador. Inicie sessão como administrador para configurar estores.",
     "tabs.device": "Dispositivo",
     "tabs.calibration": "Calibração",
     "control_mode.label": "Modo de Controlo",
@@ -350,6 +354,8 @@ export const TRANSLATIONS = {
     yaml_warning:
       "Ta encja używa konfiguracji YAML i nie może być konfigurowana z tej karty. Proszę przeprowadzić migrację do interfejsu użytkownika: Ustawienia > Urządzenia i usługi > Pomocniki > Utwórz pomocnik > Roleta sterowana czasowo.",
     load_failed: "Nie udało się załadować konfiguracji. Spróbuj ponownie.",
+    admin_required:
+      "Ta karta wymaga konta administratora. Zaloguj się jako administrator, aby skonfigurować rolety.",
     "tabs.device": "Urządzenie",
     "tabs.calibration": "Kalibracja",
     "control_mode.label": "Tryb sterowania",
@@ -521,6 +527,8 @@ export const TRANSLATIONS = {
     yaml_warning:
       "Diese Entität verwendet eine YAML-Konfiguration und kann nicht über diese Karte konfiguriert werden. Bitte migriere sie auf die Benutzeroberfläche: Einstellungen → Geräte & Dienste → Helfer → Helfer erstellen → Cover Time Based.",
     load_failed: "Laden der Konfiguration fehlgeschlagen. Bitte versuche es erneut.",
+    admin_required:
+      "Diese Karte benötigt ein Administratorkonto. Melde dich als Administrator an, um Rollläden zu konfigurieren.",
     "tabs.device": "Gerät",
     "tabs.calibration": "Kalibrierung",
     "control_mode.label": "Steuerungsmodus",
@@ -696,6 +704,8 @@ export const TRANSLATIONS = {
     yaml_warning:
       "Questa entità utilizza la configurazione YAML e non può essere configurata da questa scheda. Esegui la migrazione all'interfaccia utente: Impostazioni → Dispositivi e servizi → Helper → Crea helper → Cover Time Based.",
     load_failed: "Caricamento della configurazione non riuscito. Riprova.",
+    admin_required:
+      "Questa scheda richiede un account amministratore. Accedi come amministratore per configurare le tapparelle.",
     "tabs.device": "Dispositivo",
     "tabs.calibration": "Calibrazione",
     "control_mode.label": "Modalità di controllo",
@@ -867,6 +877,8 @@ export const TRANSLATIONS = {
     yaml_warning:
       "Deze entiteit gebruikt YAML-configuratie en kan niet vanuit deze kaart worden geconfigureerd. Migreer naar de gebruikersinterface: Instellingen → Apparaten en diensten → Helpers → Helper aanmaken → Cover Time Based.",
     load_failed: "Laden van de configuratie mislukt. Probeer het opnieuw.",
+    admin_required:
+      "Deze kaart vereist een beheerdersaccount. Log in als beheerder om rolluiken te configureren.",
     "tabs.device": "Apparaat",
     "tabs.calibration": "Kalibratie",
     "control_mode.label": "Besturingsmodus",
@@ -1038,6 +1050,8 @@ export const TRANSLATIONS = {
     yaml_warning:
       "Cette entité utilise une configuration YAML et ne peut pas être configurée depuis cette carte. Veuillez migrer vers l'interface utilisateur\u00a0: Paramètres → Appareils et services → Entrées → Créer une entrée → Cover Time Based.",
     load_failed: "Échec du chargement de la configuration. Veuillez réessayer.",
+    admin_required:
+      "Cette carte nécessite un compte administrateur. Veuillez vous connecter en tant qu'administrateur pour configurer les volets.",
     "tabs.device": "Appareil",
     "tabs.calibration": "Étalonnage",
     "control_mode.label": "Mode de commande",
@@ -1209,6 +1223,8 @@ export const TRANSLATIONS = {
     yaml_warning:
       "Esta entidad usa configuración YAML y no se puede configurar desde esta tarjeta. Migra a la interfaz de usuario: Configuración → Dispositivos y servicios → Ayudantes → Crear ayudante → Cover Time Based.",
     load_failed: "Error al cargar la configuración. Inténtalo de nuevo.",
+    admin_required:
+      "Esta tarjeta necesita una cuenta de administrador. Inicia sesión como administrador para configurar persianas.",
     "tabs.device": "Dispositivo",
     "tabs.calibration": "Calibración",
     "control_mode.label": "Modo de control",
@@ -1383,6 +1399,8 @@ export const TRANSLATIONS = {
     yaml_warning:
       "Aquesta entitat utilitza configuració YAML i no es pot configurar des d'aquesta targeta. Migra a la interfície d'usuari: Configuració → Dispositius i serveis → Ajudants → Crea ajudant → Cover Time Based.",
     load_failed: "No s'ha pogut carregar la configuració. Torna-ho a provar.",
+    admin_required:
+      "Aquesta targeta necessita un compte d'administrador. Inicia la sessió com a administrador per configurar persianes.",
     "tabs.device": "Dispositiu",
     "tabs.calibration": "Calibració",
     "control_mode.label": "Mode de control",
@@ -1557,6 +1575,8 @@ export const TRANSLATIONS = {
     yaml_warning:
       "Tato entita používá konfiguraci YAML a nelze ji nastavit z této karty. Přejděte prosím na uživatelské rozhraní: Nastavení → Zařízení a služby → Pomocníci → Vytvořit pomocníka → Cover Time Based.",
     load_failed: "Nepodařilo se načíst konfiguraci. Zkuste to prosím znovu.",
+    admin_required:
+      "Tato karta vyžaduje účet administrátora. Přihlaste se prosím jako administrátor, abyste mohli nastavit rolety.",
     "tabs.device": "Zařízení",
     "tabs.calibration": "Kalibrace",
     "control_mode.label": "Režim ovládání",
@@ -1726,6 +1746,8 @@ export const TRANSLATIONS = {
     yaml_warning:
       "Ovaj entitet koristi YAML konfiguraciju i ne može se podesiti sa ove kartice. Pređite na korisnički interfejs: Podešavanja → Uređaji i usluge → Pomoćnici → Kreirajte pomoćnika → Cover Time Based.",
     load_failed: "Učitavanje konfiguracije nije uspelo. Pokušajte ponovo.",
+    admin_required:
+      "Ova kartica zahteva administratorski nalog. Prijavite se kao administrator da biste podesili roletne.",
     "tabs.device": "Uređaj",
     "tabs.calibration": "Kalibracija",
     "control_mode.label": "Režim upravljanja",

--- a/custom_components/cover_time_based/websocket_api.py
+++ b/custom_components/cover_time_based/websocket_api.py
@@ -144,7 +144,13 @@ def _script_in_non_pulse_mode(control_mode, options):
 
 
 def async_register_websocket_api(hass: HomeAssistant) -> None:
-    """Register WebSocket API commands."""
+    """Register WebSocket API commands.
+
+    Every command here reads or writes a cover's configuration, or drives a
+    relay, so each handler carries ``@websocket_api.require_admin``
+    (outermost), matching HA core's gating of config-entry writes. A new
+    command must too.
+    """
     websocket_api.async_register_command(hass, ws_get_config)
     websocket_api.async_register_command(hass, ws_update_config)
     websocket_api.async_register_command(hass, ws_start_calibration)
@@ -169,6 +175,7 @@ def _resolve_config_entry(hass: HomeAssistant, entity_id: str):
     return config_entry, None
 
 
+@websocket_api.require_admin
 @websocket_api.websocket_command(
     {
         "type": "cover_time_based/get_config",
@@ -261,6 +268,7 @@ async def ws_get_config(
     )
 
 
+@websocket_api.require_admin
 @websocket_api.websocket_command(
     {
         "type": "cover_time_based/update_config",
@@ -417,6 +425,7 @@ async def ws_update_config(
     connection.send_result(msg["id"], {"success": True})
 
 
+@websocket_api.require_admin
 @websocket_api.websocket_command(
     {
         "type": "cover_time_based/start_calibration",
@@ -450,6 +459,7 @@ async def ws_start_calibration(
     connection.send_result(msg["id"], {"success": True})
 
 
+@websocket_api.require_admin
 @websocket_api.websocket_command(
     {
         "type": "cover_time_based/stop_calibration",
@@ -478,6 +488,7 @@ async def ws_stop_calibration(
     connection.send_result(msg["id"], result)
 
 
+@websocket_api.require_admin
 @websocket_api.websocket_command(
     {
         "type": "cover_time_based/raw_command",

--- a/tests/frontend/card_lifecycle.test.mjs
+++ b/tests/frontend/card_lifecycle.test.mjs
@@ -176,6 +176,28 @@ test("_loadConfig on a 'not_found' WS error sets _loadError to the yaml_warning 
   expect(errSpy).toHaveBeenCalled();
 });
 
+test("_loadConfig on an 'unauthorized' WS error sets _loadError to the admin_required string", async () => {
+  // The card intentionally calls console.error on this path — that is expected behavior.
+  const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  const hass = makeHass({
+    ws: {
+      // What @websocket_api.require_admin sends a non-administrator. Retrying
+      // can never help them, so the card must not offer "please try again".
+      "cover_time_based/get_config": () => {
+        throw { code: "unauthorized", message: "Unauthorized" };
+      },
+    },
+  });
+  card = await mountCard(hass);
+  card._selectedEntity = "cover.my_cover";
+  card._config = { some: "data" };
+  await card._loadConfig();
+  expect(card._config).toBeNull();
+  expect(card._loadError).toBe(card._t("admin_required"));
+  expect(card._loading).toBe(false);
+  expect(errSpy).toHaveBeenCalled();
+});
+
 // ---------------------------------------------------------------------------
 // _loadConfig — early-return (no _selectedEntity)
 // ---------------------------------------------------------------------------

--- a/tests/integration/test_admin_gating.py
+++ b/tests/integration/test_admin_gating.py
@@ -1,0 +1,135 @@
+"""Integration tests for administrator gating of the card's commands.
+
+Everything that writes a cover's configuration or drives a relay is
+admin-only: the websocket commands and the two calibration services.
+The websocket tests go through a real connection so the decorator chain
+is exercised; tests/test_websocket_api.py unwraps the decorators and
+cannot see an auth gate.
+"""
+
+from __future__ import annotations
+
+import pytest
+from homeassistant.core import Context, HomeAssistant
+from homeassistant.exceptions import HomeAssistantError, Unauthorized
+
+from .conftest import DOMAIN
+
+ENTITY_ID = "cover.test_cover"
+
+COMMANDS = [
+    {"type": "cover_time_based/get_config", "entity_id": ENTITY_ID},
+    {
+        "type": "cover_time_based/update_config",
+        "entity_id": ENTITY_ID,
+        "travel_time_open": 45.0,
+    },
+    {
+        "type": "cover_time_based/start_calibration",
+        "entity_id": ENTITY_ID,
+        "attribute": "travel_time_open",
+        # The schema minimum: a regressed gate runs a one-second calibration,
+        # not a minute-long one.
+        "timeout": 1,
+    },
+    {"type": "cover_time_based/stop_calibration", "entity_id": ENTITY_ID},
+    {"type": "cover_time_based/raw_command", "entity_id": ENTITY_ID, "command": "open"},
+]
+
+
+@pytest.mark.parametrize("command", COMMANDS, ids=[c["type"] for c in COMMANDS])
+async def test_non_admin_is_rejected(
+    hass: HomeAssistant,
+    setup_cover,
+    hass_ws_client,
+    hass_read_only_access_token,
+    base_options,
+    command,
+):
+    """A read-only user's websocket command is refused with no side effect."""
+    client = await hass_ws_client(hass, hass_read_only_access_token)
+    await client.send_json({"id": 1, **command})
+    msg = await client.receive_json()
+
+    assert msg["success"] is False
+    assert msg["error"]["code"] == "unauthorized"
+    # No side effect: update_config would have rewritten the option,
+    # start_calibration and raw_command would have driven the relay.
+    # get_config and stop_calibration have no side effect to check.
+    assert setup_cover.options["travel_time_open"] == base_options["travel_time_open"]
+    assert hass.states.get("input_boolean.open_switch").state == "off"
+
+
+@pytest.mark.parametrize("command", COMMANDS, ids=[c["type"] for c in COMMANDS])
+async def test_admin_is_accepted(
+    hass: HomeAssistant, setup_cover, hass_ws_client, base_options, command
+):
+    """An admin passes the gate on every command."""
+    client = await hass_ws_client(hass)
+    await client.send_json({"id": 1, **command})
+    msg = await client.receive_json()
+
+    if command["type"] == "cover_time_based/stop_calibration":
+        # Nothing is calibrating, so the handler's own error is what proves the
+        # gate let the admin reach it — "unauthorized" would have come instead.
+        assert msg["success"] is False
+        assert msg["error"]["code"] == "failed"
+    else:
+        assert msg["success"] is True
+
+    if command["type"] == "cover_time_based/get_config":
+        assert msg["result"]["travel_time_open"] == base_options["travel_time_open"]
+
+    if command["type"] == "cover_time_based/start_calibration":
+        # The command really ran, so cancel the session it opened rather than
+        # leaving its timers to outlive the test.
+        await client.send_json(
+            {
+                "id": 2,
+                "type": "cover_time_based/stop_calibration",
+                "entity_id": ENTITY_ID,
+                "cancel": True,
+            }
+        )
+        await client.receive_json()
+
+
+CALIBRATION_SERVICES = [
+    ("start_calibration", {"attribute": "travel_time_open", "timeout": 1}),
+    ("stop_calibration", {}),
+]
+
+
+@pytest.mark.parametrize(
+    ("service", "data"),
+    CALIBRATION_SERVICES,
+    ids=[s for s, _ in CALIBRATION_SERVICES],
+)
+async def test_non_admin_cannot_call_calibration_services(
+    hass: HomeAssistant, setup_cover, hass_read_only_user, service, data
+):
+    """A read-only user's calibration service call is refused with no side effect."""
+    with pytest.raises(Unauthorized):
+        await hass.services.async_call(
+            DOMAIN,
+            service,
+            {"entity_id": ENTITY_ID, **data},
+            blocking=True,
+            context=Context(user_id=hass_read_only_user.id),
+        )
+    await hass.async_block_till_done()
+    assert hass.states.get("input_boolean.open_switch").state == "off"
+
+
+async def test_admin_reaches_calibration_service(
+    hass: HomeAssistant, setup_cover, hass_admin_user
+):
+    """An admin passes the gate: the handler itself reports no calibration running."""
+    with pytest.raises(HomeAssistantError, match="No calibration in progress"):
+        await hass.services.async_call(
+            DOMAIN,
+            "stop_calibration",
+            {"entity_id": ENTITY_ID},
+            blocking=True,
+            context=Context(user_id=hass_admin_user.id),
+        )

--- a/tests/test_cover_services.py
+++ b/tests/test_cover_services.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 import voluptuous as vol
 import yaml
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, Unauthorized
 
 from custom_components.cover_time_based.cover import (
     CONF_CLOSE_SWITCH_ENTITY_ID,
@@ -18,6 +18,7 @@ from custom_components.cover_time_based.cover import (
     CONTROL_MODE_SWITCH,
     SERVICE_START_CALIBRATION,
     SERVICE_STOP_CALIBRATION,
+    _admin_only,
     _create_cover_from_options,
     _register_services,
 )
@@ -132,6 +133,8 @@ class TestServiceHandlers:
             "attribute": "travel_time_close",
             "timeout": 60.0,
         }
+        # An internal call carries no user, which _admin_only waves through.
+        service_call.context.user_id = None
 
         from unittest.mock import patch
 
@@ -172,6 +175,8 @@ class TestServiceHandlers:
 
         service_call = MagicMock()
         service_call.data = {"entity_id": "cover.test", "cancel": False}
+        # An internal call carries no user, which _admin_only waves through.
+        service_call.context.user_id = None
 
         from unittest.mock import patch
 
@@ -182,6 +187,43 @@ class TestServiceHandlers:
             await handler(service_call)
 
         mock_entity.stop_calibration.assert_awaited_once_with(cancel=False)
+
+
+# ---------------------------------------------------------------------------
+# _admin_only
+# ---------------------------------------------------------------------------
+
+
+class TestAdminOnly:
+    """The calibration services drive relays and rewrite options, so a
+    non-administrator must not reach their handlers."""
+
+    @staticmethod
+    def _call(user_id):
+        call = MagicMock()
+        call.context.user_id = user_id
+        return call
+
+    @pytest.mark.asyncio
+    async def test_non_admin_is_rejected(self):
+        handler = AsyncMock()
+        hass = MagicMock()
+        hass.auth.async_get_user = AsyncMock(return_value=MagicMock(is_admin=False))
+
+        with pytest.raises(Unauthorized):
+            await _admin_only(hass, handler)(self._call("read-only-user"))
+
+        handler.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_admin_reaches_the_handler(self):
+        handler = AsyncMock(return_value={"value": 45.0})
+        hass = MagicMock()
+        hass.auth.async_get_user = AsyncMock(return_value=MagicMock(is_admin=True))
+
+        call = self._call("admin-user")
+        assert await _admin_only(hass, handler)(call) == {"value": 45.0}
+        handler.assert_awaited_once_with(call)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The five `cover_time_based/*` websocket commands (`get_config`, `update_config`, `start_calibration`, `stop_calibration`, `raw_command`) and the `start_calibration` / `stop_calibration` actions accepted any authenticated user. A read-only account could read a cover's relay entity ids and timings, rewrite the config entry, run a calibration, and energise relays. Home Assistant core gates every config-entry write behind `require_admin`; both of our paths now do too.

- `@websocket_api.require_admin` (outermost, HA core convention) on all five websocket handlers.
- The two calibration actions are wrapped in an admin check (`_admin_only`); HA's `async_register_admin_service` cannot be used because on our minimum supported HA (2025.2.0) it has no `supports_response` parameter.
- The card maps the `unauthorized` error to a new **administrator account required** message (all languages) instead of the generic "try again". Non-admins can still see the cover picker because `config_entries/get` is not admin-only in HA, so the message is what tells them why the card does not work.
- README: one sentence in the card section saying an administrator account is needed.
- CHANGELOG entry under 4.12.0.

## Tests

- `tests/integration/test_admin_gating.py`: real websocket connection with a read-only token for each command (asserts `unauthorized` and no side effect on the config entry or the relay), the same five for an admin, and the two calibration actions with a read-only user context (`Unauthorized`) and an admin context. The existing `tests/test_websocket_api.py` unwraps the decorators and cannot see this class of bug, hence the integration tests.
- Mutation-checked during review: removing any one decorator fails exactly that command's test; putting `require_admin` innermost breaks the admin path.
- Frontend: `card_lifecycle.test.mjs` covers the `unauthorized` mapping; translation parity gate passes for the new key.
