### PR TITLE
fix: known-position services accept HA targets and enforce 0-100; YAML rejects zero durations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,14 @@
 - **Added an "Ignore all device reports" position-reporting profile for wrapped covers** ([#248](https://github.com/Sese-Schneider/ha-cover-time-based/issues/248)).
 - **Added a per-cover "Wait for relay confirmation before tracking" option** ([#231](https://github.com/Sese-Schneider/ha-cover-time-based/issues/231)).
 - **Serbian — Latin (`sr-Latn`) translation added.**
+- **Czech (`cs`) translation added** ([#241](https://github.com/Sese-Schneider/ha-cover-time-based/pull/241)).
 - **Added a "Single button (cycling)" control mode** ([#245](https://github.com/Sese-Schneider/ha-cover-time-based/issues/245)) for motors with one control input, where each press cycles down → stop → up → stop. Also adds a `cover_time_based.resync` action, now available in every control mode.
 
 ### Fixes
 
 - **The configuration card's backend websocket commands and the `start_calibration` / `stop_calibration` actions now require an administrator account**: they accepted any authenticated user, including read-only ones, and now return `unauthorized` for non-administrators, matching how Home Assistant itself gates configuration changes.
 - **`set_known_position` and `set_known_tilt_position` now accept area, device and label targets and reject values outside 0–100**: the action editor offered areas and devices, but only an entity target validated; and a position above 100 was accepted and tracked, so the next close ran for longer than a full travel.
+- **YAML configuration now rejects a travel, tilt or pulse time of `0`**, as the configuration card already did. A zero duration made the cover twitch while Home Assistant reported it at the endpoint.
 
 ## 4.11.0 (2026-08-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 - **The configuration card's backend websocket commands and the `start_calibration` / `stop_calibration` actions now require an administrator account**: they accepted any authenticated user, including read-only ones, and now return `unauthorized` for non-administrators, matching how Home Assistant itself gates configuration changes.
 - **`set_known_position` and `set_known_tilt_position` now accept area, device and label targets and reject values outside 0–100**: the action editor offered areas and devices, but only an entity target validated; and a position above 100 was accepted and tracked, so the next close ran for longer than a full travel.
 - **YAML configuration now rejects a travel, tilt or pulse time of `0`**, as the configuration card already did. A zero duration made the cover twitch while Home Assistant reported it at the endpoint.
+- **`set_known_position` and `set_known_tilt_position` now accept area, floor, device and label targets and reject values outside 0–100**: the action editor offered areas and devices, but only an entity target validated; and a position above 100 was accepted and tracked, so the next close ran for longer than a full travel.
+- **YAML configuration now rejects a travel, tilt or pulse time below 0.1 s**: the configuration card already enforced that minimum, and a zero duration made the cover twitch while Home Assistant reported it at the endpoint.
 
 ## 4.11.0 (2026-08-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixes
 
 - **The configuration card's backend websocket commands and the `start_calibration` / `stop_calibration` actions now require an administrator account**: they accepted any authenticated user, including read-only ones, and now return `unauthorized` for non-administrators, matching how Home Assistant itself gates configuration changes.
+- **`set_known_position` and `set_known_tilt_position` now accept area, device and label targets and reject values outside 0–100**: the action editor offered areas and devices, but only an entity target validated; and a position above 100 was accepted and tracked, so the next close ran for longer than a full travel.
 
 ## 4.11.0 (2026-08-04)
 

--- a/README.md
+++ b/README.md
@@ -551,6 +551,8 @@ prevents them nudging the tracked position out of true. Movements all the way to
 ### `cover_time_based.set_known_position`
 
 Manually set a cover's tracked position, which is useful for correcting drift.
+Aim it at any entity, device, area, floor or label; every matching Cover Time
+Based cover is set.
 
 | Field | Description |
 | --- | --- |
@@ -559,6 +561,8 @@ Manually set a cover's tracked position, which is useful for correcting drift.
 ### `cover_time_based.set_known_tilt_position`
 
 Manually set a cover's tracked tilt position.
+Aim it at any entity, device, area, floor or label; every matching Cover Time
+Based cover is set.
 
 | Field | Description |
 | --- | --- |
@@ -851,16 +855,16 @@ listed here, use the card.
 | `stop_switch_entity_id` | entity | Required in pulse mode | Switch that stops the cover. May be a `script` entity in pulse mode. | None |
 | `cover_entity_id` | entity | **Required**, or the open/close switches | Existing cover entity to wrap. | |
 | `input_mode` | string | _Optional_ | Control mode for switch-based covers: `switch`, `pulse`, `toggle`, or `toggle_opposite`. | `switch` |
-| `travelling_time_down` | float | _Optional_ | Seconds to close the cover. | unset |
-| `travelling_time_up` | float | _Optional_ | Seconds to open the cover. | unset |
-| `tilting_time_down` | float | _Optional_ | Seconds to tilt the cover fully closed. | None |
-| `tilting_time_up` | float | _Optional_ | Seconds to tilt the cover fully open. | None |
+| `travelling_time_down` | float | _Optional_ | Seconds to close the cover. Minimum 0.1 s. | unset |
+| `travelling_time_up` | float | _Optional_ | Seconds to open the cover. Minimum 0.1 s. | unset |
+| `tilting_time_down` | float | _Optional_ | Seconds to tilt the cover fully closed. Minimum 0.1 s. | None |
+| `tilting_time_up` | float | _Optional_ | Seconds to tilt the cover fully open. Minimum 0.1 s. | None |
 | `travel_moves_with_tilt` | boolean | _Optional_ | Whether tilt movements also change travel proportionally. | false |
 | `endpoint_runon_time` | float | _Optional_ | Extra relay time at the endpoints. Also accepted under its old name `travel_delay_at_end`. | 2.0 |
 | `min_movement_time` | float | _Optional_ | Minimum movement duration; blocks shorter movements. | None |
 | `travel_startup_delay` | float | _Optional_ | Startup compensation for travel movements. | None |
 | `tilt_startup_delay` | float | _Optional_ | Startup compensation for tilt movements. | None |
-| `pulse_time` | float | _Optional_ | Pulse duration in pulse mode. | 1.0 |
+| `pulse_time` | float | _Optional_ | Pulse duration in pulse mode. Minimum 0.1 s. | 1.0 |
 | `relay_reports_off` | boolean | _Optional_ | Toggle mode: set `false` for pulse modules that never report their off. | true |
 | `send_endpoint_stop` | boolean | _Optional_ | Pulse mode: set `false` for auto-stop controllers that reposition on a stop received while stopped. | true |
 | `direction_change_delay` | float | _Deprecated_ | No longer configurable. Accepted and ignored; the reversing pause is fixed at 1.0s. | — |

--- a/custom_components/cover_time_based/cover.py
+++ b/custom_components/cover_time_based/cover.py
@@ -136,10 +136,12 @@ BASE_DEVICE_SCHEMA = {
     vol.Required(CONF_NAME): cv.string,
 }
 
-# A zero travel, tilt or pulse time makes every move "arrive" on the first
-# tracker tick while the relay still fires; the websocket schema rejects it
-# with the same floor. Startup delays and run-on times may legitimately be 0.
-NONZERO_DURATION = vol.All(vol.Coerce(float), vol.Range(min=0.1))
+# The floor shared by the YAML and websocket schemas: a zero travel, tilt or
+# pulse time makes every move "arrive" on the first tracker tick while the
+# relay still fires. Startup delays and run-on times may legitimately be 0.
+MIN_DURATION = 0.1
+NONZERO_DURATION = vol.All(vol.Coerce(float), vol.Range(min=MIN_DURATION))
+NULLABLE_DURATION = vol.Any(NONZERO_DURATION, None)
 
 TRAVEL_TIME_SCHEMA = {
     vol.Optional(CONF_TRAVEL_MOVES_WITH_TILT): cv.boolean,
@@ -179,18 +181,10 @@ DEFAULTS_SCHEMA = vol.Schema(
     {
         vol.Optional(CONF_TRAVEL_MOVES_WITH_TILT, default=False): cv.boolean,
         vol.Optional(CONF_INPUT_MODE): vol.In(INPUT_MODE_VALUES),
-        vol.Optional(CONF_TRAVELLING_TIME_DOWN, default=None): vol.Any(
-            NONZERO_DURATION, None
-        ),
-        vol.Optional(CONF_TRAVELLING_TIME_UP, default=None): vol.Any(
-            NONZERO_DURATION, None
-        ),
-        vol.Optional(CONF_TILTING_TIME_DOWN, default=None): vol.Any(
-            NONZERO_DURATION, None
-        ),
-        vol.Optional(CONF_TILTING_TIME_UP, default=None): vol.Any(
-            NONZERO_DURATION, None
-        ),
+        vol.Optional(CONF_TRAVELLING_TIME_DOWN, default=None): NULLABLE_DURATION,
+        vol.Optional(CONF_TRAVELLING_TIME_UP, default=None): NULLABLE_DURATION,
+        vol.Optional(CONF_TILTING_TIME_DOWN, default=None): NULLABLE_DURATION,
+        vol.Optional(CONF_TILTING_TIME_UP, default=None): NULLABLE_DURATION,
         vol.Optional(CONF_TRAVEL_STARTUP_DELAY, default=None): vol.Any(
             cv.positive_float, None
         ),

--- a/custom_components/cover_time_based/cover.py
+++ b/custom_components/cover_time_based/cover.py
@@ -11,7 +11,6 @@ from homeassistant.components.cover import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
-    ATTR_ENTITY_ID,
     CONF_NAME,
 )
 from homeassistant.core import HomeAssistant, SupportsResponse
@@ -220,17 +219,15 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     }
 )
 
-POSITION_SCHEMA = cv.make_entity_service_schema(
-    {
-        vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
-        vol.Required(ATTR_POSITION): cv.positive_int,
-    }
-)
+# HA's own ATTR_POSITION range; anything above 100 would be tracked and
+# persisted as a position the calculator then travels *from*.
+PERCENT = vol.All(vol.Coerce(int), vol.Range(min=0, max=100))
+
+# No explicit entity_id key: make_entity_service_schema supplies the optional
+# entity/device/area/label targets services.yaml advertises and requires one.
+POSITION_SCHEMA = cv.make_entity_service_schema({vol.Required(ATTR_POSITION): PERCENT})
 TILT_POSITION_SCHEMA = cv.make_entity_service_schema(
-    {
-        vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
-        vol.Required(ATTR_TILT_POSITION): cv.positive_int,
-    }
+    {vol.Required(ATTR_TILT_POSITION): PERCENT}
 )
 RESYNC_SCHEMA = {vol.Required("state"): vol.In(list(RESYNC_POSITIONS))}
 

--- a/custom_components/cover_time_based/cover.py
+++ b/custom_components/cover_time_based/cover.py
@@ -218,12 +218,13 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     }
 )
 
-# HA's own ATTR_POSITION range; anything above 100 would be tracked and
-# persisted as a position the calculator then travels *from*.
+# HA's own ATTR_POSITION range, shared with the tilt-limit percentages in the
+# websocket schema; anything above 100 would be tracked and persisted as a
+# position the calculator then travels *from*.
 PERCENT = vol.All(vol.Coerce(int), vol.Range(min=0, max=100))
 
 # No explicit entity_id key: make_entity_service_schema supplies the optional
-# entity/device/area/label targets services.yaml advertises and requires one.
+# entity, device, area, floor and label targets and requires one.
 POSITION_SCHEMA = cv.make_entity_service_schema({vol.Required(ATTR_POSITION): PERCENT})
 TILT_POSITION_SCHEMA = cv.make_entity_service_schema(
     {vol.Required(ATTR_TILT_POSITION): PERCENT}

--- a/custom_components/cover_time_based/cover.py
+++ b/custom_components/cover_time_based/cover.py
@@ -136,12 +136,17 @@ BASE_DEVICE_SCHEMA = {
     vol.Required(CONF_NAME): cv.string,
 }
 
+# A zero travel, tilt or pulse time makes every move "arrive" on the first
+# tracker tick while the relay still fires; the websocket schema rejects it
+# with the same floor. Startup delays and run-on times may legitimately be 0.
+NONZERO_DURATION = vol.All(vol.Coerce(float), vol.Range(min=0.1))
+
 TRAVEL_TIME_SCHEMA = {
     vol.Optional(CONF_TRAVEL_MOVES_WITH_TILT): cv.boolean,
-    vol.Optional(CONF_TRAVELLING_TIME_DOWN): cv.positive_float,
-    vol.Optional(CONF_TRAVELLING_TIME_UP): cv.positive_float,
-    vol.Optional(CONF_TILTING_TIME_DOWN): cv.positive_float,
-    vol.Optional(CONF_TILTING_TIME_UP): cv.positive_float,
+    vol.Optional(CONF_TRAVELLING_TIME_DOWN): NONZERO_DURATION,
+    vol.Optional(CONF_TRAVELLING_TIME_UP): NONZERO_DURATION,
+    vol.Optional(CONF_TILTING_TIME_DOWN): NONZERO_DURATION,
+    vol.Optional(CONF_TILTING_TIME_UP): NONZERO_DURATION,
     vol.Optional(CONF_TRAVEL_STARTUP_DELAY): cv.positive_float,
     vol.Optional(CONF_TILT_STARTUP_DELAY): cv.positive_float,
     vol.Optional(CONF_ENDPOINT_RUNON_TIME): cv.positive_float,
@@ -158,7 +163,7 @@ SWITCH_COVER_SCHEMA = {
     vol.Optional(CONF_STOP_SWITCH_ENTITY_ID, default=None): vol.Any(cv.entity_id, None),
     vol.Optional(CONF_IS_BUTTON, default=False): cv.boolean,
     vol.Optional(CONF_INPUT_MODE): vol.In(INPUT_MODE_VALUES),
-    vol.Optional(CONF_PULSE_TIME): cv.positive_float,
+    vol.Optional(CONF_PULSE_TIME): NONZERO_DURATION,
     vol.Optional(CONF_RELAY_REPORTS_OFF): cv.boolean,
     vol.Optional(CONF_SEND_ENDPOINT_STOP): cv.boolean,
     **TRAVEL_TIME_SCHEMA,
@@ -175,16 +180,16 @@ DEFAULTS_SCHEMA = vol.Schema(
         vol.Optional(CONF_TRAVEL_MOVES_WITH_TILT, default=False): cv.boolean,
         vol.Optional(CONF_INPUT_MODE): vol.In(INPUT_MODE_VALUES),
         vol.Optional(CONF_TRAVELLING_TIME_DOWN, default=None): vol.Any(
-            cv.positive_float, None
+            NONZERO_DURATION, None
         ),
         vol.Optional(CONF_TRAVELLING_TIME_UP, default=None): vol.Any(
-            cv.positive_float, None
+            NONZERO_DURATION, None
         ),
         vol.Optional(CONF_TILTING_TIME_DOWN, default=None): vol.Any(
-            cv.positive_float, None
+            NONZERO_DURATION, None
         ),
         vol.Optional(CONF_TILTING_TIME_UP, default=None): vol.Any(
-            cv.positive_float, None
+            NONZERO_DURATION, None
         ),
         vol.Optional(CONF_TRAVEL_STARTUP_DELAY, default=None): vol.Any(
             cv.positive_float, None

--- a/custom_components/cover_time_based/websocket_api.py
+++ b/custom_components/cover_time_based/websocket_api.py
@@ -67,6 +67,8 @@ from .cover import (
     DEFAULT_REPORTS_COMMAND_NOT_ENDPOINT,
     DEFAULT_SEND_ENDPOINT_STOP,
     DEFAULT_WAIT_FOR_RELAY_FEEDBACK,
+    MIN_DURATION,
+    PERCENT,
 )
 from .helpers import resolve_entity_or_none
 
@@ -284,7 +286,7 @@ async def ws_get_config(
             ]
         ),
         vol.Optional("pulse_time"): vol.Any(
-            None, vol.All(vol.Coerce(float), vol.Range(min=0.1, max=10))
+            None, vol.All(vol.Coerce(float), vol.Range(min=MIN_DURATION, max=10))
         ),
         vol.Optional("relay_reports_off"): vol.Any(None, bool),
         vol.Optional("send_endpoint_stop"): vol.Any(None, bool),
@@ -313,16 +315,16 @@ async def ws_get_config(
             ]
         ),
         vol.Optional("travel_time_close"): vol.Any(
-            None, vol.All(vol.Coerce(float), vol.Range(min=0.1, max=600))
+            None, vol.All(vol.Coerce(float), vol.Range(min=MIN_DURATION, max=600))
         ),
         vol.Optional("travel_time_open"): vol.Any(
-            None, vol.All(vol.Coerce(float), vol.Range(min=0.1, max=600))
+            None, vol.All(vol.Coerce(float), vol.Range(min=MIN_DURATION, max=600))
         ),
         vol.Optional("tilt_time_close"): vol.Any(
-            None, vol.All(vol.Coerce(float), vol.Range(min=0.1, max=600))
+            None, vol.All(vol.Coerce(float), vol.Range(min=MIN_DURATION, max=600))
         ),
         vol.Optional("tilt_time_open"): vol.Any(
-            None, vol.All(vol.Coerce(float), vol.Range(min=0.1, max=600))
+            None, vol.All(vol.Coerce(float), vol.Range(min=MIN_DURATION, max=600))
         ),
         vol.Optional("travel_startup_delay"): vol.Any(
             None, vol.All(vol.Coerce(float), vol.Range(min=0, max=600))
@@ -341,12 +343,8 @@ async def ws_get_config(
         vol.Optional("direction_change_delay"): vol.Any(
             None, vol.All(vol.Coerce(float), vol.Range(min=0, max=600))
         ),
-        vol.Optional("safe_tilt_position"): vol.Any(
-            None, vol.All(vol.Coerce(int), vol.Range(min=0, max=100))
-        ),
-        vol.Optional("max_tilt_allowed_position"): vol.Any(
-            None, vol.All(vol.Coerce(int), vol.Range(min=0, max=100))
-        ),
+        vol.Optional("safe_tilt_position"): vol.Any(None, PERCENT),
+        vol.Optional("max_tilt_allowed_position"): vol.Any(None, PERCENT),
         vol.Optional("tilt_open_switch"): vol.Any(str, None),
         vol.Optional("tilt_close_switch"): vol.Any(str, None),
         vol.Optional("tilt_stop_switch"): vol.Any(str, None),

--- a/tests/integration/test_services.py
+++ b/tests/integration/test_services.py
@@ -3,16 +3,48 @@
 Both are target-based, so an area target must resolve to the cover.
 """
 
+from __future__ import annotations
+
+import pytest
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import area_registry as ar
 from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from .conftest import DOMAIN
 
 ENTITY_ID = "cover.test_cover"
 
 
+@pytest.fixture
+async def setup_tilt_cover(hass: HomeAssistant, setup_input_booleans, base_options):
+    """Load the standard switch-mode cover with tilt added."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=2,
+        title="Test Cover",
+        data={},
+        options={
+            **base_options,
+            "tilt_mode": "sequential_close",
+            "tilt_time_open": 2.0,
+            "tilt_time_close": 2.0,
+        },
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(ENTITY_ID) is not None, "Cover entity was not created"
+
+    yield entry
+
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+
 async def test_set_known_position_by_area(hass: HomeAssistant, setup_cover):
+    """An area target resolves to the cover and sets its tracked position."""
     area = ar.async_get(hass).async_get_or_create("Kitchen")
     er.async_get(hass).async_update_entity(ENTITY_ID, area_id=area.id)
 
@@ -24,3 +56,18 @@ async def test_set_known_position_by_area(hass: HomeAssistant, setup_cover):
     )
 
     assert hass.states.get(ENTITY_ID).attributes["current_position"] == 42
+
+
+async def test_set_known_tilt_position_by_area(hass: HomeAssistant, setup_tilt_cover):
+    """The tilt service is target-based too."""
+    area = ar.async_get(hass).async_get_or_create("Kitchen")
+    er.async_get(hass).async_update_entity(ENTITY_ID, area_id=area.id)
+
+    await hass.services.async_call(
+        DOMAIN,
+        "set_known_tilt_position",
+        {"area_id": area.id, "tilt_position": 37},
+        blocking=True,
+    )
+
+    assert hass.states.get(ENTITY_ID).attributes["current_tilt_position"] == 37

--- a/tests/integration/test_services.py
+++ b/tests/integration/test_services.py
@@ -1,11 +1,8 @@
 """The known-position services through HA's service layer.
 
-Both are target-based, so an area target must resolve to the cover, and the
-percent range must be enforced before the entity method runs.
+Both are target-based, so an area target must resolve to the cover.
 """
 
-import pytest
-import voluptuous as vol
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import area_registry as ar
 from homeassistant.helpers import entity_registry as er
@@ -25,16 +22,5 @@ async def test_set_known_position_by_area(hass: HomeAssistant, setup_cover):
         {"area_id": area.id, "position": 42},
         blocking=True,
     )
-    await hass.async_block_till_done()
 
     assert hass.states.get(ENTITY_ID).attributes["current_position"] == 42
-
-
-async def test_set_known_position_above_100_rejected(hass: HomeAssistant, setup_cover):
-    with pytest.raises(vol.Invalid):
-        await hass.services.async_call(
-            DOMAIN,
-            "set_known_position",
-            {"entity_id": ENTITY_ID, "position": 150},
-            blocking=True,
-        )

--- a/tests/integration/test_services.py
+++ b/tests/integration/test_services.py
@@ -1,0 +1,40 @@
+"""The known-position services through HA's service layer.
+
+Both are target-based, so an area target must resolve to the cover, and the
+percent range must be enforced before the entity method runs.
+"""
+
+import pytest
+import voluptuous as vol
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import area_registry as ar
+from homeassistant.helpers import entity_registry as er
+
+from .conftest import DOMAIN
+
+ENTITY_ID = "cover.test_cover"
+
+
+async def test_set_known_position_by_area(hass: HomeAssistant, setup_cover):
+    area = ar.async_get(hass).async_get_or_create("Kitchen")
+    er.async_get(hass).async_update_entity(ENTITY_ID, area_id=area.id)
+
+    await hass.services.async_call(
+        DOMAIN,
+        "set_known_position",
+        {"area_id": area.id, "position": 42},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get(ENTITY_ID).attributes["current_position"] == 42
+
+
+async def test_set_known_position_above_100_rejected(hass: HomeAssistant, setup_cover):
+    with pytest.raises(vol.Invalid):
+        await hass.services.async_call(
+            DOMAIN,
+            "set_known_position",
+            {"entity_id": ENTITY_ID, "position": 150},
+            blocking=True,
+        )

--- a/tests/test_cover_factory.py
+++ b/tests/test_cover_factory.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+import voluptuous as vol
 
 from custom_components.cover_time_based.cover import (
     CONF_CLOSE_SWITCH_ENTITY_ID,
@@ -35,6 +36,8 @@ from custom_components.cover_time_based.cover import (
     CONTROL_MODE_TOGGLE,
     CONTROL_MODE_TOGGLE_OPPOSITE,
     CONTROL_MODE_WRAPPED,
+    DEFAULTS_SCHEMA,
+    PLATFORM_SCHEMA,
     _create_cover_from_options,
     _resolve_tilt_strategy,
     devices_from_config,
@@ -834,3 +837,77 @@ class TestLegacyTravelMovesWithTiltMigration:
         devices = devices_from_config(config)
         cover = devices[0]
         assert cover._tilt_strategy is None
+
+
+# ===================================================================
+# YAML rejects zero travel / tilt / pulse durations
+# ===================================================================
+
+
+def _yaml_device(**timing):
+    return {
+        "platform": "cover_time_based",
+        CONF_DEVICES: {
+            "blind1": {
+                "name": "Test",
+                CONF_OPEN_SWITCH_ENTITY_ID: "switch.open",
+                CONF_CLOSE_SWITCH_ENTITY_ID: "switch.close",
+                **timing,
+            },
+        },
+    }
+
+
+class TestYamlRejectsZeroDurations:
+    """A zero travel, tilt or pulse time makes every move "arrive" on the
+    first tracker tick while the relay still fires; the websocket schema
+    already rejects it (min 0.1), YAML must match."""
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            CONF_TRAVELLING_TIME_DOWN,
+            CONF_TRAVELLING_TIME_UP,
+            CONF_TILTING_TIME_DOWN,
+            CONF_TILTING_TIME_UP,
+            CONF_PULSE_TIME,
+        ],
+    )
+    def test_device_level_zero_rejected(self, key):
+        with pytest.raises(vol.Invalid):
+            PLATFORM_SCHEMA(_yaml_device(**{key: 0}))
+
+    def test_device_level_minimum_accepted(self):
+        validated = PLATFORM_SCHEMA(
+            _yaml_device(**{CONF_TRAVELLING_TIME_DOWN: 0.1, CONF_PULSE_TIME: 0.1})
+        )
+        device = validated[CONF_DEVICES]["blind1"]
+        assert device[CONF_TRAVELLING_TIME_DOWN] == 0.1
+        assert device[CONF_PULSE_TIME] == 0.1
+
+    def test_zero_startup_delay_still_allowed(self):
+        validated = PLATFORM_SCHEMA(_yaml_device(**{CONF_TRAVEL_STARTUP_DELAY: 0}))
+        assert validated[CONF_DEVICES]["blind1"][CONF_TRAVEL_STARTUP_DELAY] == 0.0
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            CONF_TRAVELLING_TIME_DOWN,
+            CONF_TRAVELLING_TIME_UP,
+            CONF_TILTING_TIME_DOWN,
+            CONF_TILTING_TIME_UP,
+        ],
+    )
+    def test_defaults_level_zero_rejected(self, key):
+        with pytest.raises(vol.Invalid):
+            DEFAULTS_SCHEMA({key: 0})
+
+    def test_defaults_level_none_and_minimum_accepted(self):
+        assert (
+            DEFAULTS_SCHEMA({CONF_TRAVELLING_TIME_UP: None})[CONF_TRAVELLING_TIME_UP]
+            is None
+        )
+        assert (
+            DEFAULTS_SCHEMA({CONF_TRAVELLING_TIME_UP: 0.1})[CONF_TRAVELLING_TIME_UP]
+            == 0.1
+        )

--- a/tests/test_cover_factory.py
+++ b/tests/test_cover_factory.py
@@ -514,11 +514,7 @@ class TestDefaultsSchemaLegacyEndpointRunonMigration:
     """
 
     def test_defaults_level_travel_delay_at_end_migrates(self):
-        from custom_components.cover_time_based.cover import (
-            CONF_TRAVEL_DELAY_AT_END,
-            DEFAULTS_SCHEMA,
-            _migrate_yaml_keys,
-        )
+        from custom_components.cover_time_based.cover import _migrate_yaml_keys
 
         validated = DEFAULTS_SCHEMA({CONF_TRAVEL_DELAY_AT_END: 5.0})
         _migrate_yaml_keys(validated)
@@ -527,10 +523,7 @@ class TestDefaultsSchemaLegacyEndpointRunonMigration:
 
     def test_defaults_level_explicit_endpoint_runon_time_untouched(self):
         """Setting the new name directly still works (no old key present)."""
-        from custom_components.cover_time_based.cover import (
-            DEFAULTS_SCHEMA,
-            _migrate_yaml_keys,
-        )
+        from custom_components.cover_time_based.cover import _migrate_yaml_keys
 
         validated = DEFAULTS_SCHEMA({CONF_ENDPOINT_RUNON_TIME: 3.0})
         _migrate_yaml_keys(validated)
@@ -543,8 +536,6 @@ class TestDefaultsSchemaLegacyEndpointRunonMigration:
         pipeline (not just the direct _create_cover_from_options .get()
         fallback that the unit-level factory tests exercise).
         """
-        from custom_components.cover_time_based.cover import PLATFORM_SCHEMA
-
         raw = {
             "platform": "cover_time_based",
             CONF_DEVICES: {
@@ -582,8 +573,6 @@ class TestInputModeSchemaValidation:
         ],
     )
     def test_switch_cover_schema_accepts_input_mode(self, value):
-        import voluptuous as vol
-
         from custom_components.cover_time_based.cover import SWITCH_COVER_SCHEMA
 
         validated = vol.Schema(SWITCH_COVER_SCHEMA)(
@@ -597,8 +586,6 @@ class TestInputModeSchemaValidation:
         assert validated["input_mode"] == value
 
     def test_switch_cover_schema_rejects_unknown_input_mode(self):
-        import voluptuous as vol
-
         from custom_components.cover_time_based.cover import SWITCH_COVER_SCHEMA
 
         with pytest.raises(vol.Invalid):
@@ -612,16 +599,12 @@ class TestInputModeSchemaValidation:
             )
 
     def test_defaults_schema_accepts_input_mode(self):
-        from custom_components.cover_time_based.cover import DEFAULTS_SCHEMA
-
         validated = DEFAULTS_SCHEMA({"input_mode": CONTROL_MODE_TOGGLE})
         assert validated["input_mode"] == CONTROL_MODE_TOGGLE
 
     def test_input_mode_reachable_through_full_platform_schema_pipeline(self):
         """End-to-end: a real YAML device with input_mode: toggle must
         actually produce a ToggleModeCover, not be rejected by PLATFORM_SCHEMA."""
-        from custom_components.cover_time_based.cover import PLATFORM_SCHEMA
-
         raw = {
             "platform": "cover_time_based",
             CONF_DEVICES: {
@@ -859,9 +842,7 @@ def _yaml_device(**timing):
 
 
 class TestYamlRejectsZeroDurations:
-    """A zero travel, tilt or pulse time makes every move "arrive" on the
-    first tracker tick while the relay still fires; the websocket schema
-    already rejects it (min 0.1), YAML must match."""
+    """YAML rejects a zero travel, tilt or pulse time, like the websocket schema."""
 
     @pytest.mark.parametrize(
         "key",
@@ -902,12 +883,8 @@ class TestYamlRejectsZeroDurations:
         with pytest.raises(vol.Invalid):
             DEFAULTS_SCHEMA({key: 0})
 
-    def test_defaults_level_none_and_minimum_accepted(self):
+    def test_defaults_level_none_accepted(self):
         assert (
             DEFAULTS_SCHEMA({CONF_TRAVELLING_TIME_UP: None})[CONF_TRAVELLING_TIME_UP]
             is None
-        )
-        assert (
-            DEFAULTS_SCHEMA({CONF_TRAVELLING_TIME_UP: 0.1})[CONF_TRAVELLING_TIME_UP]
-            == 0.1
         )

--- a/tests/test_cover_services.py
+++ b/tests/test_cover_services.py
@@ -355,10 +355,8 @@ class TestServiceFieldTranslationsMatchServicesYaml:
     ids=["position", "tilt_position"],
 )
 class TestKnownPositionSchemas:
-    """Both services are target-based (services.yaml declares `target:`), so
-    they must accept any HA target kind, and their percent must stay in
-    0..100 — a value above 100 used to be tracked, persisted, and turned the
-    next close into a 1.5x-travel move."""
+    """Pins what both known-position services accept: any HA target kind, and
+    a percent within 0..100."""
 
     def test_above_100_rejected(self, schema, field):
         with pytest.raises(vol.Invalid):
@@ -375,14 +373,12 @@ class TestKnownPositionSchemas:
     def test_string_coerced_to_int(self, schema, field):
         assert schema({"entity_id": "cover.x", field: "50"})[field] == 50
 
-    def test_area_target_accepted(self, schema, field):
-        assert schema({"area_id": "kitchen", field: 50})["area_id"] == ["kitchen"]
-
-    def test_device_target_accepted(self, schema, field):
-        assert schema({"device_id": "abc123", field: 50})["device_id"] == ["abc123"]
-
-    def test_label_target_accepted(self, schema, field):
-        assert schema({"label_id": "blinds", field: 50})["label_id"] == ["blinds"]
+    @pytest.mark.parametrize(
+        ("key", "value"),
+        [("area_id", "kitchen"), ("device_id", "abc123"), ("label_id", "blinds")],
+    )
+    def test_target_kinds_accepted(self, schema, field, key, value):
+        assert schema({key: value, field: 50})[key] == [value]
 
     def test_some_target_required(self, schema, field):
         with pytest.raises(vol.Invalid):

--- a/tests/test_cover_services.py
+++ b/tests/test_cover_services.py
@@ -375,7 +375,12 @@ class TestKnownPositionSchemas:
 
     @pytest.mark.parametrize(
         ("key", "value"),
-        [("area_id", "kitchen"), ("device_id", "abc123"), ("label_id", "blinds")],
+        [
+            ("area_id", "kitchen"),
+            ("device_id", "abc123"),
+            ("floor_id", "ground"),
+            ("label_id", "blinds"),
+        ],
     )
     def test_target_kinds_accepted(self, schema, field, key, value):
         assert schema({key: value, field: 50})[key] == [value]

--- a/tests/test_cover_services.py
+++ b/tests/test_cover_services.py
@@ -16,8 +16,10 @@ from custom_components.cover_time_based.cover import (
     CONF_TRAVEL_TIME_CLOSE,
     CONF_TRAVEL_TIME_OPEN,
     CONTROL_MODE_SWITCH,
+    POSITION_SCHEMA,
     SERVICE_START_CALIBRATION,
     SERVICE_STOP_CALIBRATION,
+    TILT_POSITION_SCHEMA,
     _admin_only,
     _create_cover_from_options,
     _register_services,
@@ -340,3 +342,48 @@ class TestServiceFieldTranslationsMatchServicesYaml:
         for service in ("start_calibration", "stop_calibration"):
             assert "entity_id" in yaml_fields[service]
             assert "entity_id" in strings_fields[service]
+
+
+# ---------------------------------------------------------------------------
+# set_known_position / set_known_tilt_position schemas
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("schema", "field"),
+    [(POSITION_SCHEMA, "position"), (TILT_POSITION_SCHEMA, "tilt_position")],
+    ids=["position", "tilt_position"],
+)
+class TestKnownPositionSchemas:
+    """Both services are target-based (services.yaml declares `target:`), so
+    they must accept any HA target kind, and their percent must stay in
+    0..100 — a value above 100 used to be tracked, persisted, and turned the
+    next close into a 1.5x-travel move."""
+
+    def test_above_100_rejected(self, schema, field):
+        with pytest.raises(vol.Invalid):
+            schema({"entity_id": "cover.x", field: 150})
+
+    def test_negative_rejected(self, schema, field):
+        with pytest.raises(vol.Invalid):
+            schema({"entity_id": "cover.x", field: -1})
+
+    def test_endpoints_accepted(self, schema, field):
+        assert schema({"entity_id": "cover.x", field: 0})[field] == 0
+        assert schema({"entity_id": "cover.x", field: 100})[field] == 100
+
+    def test_string_coerced_to_int(self, schema, field):
+        assert schema({"entity_id": "cover.x", field: "50"})[field] == 50
+
+    def test_area_target_accepted(self, schema, field):
+        assert schema({"area_id": "kitchen", field: 50})["area_id"] == ["kitchen"]
+
+    def test_device_target_accepted(self, schema, field):
+        assert schema({"device_id": "abc123", field: 50})["device_id"] == ["abc123"]
+
+    def test_label_target_accepted(self, schema, field):
+        assert schema({"label_id": "blinds", field: 50})["label_id"] == ["blinds"]
+
+    def test_some_target_required(self, schema, field):
+        with pytest.raises(vol.Invalid):
+            schema({field: 50})

--- a/tests/test_websocket_api.py
+++ b/tests/test_websocket_api.py
@@ -1507,21 +1507,44 @@ class TestPulseTimeSchemaValidation:
 
 
 class TestTimingFieldValidation:
-    """Verify that travel/tilt time fields reject 0 (min 0.1) while delay fields allow it."""
+    """The duration floor is one constant shared with the YAML schema, so the
+    websocket side is pinned against the registered schema rather than a local
+    copy of the validator. Delay and auxiliary fields sit below that floor:
+    0 is a legitimate value for them.
+    """
 
     @pytest.mark.parametrize(
-        "field",
-        ["travel_time_close", "travel_time_open", "tilt_time_close", "tilt_time_open"],
+        ("field", "maximum"),
+        [
+            ("pulse_time", 10),
+            ("travel_time_close", 600),
+            ("travel_time_open", 600),
+            ("tilt_time_close", 600),
+            ("tilt_time_open", 600),
+        ],
     )
-    def test_zero_rejected_for_travel_tilt_times(self, field):
-        """travel_time_* and tilt_time_* require >= 0.1."""
+    def test_duration_bounds(self, field, maximum):
+        """Durations span MIN_DURATION..maximum inclusive; outside is rejected."""
         import voluptuous as vol
 
-        validator = vol.All(vol.Coerce(float), vol.Range(min=0.1, max=600))
+        schema = ws_update_config._ws_schema
+
+        def call(value):
+            return schema(
+                {
+                    "id": 1,
+                    "type": "cover_time_based/update_config",
+                    "entity_id": ENTITY_ID,
+                    field: value,
+                }
+            )
+
         with pytest.raises(vol.Invalid):
-            validator(0)
-        # 0.1 must be accepted
-        assert validator(0.1) == pytest.approx(0.1)
+            call(0)
+        assert call(0.1)[field] == pytest.approx(0.1)
+        assert call(maximum)[field] == pytest.approx(maximum)
+        with pytest.raises(vol.Invalid):
+            call(maximum + 0.1)
 
     @pytest.mark.parametrize(
         "field",
@@ -1534,10 +1557,16 @@ class TestTimingFieldValidation:
     )
     def test_zero_accepted_for_delay_fields(self, field):
         """Delay and auxiliary timing fields allow 0."""
-        import voluptuous as vol
-
-        validator = vol.All(vol.Coerce(float), vol.Range(min=0, max=600))
-        assert validator(0) == pytest.approx(0)
+        schema = ws_update_config._ws_schema
+        result = schema(
+            {
+                "id": 1,
+                "type": "cover_time_based/update_config",
+                "entity_id": ENTITY_ID,
+                field: 0,
+            }
+        )
+        assert result[field] == pytest.approx(0)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Three schema fixes from a whole-integration review.

- **`set_known_position` / `set_known_tilt_position`** passed an explicit required `entity_id` into `cv.make_entity_service_schema`, which overrode HA's optional target keys: the action editor offered areas and devices (`services.yaml` declares `target:`) but only an entity target validated. They also used `cv.positive_int`, so `position: 150` was accepted, tracked and persisted, and the next close ran for 1.5× the travel time. Now a shared `PERCENT` validator (HA's own `ATTR_POSITION` range) and no explicit entity key, so entity, device, area, floor and label targets all work and at least one is required.
- **YAML accepted a travel, tilt or pulse time of 0** (`cv.positive_float`), while the websocket schema enforced a 0.1 s floor. With 0 the first tracker tick saw the position reached and stopped immediately. Now `MIN_DURATION = 0.1` lives in `cover.py`; the YAML schema uses it for the five duration keys, and the websocket schema imports it (and `PERCENT`) so the two entry points cannot drift. Startup delays, endpoint run-on and min-movement still allow 0.
- **CHANGELOG**: the Czech translation (#241) was missing from the 4.12.0 section; added, plus the two Fixes lines. README notes the 0.1 s minimum in the YAML table and the accepted target kinds on the two services.

## Tests

- Unit: schema tests for both services (range, coercion, each target kind, at-least-one-target), YAML `PLATFORM_SCHEMA` / `DEFAULTS_SCHEMA` rejecting 0 and accepting 0.1 for each key (0 still accepted for startup delay), and the websocket duration and tilt-percent fields now validated against the real registered schema (mutating `MIN_DURATION` fails them).
- Integration: `set_known_position` and `set_known_tilt_position` called through `hass.services.async_call` with an `area_id` target set the tracked positions.
- During review: base-vs-head probes confirmed the original defects and that every change is mutation-guarded.
