### PR TITLE
fix: decide travel arrival by elapsed time, not integer truncation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,9 @@
 ### Fixes
 
 - **The configuration card's backend websocket commands and the `start_calibration` / `stop_calibration` actions now require an administrator account**: they accepted any authenticated user, including read-only ones, and now return `unauthorized` for non-administrators, matching how Home Assistant itself gates configuration changes.
-- **`set_known_position` and `set_known_tilt_position` now accept area, device and label targets and reject values outside 0–100**: the action editor offered areas and devices, but only an entity target validated; and a position above 100 was accepted and tracked, so the next close ran for longer than a full travel.
-- **YAML configuration now rejects a travel, tilt or pulse time of `0`**, as the configuration card already did. A zero duration made the cover twitch while Home Assistant reported it at the endpoint.
 - **`set_known_position` and `set_known_tilt_position` now accept area, floor, device and label targets and reject values outside 0–100**: the action editor offered areas and devices, but only an entity target validated; and a position above 100 was accepted and tracked, so the next close ran for longer than a full travel.
 - **YAML configuration now rejects a travel, tilt or pulse time below 0.1 s**: the configuration card already enforced that minimum, and a zero duration made the cover twitch while Home Assistant reported it at the endpoint.
+- **Partial moves now run for their full travel time in both directions**: the tracked position was truncated to a whole number, so a closing move counted as arrived up to one step early (a one-step close stopped on its first tick) while an opening move waited for the clock. Repeated partial closes drifted "more open" than tracked. Arrival is now decided by elapsed time alone, and the intermediate position is rounded. A cover now reads `closed`/`open` only when its travel time has elapsed, and a stop in the final half-step leaves it one step short rather than at the endpoint.
 
 ## 4.11.0 (2026-08-04)
 

--- a/custom_components/cover_time_based/travel_calculator.py
+++ b/custom_components/cover_time_based/travel_calculator.py
@@ -195,7 +195,13 @@ class TravelCalculator:
         self.start_travel(self.position_closed)
 
     def current_position(self) -> int | None:
-        """Return current (calculated or known) position."""
+        """Return current (calculated or known) position.
+
+        While a move is in flight, the calculated position never equals the
+        target until the travel time has elapsed; position_reached,
+        is_traveling, is_open, is_closed and external `== target` checks rely
+        on this.
+        """
         if not self._position_confirmed:
             return self._calculate_position()
         return self._last_known_position
@@ -259,14 +265,21 @@ class TravelCalculator:
         )
         if remaining_travel_time <= 0:
             return self._travel_to_position
-        if time.time() > self._last_known_position_timestamp + remaining_travel_time:
+        now = time.time()
+        if now >= self._last_known_position_timestamp + remaining_travel_time:
             return self._travel_to_position
 
         progress = max(
             0.0,
-            (time.time() - self._last_known_position_timestamp) / remaining_travel_time,
+            (now - self._last_known_position_timestamp) / remaining_travel_time,
         )
-        return int(self._last_known_position + relative_position * progress)
+        position = round(self._last_known_position + relative_position * progress)
+        # Arrival is the time check above, never rounding: hold one step short of the
+        # target so position_reached()/is_traveling()/stop() and external `== target`
+        # checks cannot call the move done while the motor is still running.
+        if position == self._travel_to_position:
+            position = self._travel_to_position - (1 if relative_position > 0 else -1)
+        return position
 
     def calculate_travel_time(self, from_position: int, to_position: int) -> float:
         """Calculate time to travel from one position to another."""

--- a/tests/test_travel_calculator.py
+++ b/tests/test_travel_calculator.py
@@ -2,10 +2,23 @@
 
 from unittest.mock import patch
 
+import pytest
+
 from custom_components.cover_time_based.travel_calculator import (
     TravelCalculator,
     TravelStatus,
 )
+
+
+@pytest.fixture
+def mock_time():
+    """Patch the calculator's clock, anchored at 1000.0, so a test drives
+    travel progress by setting ``mock_time.time.return_value``."""
+    with patch(
+        "custom_components.cover_time_based.travel_calculator.time"
+    ) as mocked_time:
+        mocked_time.time.return_value = 1000.0
+        yield mocked_time
 
 
 class TestTravelCalculatorEdgeCases:
@@ -93,46 +106,113 @@ class TestTravelCalculatorEdgeCases:
         calc.set_position(0)
         assert calc.is_open() is False
 
-    def test_position_returns_target_when_time_exceeded(self):
+    def test_position_returns_target_when_time_exceeded(self, mock_time):
         """current_position() returns target when travel time has elapsed."""
         calc = TravelCalculator(travel_time_down=10, travel_time_up=10)
         calc.set_position(0)
 
-        # Start travel, then advance time past the full travel duration
-        with patch(
-            "custom_components.cover_time_based.travel_calculator.time"
-        ) as mock_time:
-            mock_time.time.return_value = 1000.0
-            calc.start_travel(100)
-            # Now advance time past the travel duration (10s for full range)
-            mock_time.time.return_value = 1020.0
-            pos = calc.current_position()
-            assert pos == 100
+        calc.start_travel(100)
+        # Advance time past the travel duration (10s for full range).
+        mock_time.time.return_value = 1020.0
+        pos = calc.current_position()
+        assert pos == 100
 
-    def test_start_travel_base_timestamp_in_past_advances_position(self):
+    def test_start_travel_base_timestamp_in_past_advances_position(self, mock_time):
         """start_travel(base_timestamp=...) anchors the move's start at that
         timestamp instead of 'now'. A base already in the past means travel
         that began then is already partly complete — this is how relay-feedback
         timing starts tracking from the switch echo's last_changed."""
         calc = TravelCalculator(travel_time_down=30, travel_time_up=30)
         calc.set_position(0)
-        with patch(
-            "custom_components.cover_time_based.travel_calculator.time"
-        ) as mock_time:
-            mock_time.time.return_value = 1000.0
-            # Motor actually got power 15s ago — half of the 30s open travel.
-            calc.start_travel(100, base_timestamp=985.0)
-            assert calc.current_position() == 50
+        # Motor actually got power 15s ago — half of the 30s open travel.
+        calc.start_travel(100, base_timestamp=985.0)
+        assert calc.current_position() == 50
 
-    def test_start_travel_base_timestamp_in_future_holds_position(self):
+    def test_start_travel_base_timestamp_in_future_holds_position(self, mock_time):
         """A base_timestamp in the future holds the start position until real
         time reaches it (the fixed startup delay is folded in this way)."""
         calc = TravelCalculator(travel_time_down=30, travel_time_up=30)
         calc.set_position(0)
-        with patch(
-            "custom_components.cover_time_based.travel_calculator.time"
-        ) as mock_time:
-            mock_time.time.return_value = 1000.0
-            # Base 5s in the future: no progress yet.
-            calc.start_travel(100, base_timestamp=1005.0)
-            assert calc.current_position() == 0
+        # Base 5s in the future: no progress yet.
+        calc.start_travel(100, base_timestamp=1005.0)
+        assert calc.current_position() == 0
+
+
+class TestArrivalIsDecidedByTime:
+    """The target is reached only once the travel time has elapsed, in both
+    directions."""
+
+    # 60 s each way, so one position step is 0.6 s.
+    @pytest.mark.parametrize(
+        ("start", "target", "elapsed", "expected_midway"),
+        [
+            (50, 30, 12.0 * 0.951, 31),
+            (30, 50, 12.0 * 0.999, 49),
+            (51, 50, 0.3, 51),  # one-step close, half a step in
+            (50, 51, 0.3, 50),  # one-step open, half a step in
+            (52, 50, 0.6, 51),  # 50% of the 1.2 s move
+            (52, 50, 0.9, 51),  # 75% in, past the step boundary
+            (10, 0, 6.0 * 0.999, 1),  # close to the endpoint
+        ],
+        ids=[
+            "close-mid",
+            "open-mid",
+            "one-step-close",
+            "one-step-open",
+            "two-step-half",
+            "two-step-past-half",
+            "to-endpoint",
+        ],
+    )
+    def test_position_holds_short_of_target_until_time_elapses(
+        self, mock_time, start, target, elapsed, expected_midway
+    ):
+        """Mid-move the position sits short of the target, reaching it only
+        once the full travel time has elapsed."""
+        calc = TravelCalculator(travel_time_down=60, travel_time_up=60)
+        calc.set_position(start)
+        calc.start_travel(target)
+
+        mock_time.time.return_value = 1000.0 + elapsed
+        assert calc.current_position() == expected_midway
+        assert not calc.position_reached()
+        assert calc.is_traveling()
+        if target == 0:
+            assert not calc.is_closed()
+
+        full_travel_time = abs(target - start) * 0.6
+        mock_time.time.return_value = 1000.0 + full_travel_time + 0.001
+        assert calc.current_position() == target
+        assert calc.position_reached()
+        if target == 0:
+            assert calc.is_closed()
+
+    @pytest.mark.parametrize(
+        ("start", "target"), [(50, 30), (30, 50)], ids=["close", "open"]
+    )
+    def test_arrival_at_the_exact_boundary(self, mock_time, start, target):
+        """Elapsed includes equality: at exactly the travel time the target is
+        reached, not held one step short."""
+        calc = TravelCalculator(travel_time_down=60, travel_time_up=60)
+        calc.set_position(start)
+        calc.start_travel(target)
+
+        mock_time.time.return_value = 1000.0 + 12.0
+        assert calc.current_position() == target
+        assert calc.position_reached()
+
+    def test_intermediate_position_is_rounded_symmetrically(self, mock_time):
+        """The same fraction of a move reads the same distance travelled in
+        either direction."""
+        calc = TravelCalculator(travel_time_down=60, travel_time_up=60)
+        calc.set_position(0)
+        calc.start_travel(100)
+        mock_time.time.return_value = 1000.0 + 60 * 0.337  # 33.7 -> 34
+        assert calc.current_position() == 34
+
+        mock_time.time.return_value = 1000.0
+        calc = TravelCalculator(travel_time_down=60, travel_time_up=60)
+        calc.set_position(100)
+        calc.start_travel(0)
+        mock_time.time.return_value = 1000.0 + 60 * 0.337  # 66.3 -> 66
+        assert calc.current_position() == 66


### PR DESCRIPTION
## Summary

`TravelCalculator._calculate_position` truncated the intermediate position with `int()`, and `position_reached()` compares that integer with the target. For a decreasing move the tracker equalled the target as soon as the true value dropped below `target + 1`; an increasing move only arrived when the time check returned the target. Consequences, verified in review against a real switch-mode cover:

- A 50→30 move on a 60 s cover "arrived" at 95 % and cut the relay early; 30→50 waited for the clock.
- A one-step close (51→50) arrived on its **first tick**; a two-step close at ~58 %. Short closes barely moved the motor.
- Repeated partial closes drifted "more open" than tracked, and the `is_traveling()` window that reversal logic depends on was narrowed. Overhead calibration under-drove every close-direction step.

The fix rounds the intermediate position and holds it one step short of the target until the existing elapsed-time check declares arrival, so both directions arrive at exactly 100 % of the travel time. Value-level rather than a separate predicate because two external callers compare `current_position()` against a target directly (`cover_base` endpoint settle, the calibration loop).

Visible consequence: a cover reads `closed`/`open` only when its travel time has elapsed, and a stop in the final half-step leaves it one step short rather than at the endpoint (physically it is at ~0.5 %; the old value lied the other way).

## Tests

- New calculator tests: long, one-step, two-step and endpoint moves in both directions (mid-move not reached, reached at full time), symmetric rounding. They fail on `main` (6 of 19).
- No pre-existing test changed: nothing in the suite depended on the truncation.
- Review ran a 20 000-move fuzz (never early, never more than one step from exact, monotonic, in range, arrival at 100 %) with 0 violations at head and ~93 000 early arrivals at base, plus real-HA runs of short closes showing the relay now held for the full step time.

## Also

Removes two stale duplicate lines from the 4.12.0 changelog (the pre-review wording of #265's two entries, which a rebase replayed as additions next to their final wording).