### PR TITLE
perf: cheaper auto-updater ticks, wrapped-cover decisions and card registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - **`set_known_position` and `set_known_tilt_position` now accept area, floor, device and label targets and reject values outside 0–100**: the action editor offered areas and devices, but only an entity target validated; and a position above 100 was accepted and tracked, so the next close ran for longer than a full travel.
 - **YAML configuration now rejects a travel, tilt or pulse time below 0.1 s**: the configuration card already enforced that minimum, and a zero duration made the cover twitch while Home Assistant reported it at the endpoint.
 - **Partial moves now run for their full travel time in both directions**: the tracked position was truncated to a whole number, so a closing move counted as arrived up to one step early (a one-step close stopped on its first tick) while an opening move waited for the clock. Repeated partial closes drifted "more open" than tracked. Arrival is now decided by elapsed time alone, and the intermediate position is rounded. A cover now reads `closed`/`open` only when its travel time has elapsed, and a stop in the final half-step leaves it one step short rather than at the endpoint.
+- **Wrapped covers with a startup delay no longer drop a reversal issued during that delay after the device re-reports its position**: a redundant position report used to reset the pending move's bookkeeping, so the next command was ignored and the cover ran on to the endpoint.
 
 ## 4.11.0 (2026-08-04)
 

--- a/custom_components/cover_time_based/__init__.py
+++ b/custom_components/cover_time_based/__init__.py
@@ -13,7 +13,6 @@ from homeassistant.helpers.typing import ConfigType
 from .card_resources import (
     async_register_card_resource,
     async_unregister_card_resource,
-    card_resource_registered,
 )
 from .const import DOMAIN
 from .position_storage import async_get_position_store
@@ -63,10 +62,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Cover Time Based from a config entry."""
     # Re-establishes the card resource when an entry is added after the last
-    # one was removed (which unregisters it). Once recorded for this session,
-    # every further entry would only rescan every Lovelace resource.
-    if not card_resource_registered(hass):
-        await async_register_card_resource(hass, _CARD_BASE_URL, _CARD_JS_URL)
+    # one was removed (which unregisters it); a no-op otherwise — the registrar
+    # returns early once the id is recorded for this session.
+    await async_register_card_resource(hass, _CARD_BASE_URL, _CARD_JS_URL)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(async_update_options))
 

--- a/custom_components/cover_time_based/__init__.py
+++ b/custom_components/cover_time_based/__init__.py
@@ -13,6 +13,7 @@ from homeassistant.helpers.typing import ConfigType
 from .card_resources import (
     async_register_card_resource,
     async_unregister_card_resource,
+    card_resource_registered,
 )
 from .const import DOMAIN
 from .position_storage import async_get_position_store
@@ -61,10 +62,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Cover Time Based from a config entry."""
-    # Idempotent: re-establishes the card resource whenever an entry is added,
-    # including re-adding a cover after the last one was removed (which
-    # unregisters the resource) — async_setup only runs once per session.
-    await async_register_card_resource(hass, _CARD_BASE_URL, _CARD_JS_URL)
+    # Re-establishes the card resource when an entry is added after the last
+    # one was removed (which unregisters it). Once recorded for this session,
+    # every further entry would only rescan every Lovelace resource.
+    if not card_resource_registered(hass):
+        await async_register_card_resource(hass, _CARD_BASE_URL, _CARD_JS_URL)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(async_update_options))
 

--- a/custom_components/cover_time_based/card_resources.py
+++ b/custom_components/cover_time_based/card_resources.py
@@ -82,11 +82,13 @@ async def async_register_card_resource(
     resource left over from a previous version so it can be cache-busted in
     place; ``card_url`` is the current, content-hashed URL. Falls back to
     ``add_extra_js_url`` if the Lovelace resource store isn't available.
+    Returns immediately once the resource id is recorded for this session.
     """
     # Once recorded for this session the resource exists; every further entry
     # setup would only rescan every Lovelace resource to reach the same state.
     # async_unregister_card_resource pops the id, so a re-add after the last
-    # removal registers again.
+    # removal registers again — but a resource deleted by hand mid-session is
+    # only re-created on restart, or once the last entry is removed.
     if _RESOURCE_ID_KEY in hass.data.get(DOMAIN, {}):
         return
 
@@ -154,7 +156,8 @@ async def async_unregister_card_resource(
 
     Mirrors :func:`async_register_card_resource`: deletes the resource by the id
     stored at registration time, or — if the card was added via the
-    ``add_extra_js_url`` fallback (no stored id) — removes that instead.
+    ``add_extra_js_url`` fallback (no stored id) — removes that instead, and
+    forgets the recorded id, re-arming :func:`async_register_card_resource`.
     """
     resource_id = hass.data.get(DOMAIN, {}).get(_RESOURCE_ID_KEY)
     if resource_id is None:

--- a/custom_components/cover_time_based/card_resources.py
+++ b/custom_components/cover_time_based/card_resources.py
@@ -43,6 +43,11 @@ def _record_resource_id(hass: HomeAssistant, resource_id: str) -> None:
     hass.data.setdefault(DOMAIN, {})[_RESOURCE_ID_KEY] = resource_id
 
 
+def card_resource_registered(hass: HomeAssistant) -> bool:
+    """Whether this session already recorded the card's Lovelace resource id."""
+    return _RESOURCE_ID_KEY in hass.data.get(DOMAIN, {})
+
+
 def _create_refresh_issue(hass: HomeAssistant) -> None:
     """Raise a repair issue telling the user to hard-refresh for the new card.
 
@@ -159,11 +164,16 @@ async def async_unregister_card_resource(
             )
         return
 
+    # Dropped before the delete, not after it: once we've decided the resource
+    # is going, a stale id must not survive a failed delete (a hand-deleted
+    # resource makes it raise) — async_setup_entry treats a recorded id as
+    # "already registered" and would skip re-registering for the session. A
+    # transient failure is safe: the next register rescans by URL and re-records.
+    hass.data.get(DOMAIN, {}).pop(_RESOURCE_ID_KEY, None)
     try:
         resources = _get_lovelace_resources(hass)
         if resources is not None and hasattr(resources, "async_delete_item"):
             await resources.async_delete_item(resource_id)
-            hass.data.get(DOMAIN, {}).pop(_RESOURCE_ID_KEY, None)
     except Exception:  # pylint: disable=broad-exception-caught
         _LOGGER.debug(
             "Could not remove Lovelace resource %s", resource_id, exc_info=True

--- a/custom_components/cover_time_based/card_resources.py
+++ b/custom_components/cover_time_based/card_resources.py
@@ -43,11 +43,6 @@ def _record_resource_id(hass: HomeAssistant, resource_id: str) -> None:
     hass.data.setdefault(DOMAIN, {})[_RESOURCE_ID_KEY] = resource_id
 
 
-def card_resource_registered(hass: HomeAssistant) -> bool:
-    """Whether this session already recorded the card's Lovelace resource id."""
-    return _RESOURCE_ID_KEY in hass.data.get(DOMAIN, {})
-
-
 def _create_refresh_issue(hass: HomeAssistant) -> None:
     """Raise a repair issue telling the user to hard-refresh for the new card.
 
@@ -88,6 +83,13 @@ async def async_register_card_resource(
     place; ``card_url`` is the current, content-hashed URL. Falls back to
     ``add_extra_js_url`` if the Lovelace resource store isn't available.
     """
+    # Once recorded for this session the resource exists; every further entry
+    # setup would only rescan every Lovelace resource to reach the same state.
+    # async_unregister_card_resource pops the id, so a re-add after the last
+    # removal registers again.
+    if _RESOURCE_ID_KEY in hass.data.get(DOMAIN, {}):
+        return
+
     # Set only when the resource is created for the first time — the sole case
     # that warrants a refresh prompt (see _create_refresh_issue for why).
     installed = False
@@ -166,8 +168,8 @@ async def async_unregister_card_resource(
 
     # Dropped before the delete, not after it: once we've decided the resource
     # is going, a stale id must not survive a failed delete (a hand-deleted
-    # resource makes it raise) — async_setup_entry treats a recorded id as
-    # "already registered" and would skip re-registering for the session. A
+    # resource makes it raise) — async_register_card_resource treats a recorded
+    # id as "already registered" and would skip re-registering for the session. A
     # transient failure is safe: the next register rescans by URL and re-records.
     hass.data.get(DOMAIN, {}).pop(_RESOURCE_ID_KEY, None)
     try:

--- a/custom_components/cover_time_based/cover_base.py
+++ b/custom_components/cover_time_based/cover_base.py
@@ -2655,7 +2655,7 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         self._log("start_auto_updater")
         if self._unsubscribe_auto_updater is None:
             self._log("init _unsubscribe_auto_updater")
-            # Forget the last written snapshot so the first tick always writes.
+            # Forget the last written positions so the first tick always writes.
             self._auto_updater_last_written = None
             interval = timedelta(seconds=0.1)
             self._unsubscribe_auto_updater = async_track_time_interval(
@@ -2666,14 +2666,14 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
     def auto_updater_hook(self, _now):
         """Call for the autoupdater.
 
-        Write only when the snapshot the UI sees changed; spawn the auto-stop
-        only on arrival.
+        Write only when the reported position or tilt changed; spawn the
+        auto-stop only on arrival.
         """
-        snapshot = (self.current_cover_position, self.current_cover_tilt_position)
-        if snapshot != self._auto_updater_last_written:
-            self._auto_updater_last_written = snapshot
+        positions = (self.current_cover_position, self.current_cover_tilt_position)
+        if positions != self._auto_updater_last_written:
+            self._auto_updater_last_written = positions
             self.async_schedule_update_ha_state()
-        if self.position_reached(snapshot):
+        if self.position_reached(positions=positions):
             self._log("auto_updater_hook :: position_reached")
             self.stop_auto_updater()
             self.hass.async_create_task(self.auto_stop_if_necessary())
@@ -2685,14 +2685,16 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
             self._unsubscribe_auto_updater()
             self._unsubscribe_auto_updater = None
 
-    def position_reached(self, snapshot=None):
+    def position_reached(
+        self, *, positions: tuple[int | None, int | None] | None = None
+    ) -> bool:
         """Return if cover has reached its final position.
 
-        ``snapshot`` is a ``(position, tilt_position)`` pair a caller already
+        ``positions`` is a ``(position, tilt_position)`` pair a caller already
         computed (the auto-updater tick), handed down so neither calculator
         recalculates. Its tilt member is ignored when tilt is unsupported.
         """
-        travel_pos, tilt_pos = (None, None) if snapshot is None else snapshot
+        travel_pos, tilt_pos = (None, None) if positions is None else positions
         return self.travel_calc.position_reached(travel_pos) and (
             not self._has_tilt_support() or self.tilt_calc.position_reached(tilt_pos)
         )

--- a/custom_components/cover_time_based/cover_base.py
+++ b/custom_components/cover_time_based/cover_base.py
@@ -2666,19 +2666,14 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
     def auto_updater_hook(self, _now):
         """Call for the autoupdater.
 
-        Ticks every 100 ms while moving, but the integer position changes far
-        less often on a long travel: write state only when the snapshot the
-        UI sees has changed, and spawn the auto-stop only on arrival — its
-        body is entirely inside the same position_reached check.
+        Write only when the snapshot the UI sees changed; spawn the auto-stop
+        only on arrival.
         """
-        snapshot = (
-            self.travel_calc.current_position(),
-            self.tilt_calc.current_position() if self._has_tilt_support() else None,
-        )
+        snapshot = (self.current_cover_position, self.current_cover_tilt_position)
         if snapshot != self._auto_updater_last_written:
             self._auto_updater_last_written = snapshot
             self.async_schedule_update_ha_state()
-        if self.position_reached():
+        if self.position_reached(snapshot):
             self._log("auto_updater_hook :: position_reached")
             self.stop_auto_updater()
             self.hass.async_create_task(self.auto_stop_if_necessary())
@@ -2690,10 +2685,16 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
             self._unsubscribe_auto_updater()
             self._unsubscribe_auto_updater = None
 
-    def position_reached(self):
-        """Return if cover has reached its final position."""
-        return self.travel_calc.position_reached() and (
-            not self._has_tilt_support() or self.tilt_calc.position_reached()
+    def position_reached(self, snapshot=None):
+        """Return if cover has reached its final position.
+
+        ``snapshot`` is a ``(position, tilt_position)`` pair a caller already
+        computed (the auto-updater tick), handed down so neither calculator
+        recalculates. Its tilt member is ignored when tilt is unsupported.
+        """
+        travel_pos, tilt_pos = (None, None) if snapshot is None else snapshot
+        return self.travel_calc.position_reached(travel_pos) and (
+            not self._has_tilt_support() or self.tilt_calc.position_reached(tilt_pos)
         )
 
     # -----------------------------------------------------------------------
@@ -2701,7 +2702,11 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
     # -----------------------------------------------------------------------
 
     async def auto_stop_if_necessary(self):
-        """Do auto stop if necessary."""
+        """Do auto stop if necessary.
+
+        ``auto_updater_hook`` spawns this only on arrival, so anything added
+        outside the ``position_reached`` check below would never run for it.
+        """
         if self.position_reached():
             self._log(
                 "auto_stop_if_necessary :: position reached (self_initiated=%s)",

--- a/custom_components/cover_time_based/cover_base.py
+++ b/custom_components/cover_time_based/cover_base.py
@@ -244,7 +244,13 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
             )
 
     def _log(self, msg, *args):
-        """Log a debug message prefixed with the entity ID."""
+        """Log a debug message prefixed with the entity ID.
+
+        Guarded: this is called on every tick and event, so the format
+        concat and the logger call must cost nothing with DEBUG off.
+        """
+        if not _LOGGER.isEnabledFor(logging.DEBUG):
+            return
         _LOGGER.debug("(%s) " + msg, self.entity_id, *args)
 
     def _extra_persist_data(self) -> dict:

--- a/custom_components/cover_time_based/cover_base.py
+++ b/custom_components/cover_time_based/cover_base.py
@@ -171,6 +171,7 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         self._config_entry_id: str | None = None
         self._calibration: CalibrationState | None = None
         self._unsubscribe_auto_updater = None
+        self._auto_updater_last_written: tuple | None = None
         self._delay_task = None
         self._startup_delay_task = None
         self._last_command = None
@@ -2649,6 +2650,8 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         self._log("start_auto_updater")
         if self._unsubscribe_auto_updater is None:
             self._log("init _unsubscribe_auto_updater")
+            # Forget the last written snapshot so the first tick always writes.
+            self._auto_updater_last_written = None
             interval = timedelta(seconds=0.1)
             self._unsubscribe_auto_updater = async_track_time_interval(
                 self.hass, self.auto_updater_hook, interval
@@ -2656,12 +2659,24 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
 
     @callback
     def auto_updater_hook(self, _now):
-        """Call for the autoupdater."""
-        self.async_schedule_update_ha_state()
+        """Call for the autoupdater.
+
+        Ticks every 100 ms while moving, but the integer position changes far
+        less often on a long travel: write state only when the snapshot the
+        UI sees has changed, and spawn the auto-stop only on arrival — its
+        body is entirely inside the same position_reached check.
+        """
+        snapshot = (
+            self.travel_calc.current_position(),
+            self.tilt_calc.current_position() if self._has_tilt_support() else None,
+        )
+        if snapshot != self._auto_updater_last_written:
+            self._auto_updater_last_written = snapshot
+            self.async_schedule_update_ha_state()
         if self.position_reached():
             self._log("auto_updater_hook :: position_reached")
             self.stop_auto_updater()
-        self.hass.async_create_task(self.auto_stop_if_necessary())
+            self.hass.async_create_task(self.auto_stop_if_necessary())
 
     def stop_auto_updater(self):
         """Stop the autoupdater."""

--- a/custom_components/cover_time_based/cover_base.py
+++ b/custom_components/cover_time_based/cover_base.py
@@ -2578,10 +2578,9 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
                 base_timestamp=base_timestamp,
             )
             if coupled_target is not None:
-                # extra_delay (mechanical startup delay) applies to the coupled
-                # calc too: the old sleep-based path delayed the whole start
-                # callback, offsetting both calcs equally. pre_step_delay is the
-                # primary's alone — the coupled calc IS the pre-step.
+                # extra_delay (the mechanical startup delay) applies to the
+                # coupled calc too so both calcs start together; pre_step_delay
+                # is the primary's alone — the coupled calc IS the pre-step.
                 coupled_calc.start_travel(
                     int(coupled_target),
                     delay=extra_delay,

--- a/custom_components/cover_time_based/cover_single_button_mode.py
+++ b/custom_components/cover_time_based/cover_single_button_mode.py
@@ -122,11 +122,7 @@ class SingleButtonModeCover(SwitchCoverTimeBased):
         wait pulse_time, OFF -- fully resolved before the next press's gap
         even starts. This guarantees the button is OFF between consecutive
         presses regardless of how pulse_time compares to
-        DIRECTION_CHANGE_DELAY (the previous behaviour scheduled each press's
-        OFF as a background task, so with the default pulse_time equal to
-        DIRECTION_CHANGE_DELAY a re-press could race and cancel the prior
-        press's pending OFF -- the motor would then register fewer presses
-        than intended, desyncing the tracked phase).
+        DIRECTION_CHANGE_DELAY.
 
         `_phase` is updated -- and `_press_active` raised -- immediately
         after the ON edge, before the pulse-time sleep, not after the OFF: a

--- a/custom_components/cover_time_based/cover_wrapped.py
+++ b/custom_components/cover_time_based/cover_wrapped.py
@@ -135,14 +135,15 @@ class WrappedCoverTimeBased(CoverTimeBased):
         """Wrapped mode drives the wrapped cover entity for all tilt."""
         return self._cover_entity_id
 
-    def _wrapped_features(self) -> int | None:
+    def _wrapped_features(self, *, state=None) -> int | None:
         """Return the wrapped entity's supported_features bitmask, or None.
 
         None means "unknown" — the entity is missing, unavailable, or reports
         no integer feature bitmask. Mirrors _wrapped_supports_tilt's treatment
-        of an offline entity as "don't assume capabilities".
+        of an offline entity as "don't assume capabilities". ``state`` lets a
+        caller that already holds the entity's state skip the machine read.
         """
-        state = self.hass.states.get(self._cover_entity_id)
+        state = self.hass.states.get(self._cover_entity_id) if state is None else state
         if state is None or state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
             return None
         features = state.attributes.get(ATTR_SUPPORTED_FEATURES)
@@ -154,8 +155,9 @@ class WrappedCoverTimeBased(CoverTimeBased):
         """Return True if the wrapped cover advertises native SET_POSITION.
 
         ``features`` lets a caller that already fetched the bitmask reuse it;
-        None means fetch. Every fetch is a state-machine read, and one decision
-        used to make several.
+        None means fetch. One decision reads the state machine once and judges
+        the whole chain against the same bitmask, so it can't answer half its
+        questions from a capability set that changed mid-decision.
         """
         features = self._wrapped_features() if features is None else features
         return features is not None and bool(features & CoverEntityFeature.SET_POSITION)
@@ -257,7 +259,12 @@ class WrappedCoverTimeBased(CoverTimeBased):
         The bitmask is fetched once here and threaded through the decision:
         the chain below would otherwise read the state machine up to 3 times.
         """
-        if self._use_native_set_position(features=self._wrapped_features()):
+        features = self._wrapped_features()
+        # Unknown capabilities: every support helper answers False on None, so
+        # the decision below can only land on the timed driver.
+        if features is None:
+            return self._timed_position_driver
+        if self._use_native_set_position(features=features):
             return self._native_position_driver
         return self._timed_position_driver
 
@@ -710,7 +717,10 @@ class WrappedCoverTimeBased(CoverTimeBased):
         the coupling model owns the tilt tracker, so we must not clobber it.
         Skipped while our own tilt animation is still in flight.
         """
-        if not self._use_native_tilt():
+        # A caller-supplied state already carries the feature bitmask; without
+        # one, leave the fetch to the gate so it stays behind the cheap checks.
+        features = None if state is None else self._wrapped_features(state=state)
+        if not self._use_native_tilt(features=features):
             return
         if self.tilt_calc.is_traveling():
             return

--- a/custom_components/cover_time_based/cover_wrapped.py
+++ b/custom_components/cover_time_based/cover_wrapped.py
@@ -19,6 +19,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
+from homeassistant.core import State
 from homeassistant.helpers.event import async_track_state_change_event
 
 from .cover_base import CoverTimeBased
@@ -135,7 +136,7 @@ class WrappedCoverTimeBased(CoverTimeBased):
         """Wrapped mode drives the wrapped cover entity for all tilt."""
         return self._cover_entity_id
 
-    def _wrapped_features(self, *, state=None) -> int | None:
+    def _wrapped_features(self, *, state: State | None = None) -> int | None:
         """Return the wrapped entity's supported_features bitmask, or None.
 
         None means "unknown" — the entity is missing, unavailable, or reports
@@ -162,9 +163,9 @@ class WrappedCoverTimeBased(CoverTimeBased):
         features = self._wrapped_features() if features is None else features
         return features is not None and bool(features & CoverEntityFeature.SET_POSITION)
 
-    def _wrapped_supports_stop(self) -> bool:
+    def _wrapped_supports_stop(self, *, features: int | None = None) -> bool:
         """Return True if the wrapped cover advertises native STOP."""
-        features = self._wrapped_features()
+        features = self._wrapped_features() if features is None else features
         return features is not None and bool(features & CoverEntityFeature.STOP)
 
     def _wrapped_supports_set_tilt_position(
@@ -257,7 +258,7 @@ class WrappedCoverTimeBased(CoverTimeBased):
         change at runtime (e.g. it goes unavailable and back).
 
         The bitmask is fetched once here and threaded through the decision:
-        the chain below would otherwise read the state machine up to 3 times.
+        the chain below would otherwise read the state machine twice.
         """
         features = self._wrapped_features()
         # Unknown capabilities: every support helper answers False on None, so
@@ -530,12 +531,12 @@ class WrappedCoverTimeBased(CoverTimeBased):
         because their values may be stale or live depending on the device.
 
         While a self-initiated timed move is in flight, reports are ignored
-        whatever state they carry: an underlying that reports current_position
-        but never opening/closing (e.g. an MQTT position-topic-only cover)
-        always looks "stopped", so its mid-travel reports would otherwise snap
-        the tracker and cancel the pending auto-stop (see the is_traveling
-        guard below). Native (holds_itself) moves are unaffected and keep
-        snapping.
+        even though they look stopped: an underlying that reports
+        current_position but never opening/closing (e.g. an MQTT
+        position-topic-only cover) always looks "stopped", so its mid-travel
+        reports would otherwise snap the tracker and cancel the pending
+        auto-stop (see the is_traveling guard, below the stopped-state check).
+        Native (holds_itself) moves are unaffected and keep snapping.
 
         Command-echo covers (reports_command_not_endpoint) report no
         trustworthy position or endpoint, so we ignore their attribute-only
@@ -604,8 +605,9 @@ class WrappedCoverTimeBased(CoverTimeBased):
         """Snap our tracker to a known position.
 
         Always goes through set_known_position so that a still-running
-        auto-updater is stopped even when our calculated position happens
-        to match the target at this instant.
+        auto-updater is stopped even when our calculated position happens to
+        match the target at this instant; the caller skips the call only when
+        the position matches and no updater is running.
         """
         self._log("_snap_to_position :: snapping to %d", target)
         # The device reporting where it ended up, not a command — it must not
@@ -649,7 +651,7 @@ class WrappedCoverTimeBased(CoverTimeBased):
         return still_returning and new_val in _COMMANDED_STATES
 
     def _wrapped_reported_position(
-        self, *, trust_closed: bool = True, state=None
+        self, *, trust_closed: bool = True, state: State | None = None
     ) -> int | None:
         """Return the wrapped cover's reported position, or None if unknown.
 
@@ -691,7 +693,9 @@ class WrappedCoverTimeBased(CoverTimeBased):
             return self._invert_position(0)
         return None
 
-    def _wrapped_reported_tilt_position(self, *, state=None) -> int | None:
+    def _wrapped_reported_tilt_position(
+        self, *, state: State | None = None
+    ) -> int | None:
         """Return the wrapped cover's reported tilt position, or None.
 
         Honors ignore_reported_position — a device whose reported values are
@@ -709,7 +713,7 @@ class WrappedCoverTimeBased(CoverTimeBased):
             return int(attr_tilt)
         return None
 
-    async def _maybe_snap_to_reported_tilt(self, *, state=None) -> None:
+    async def _maybe_snap_to_reported_tilt(self, *, state: State | None = None) -> None:
         """Snap tilt_calc to the wrapped cover's reported tilt once it settles.
 
         Gated on _use_native_tilt(): only covers whose tilt we forward natively
@@ -718,7 +722,7 @@ class WrappedCoverTimeBased(CoverTimeBased):
         Skipped while our own tilt animation is still in flight.
         """
         # A caller-supplied state already carries the feature bitmask; without
-        # one, leave the fetch to the gate so it stays behind the cheap checks.
+        # one, leave the fetch to the gate.
         features = None if state is None else self._wrapped_features(state=state)
         if not self._use_native_tilt(features=features):
             return

--- a/custom_components/cover_time_based/cover_wrapped.py
+++ b/custom_components/cover_time_based/cover_wrapped.py
@@ -150,9 +150,14 @@ class WrappedCoverTimeBased(CoverTimeBased):
             return None
         return features
 
-    def _wrapped_supports_set_position(self) -> bool:
-        """Return True if the wrapped cover advertises native SET_POSITION."""
-        features = self._wrapped_features()
+    def _wrapped_supports_set_position(self, *, features: int | None = None) -> bool:
+        """Return True if the wrapped cover advertises native SET_POSITION.
+
+        ``features`` lets a caller that already fetched the bitmask reuse it;
+        None means fetch. Every fetch is a state-machine read, and one decision
+        used to make several.
+        """
+        features = self._wrapped_features() if features is None else features
         return features is not None and bool(features & CoverEntityFeature.SET_POSITION)
 
     def _wrapped_supports_stop(self) -> bool:
@@ -160,14 +165,16 @@ class WrappedCoverTimeBased(CoverTimeBased):
         features = self._wrapped_features()
         return features is not None and bool(features & CoverEntityFeature.STOP)
 
-    def _wrapped_supports_set_tilt_position(self) -> bool:
+    def _wrapped_supports_set_tilt_position(
+        self, *, features: int | None = None
+    ) -> bool:
         """Return True if the wrapped cover advertises native SET_TILT_POSITION."""
-        features = self._wrapped_features()
+        features = self._wrapped_features() if features is None else features
         return features is not None and bool(
             features & CoverEntityFeature.SET_TILT_POSITION
         )
 
-    def _use_native_tilt(self) -> bool:
+    def _use_native_tilt(self, *, features: int | None = None) -> bool:
         """Return True if tilt commands should be forwarded to the wrapped
         cover's own tilt instead of simulated with the main motor.
 
@@ -183,7 +190,7 @@ class WrappedCoverTimeBased(CoverTimeBased):
             return False
         if not isinstance(self._tilt_strategy, InlineTilt):
             return False
-        return self._wrapped_supports_set_tilt_position()
+        return self._wrapped_supports_set_tilt_position(features=features)
 
     async def _plan_tilt_for_travel(self, target, command, current_pos, current_tilt):
         """Sweep the tilt DISPLAY to the direction endpoint during native travel.
@@ -206,7 +213,7 @@ class WrappedCoverTimeBased(CoverTimeBased):
             target, command, current_pos, current_tilt
         )
 
-    def _use_native_set_position(self) -> bool:
+    def _use_native_set_position(self, *, features: int | None = None) -> bool:
         """Return True if set_cover_position should be forwarded natively.
 
         Auto-detected from the wrapped entity's SET_POSITION support, with three
@@ -235,17 +242,22 @@ class WrappedCoverTimeBased(CoverTimeBased):
         # natively (_use_native_tilt) the wrapped device owns its slats, so
         # driving position natively is coupling-safe and gives device-accurate
         # positioning. Dual-motor/sequential (timed tilt) keep the timed path.
-        if self._tilt_strategy is not None and not self._use_native_tilt():
+        if self._tilt_strategy is not None and not self._use_native_tilt(
+            features=features
+        ):
             return False
-        return self._wrapped_supports_set_position()
+        return self._wrapped_supports_set_position(features=features)
 
     def _position_driver(self) -> PositionDriver:
         """Select the position actuation driver from current capabilities.
 
         Re-evaluated per call: the wrapped entity's supported_features can
         change at runtime (e.g. it goes unavailable and back).
+
+        The bitmask is fetched once here and threaded through the decision:
+        the chain below would otherwise read the state machine up to 3 times.
         """
-        if self._use_native_set_position():
+        if self._use_native_set_position(features=self._wrapped_features()):
             return self._native_position_driver
         return self._timed_position_driver
 
@@ -511,12 +523,12 @@ class WrappedCoverTimeBased(CoverTimeBased):
         because their values may be stale or live depending on the device.
 
         While a self-initiated timed move is in flight, reports are ignored
-        outright rather than checked for opening/closing: an underlying that
-        reports current_position but never opening/closing (e.g. an MQTT
-        position-topic-only cover) always looks "stopped" to that check, so
-        its mid-travel reports would otherwise snap the tracker and cancel
-        the pending auto-stop (see the is_traveling guard below). Native
-        (holds_itself) moves are unaffected and keep snapping.
+        whatever state they carry: an underlying that reports current_position
+        but never opening/closing (e.g. an MQTT position-topic-only cover)
+        always looks "stopped", so its mid-travel reports would otherwise snap
+        the tracker and cancel the pending auto-stop (see the is_traveling
+        guard below). Native (holds_itself) moves are unaffected and keep
+        snapping.
 
         Command-echo covers (reports_command_not_endpoint) report no
         trustworthy position or endpoint, so we ignore their attribute-only
@@ -537,6 +549,9 @@ class WrappedCoverTimeBased(CoverTimeBased):
         if self._reports_command_not_endpoint:
             return
         if self._in_bounce_grace_window():
+            return
+        new_state = event.data.get("new_state")
+        if new_state is None or new_state.state not in _STOPPED_STATES:
             return
         # A self-initiated TIMED move in flight: the pending auto-stop is the
         # only thing that will halt the underlying, and _snap_to_position would
@@ -560,19 +575,23 @@ class WrappedCoverTimeBased(CoverTimeBased):
                 " position report"
             )
             return
-        new_state = event.data.get("new_state")
-        if new_state is None or new_state.state not in _STOPPED_STATES:
-            return
         # Only the reported position, never the closed-state fallback: an
         # attribute touch that carries no position says nothing new about
         # endpoints (the transition *into* closed already snapped, above), and
         # trusting it here would re-open issue #160 through the side door —
         # a reappearance whose bare `closed` we just refused snaps anyway on
         # whatever attribute the entity settles next.
-        target = self._wrapped_reported_position(trust_closed=False)
-        if target is not None:
+        target = self._wrapped_reported_position(trust_closed=False, state=new_state)
+        # The snap exists to park a still-running auto-updater and record a
+        # new value; when neither applies it would only stop, write and
+        # persist the same number again — a device reporting every 1 % step
+        # does that ~100 times per travel.
+        if target is not None and (
+            target != self.travel_calc.current_position()
+            or self._unsubscribe_auto_updater is not None
+        ):
             await self._snap_to_position(target)
-        await self._maybe_snap_to_reported_tilt()
+        await self._maybe_snap_to_reported_tilt(state=new_state)
 
     async def _snap_to_position(self, target: int) -> None:
         """Snap our tracker to a known position.
@@ -622,7 +641,9 @@ class WrappedCoverTimeBased(CoverTimeBased):
         self._returning_from_unavailable = False
         return still_returning and new_val in _COMMANDED_STATES
 
-    def _wrapped_reported_position(self, *, trust_closed: bool = True) -> int | None:
+    def _wrapped_reported_position(
+        self, *, trust_closed: bool = True, state=None
+    ) -> int | None:
         """Return the wrapped cover's reported position, or None if unknown.
 
         Prefers the current_position attribute. Falls back to 0 for
@@ -644,7 +665,7 @@ class WrappedCoverTimeBased(CoverTimeBased):
         # the time-based tracker rather than a value we do not trust.
         if self._ignore_all_reports:
             return None
-        state = self.hass.states.get(self._cover_entity_id)
+        state = self.hass.states.get(self._cover_entity_id) if state is None else state
         if state is None:
             return None
         # When configured to ignore the reported position, behave like a cover
@@ -663,7 +684,7 @@ class WrappedCoverTimeBased(CoverTimeBased):
             return self._invert_position(0)
         return None
 
-    def _wrapped_reported_tilt_position(self) -> int | None:
+    def _wrapped_reported_tilt_position(self, *, state=None) -> int | None:
         """Return the wrapped cover's reported tilt position, or None.
 
         Honors ignore_reported_position — a device whose reported values are
@@ -673,7 +694,7 @@ class WrappedCoverTimeBased(CoverTimeBased):
         """
         if self._ignore_reported_position:
             return None
-        state = self.hass.states.get(self._cover_entity_id)
+        state = self.hass.states.get(self._cover_entity_id) if state is None else state
         if state is None:
             return None
         attr_tilt = state.attributes.get(ATTR_CURRENT_TILT_POSITION)
@@ -681,7 +702,7 @@ class WrappedCoverTimeBased(CoverTimeBased):
             return int(attr_tilt)
         return None
 
-    async def _maybe_snap_to_reported_tilt(self) -> None:
+    async def _maybe_snap_to_reported_tilt(self, *, state=None) -> None:
         """Snap tilt_calc to the wrapped cover's reported tilt once it settles.
 
         Gated on _use_native_tilt(): only covers whose tilt we forward natively
@@ -693,7 +714,7 @@ class WrappedCoverTimeBased(CoverTimeBased):
             return
         if self.tilt_calc.is_traveling():
             return
-        target = self._wrapped_reported_tilt_position()
+        target = self._wrapped_reported_tilt_position(state=state)
         if target is None or self.tilt_calc.current_position() == target:
             return
         self._log("_maybe_snap_to_reported_tilt :: snapping tilt to %d", target)

--- a/custom_components/cover_time_based/helpers.py
+++ b/custom_components/cover_time_based/helpers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_component import DATA_INSTANCES
 
 
 def resolve_entity(hass: HomeAssistant, entity_id: str):
@@ -13,7 +14,7 @@ def resolve_entity(hass: HomeAssistant, entity_id: str):
     """
     from .cover_base import CoverTimeBased
 
-    component = hass.data.get("entity_components", {}).get("cover")
+    component = hass.data.get(DATA_INSTANCES, {}).get("cover")
     if component is None:
         raise HomeAssistantError("Cover platform not loaded")
     entity = component.get_entity(entity_id)

--- a/custom_components/cover_time_based/travel_calculator.py
+++ b/custom_components/cover_time_based/travel_calculator.py
@@ -222,9 +222,14 @@ class TravelCalculator:
             self.is_traveling() and self.travel_direction == TravelStatus.DIRECTION_DOWN
         )
 
-    def position_reached(self) -> bool:
-        """Return if cover has reached designated position."""
-        return self.current_position() == self._travel_to_position
+    def position_reached(self, current: int | None = None) -> bool:
+        """Return if cover has reached designated position.
+
+        ``current`` lets a caller that already computed the position (the
+        auto-updater tick) pass it in rather than recalculating it.
+        """
+        current = self.current_position() if current is None else current
+        return current == self._travel_to_position
 
     def is_open(self) -> bool:
         """Return if cover is (fully) open."""

--- a/tests/integration/test_feedback.py
+++ b/tests/integration/test_feedback.py
@@ -12,6 +12,7 @@ from datetime import timedelta
 from unittest.mock import patch
 
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_component import DATA_INSTANCES
 from homeassistant.util import dt as dt_util
 from pytest_homeassistant_custom_component.common import async_fire_time_changed
 
@@ -32,7 +33,7 @@ class MockTime:
 
 def _get_cover_entity(hass: HomeAssistant):
     """Return the CoverTimeBased entity object."""
-    entity_comp = hass.data["entity_components"]["cover"]
+    entity_comp = hass.data[DATA_INSTANCES]["cover"]
     entities = [e for e in entity_comp.entities if e.entity_id == "cover.test_cover"]
     assert entities, "Cover entity not found"
     return entities[0]

--- a/tests/integration/test_lifecycle.py
+++ b/tests/integration/test_lifecycle.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from homeassistant.components.cover import ATTR_CURRENT_POSITION, CoverEntityFeature
 from homeassistant.core import HomeAssistant, State
+from homeassistant.helpers.entity_component import DATA_INSTANCES
 from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
     mock_restore_cache,
@@ -17,7 +18,7 @@ from .conftest import DOMAIN
 
 def _get_cover_entity(hass: HomeAssistant):
     """Return the CoverTimeBased entity object."""
-    entity_comp = hass.data["entity_components"]["cover"]
+    entity_comp = hass.data[DATA_INSTANCES]["cover"]
     entities = [e for e in entity_comp.entities if e.entity_id == "cover.test_cover"]
     assert entities, "Cover entity not found"
     return entities[0]

--- a/tests/integration/test_modes.py
+++ b/tests/integration/test_modes.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 
 import pytest
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_component import DATA_INSTANCES
 from homeassistant.util import dt as dt_util
 from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
@@ -36,7 +37,7 @@ class MockTime:
 
 def _get_cover_entity(hass: HomeAssistant):
     """Return the CoverTimeBased entity object."""
-    entity_comp = hass.data["entity_components"]["cover"]
+    entity_comp = hass.data[DATA_INSTANCES]["cover"]
     entities = [e for e in entity_comp.entities if e.entity_id == "cover.test_cover"]
     assert entities, "Cover entity not found"
     return entities[0]

--- a/tests/integration/test_movement.py
+++ b/tests/integration/test_movement.py
@@ -13,6 +13,7 @@ from unittest.mock import patch
 
 import pytest
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_component import DATA_INSTANCES
 from homeassistant.util import dt as dt_util
 from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
@@ -37,7 +38,7 @@ def base_options():
 
 def _get_cover_entity(hass: HomeAssistant):
     """Return the CoverTimeBased entity object (not just state)."""
-    entity_comp = hass.data["entity_components"]["cover"]
+    entity_comp = hass.data[DATA_INSTANCES]["cover"]
     entities = [e for e in entity_comp.entities if e.entity_id == "cover.test_cover"]
     assert entities, "Cover entity not found"
     return entities[0]

--- a/tests/integration/test_position_store.py
+++ b/tests/integration/test_position_store.py
@@ -13,6 +13,7 @@ from unittest.mock import patch
 
 import pytest
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_component import DATA_INSTANCES
 from homeassistant.util import dt as dt_util
 from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
@@ -30,7 +31,7 @@ POSITION_STORE_KEY = STORAGE_KEY
 
 
 def _get_cover_entity(hass: HomeAssistant):
-    entity_comp = hass.data["entity_components"]["cover"]
+    entity_comp = hass.data[DATA_INSTANCES]["cover"]
     entities = [e for e in entity_comp.entities if e.entity_id == "cover.test_cover"]
     assert entities, "Cover entity not found"
     return entities[0]

--- a/tests/integration/test_tilt.py
+++ b/tests/integration/test_tilt.py
@@ -10,6 +10,7 @@ from datetime import timedelta
 from unittest.mock import patch
 
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_component import DATA_INSTANCES
 from homeassistant.util import dt as dt_util
 from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
@@ -35,7 +36,7 @@ class MockTime:
 
 def _get_cover_entity(hass: HomeAssistant):
     """Return the CoverTimeBased entity object."""
-    entity_comp = hass.data["entity_components"]["cover"]
+    entity_comp = hass.data[DATA_INSTANCES]["cover"]
     entities = [e for e in entity_comp.entities if e.entity_id == "cover.test_cover"]
     assert entities, "Cover entity not found"
     return entities[0]

--- a/tests/test_cover_base_extra.py
+++ b/tests/test_cover_base_extra.py
@@ -383,6 +383,79 @@ class TestAutoUpdaterHook:
         assert cover._unsubscribe_auto_updater is None
 
 
+class TestAutoUpdaterTickCost:
+    """One tick writes state only when the integer position/tilt changed, and
+    spawns the auto-stop task only when the position is reached."""
+
+    @pytest.mark.asyncio
+    async def test_unchanged_position_writes_once(self, make_cover):
+        cover = make_cover()
+        cover.travel_calc.set_position(0)
+        cover.travel_calc.start_travel(100)
+        cover.start_auto_updater()
+        mock_update = MagicMock()
+        with patch.object(cover, "async_schedule_update_ha_state", mock_update):
+            for _ in range(5):  # microseconds apart: the integer position is the same
+                cover.auto_updater_hook(None)
+        assert mock_update.call_count == 1
+        cover.stop_auto_updater()
+
+    @pytest.mark.asyncio
+    async def test_changed_position_writes_again(self, make_cover):
+        cover = make_cover()
+        cover.travel_calc.set_position(0)
+        cover.travel_calc.start_travel(100)
+        cover.start_auto_updater()
+        mock_update = MagicMock()
+        with patch.object(cover, "async_schedule_update_ha_state", mock_update):
+            cover.auto_updater_hook(None)
+            cover.travel_calc.set_position(50)
+            cover.travel_calc.start_travel(100)
+            cover.auto_updater_hook(None)
+        assert mock_update.call_count == 2
+        cover.stop_auto_updater()
+
+    @pytest.mark.asyncio
+    async def test_restart_writes_on_first_tick(self, make_cover):
+        cover = make_cover()
+        cover.travel_calc.set_position(0)
+        cover.travel_calc.start_travel(100)
+        mock_update = MagicMock()
+        with patch.object(cover, "async_schedule_update_ha_state", mock_update):
+            cover.start_auto_updater()
+            cover.auto_updater_hook(None)
+            cover.stop_auto_updater()
+            cover.start_auto_updater()
+            cover.auto_updater_hook(None)
+        assert mock_update.call_count == 2
+        cover.stop_auto_updater()
+
+    @pytest.mark.asyncio
+    async def test_no_stop_task_before_arrival(self, make_cover):
+        cover = make_cover()
+        cover.travel_calc.set_position(0)
+        cover.travel_calc.start_travel(100)
+        with patch.object(cover, "async_schedule_update_ha_state"):
+            cover.auto_updater_hook(None)
+        assert cover.hass._test_tasks == []
+
+    @pytest.mark.asyncio
+    async def test_stop_task_on_arrival(self, make_cover):
+        cover = make_cover()
+        cover.travel_calc.set_position(50)
+        cover.travel_calc.start_travel(50)  # already at target
+        with (
+            patch.object(cover, "async_schedule_update_ha_state"),
+            patch.object(
+                cover, "auto_stop_if_necessary", new_callable=AsyncMock
+            ) as stop,
+        ):
+            cover.auto_updater_hook(None)
+            for task in cover.hass._test_tasks:
+                await task
+        stop.assert_awaited_once()
+
+
 # ===================================================================
 # auto_stop_if_necessary with tilt
 # ===================================================================

--- a/tests/test_cover_base_extra.py
+++ b/tests/test_cover_base_extra.py
@@ -451,6 +451,41 @@ class TestAutoUpdaterTickCost:
                 await task
         stop.assert_awaited_once()
 
+    @pytest.mark.asyncio
+    async def test_tilt_arrival_decides_the_spawn(self, make_cover):
+        """Each member of the tick's positions pair is judged by its own
+        calculator: travel sits at its target throughout, so only the tilt
+        member can decide the spawn."""
+        cover = make_cover(
+            tilt_mode="dual_motor",
+            tilt_open_switch="switch.tilt_open",
+            tilt_close_switch="switch.tilt_close",
+            tilt_stop_switch="switch.tilt_stop",
+            tilt_time_open=5.0,
+            tilt_time_close=5.0,
+        )
+        cover.travel_calc.set_position(50)
+        cover.travel_calc.start_travel(50)
+        cover.tilt_calc.set_position(30)
+        cover.tilt_calc.start_travel(30)  # tilt already at its target
+
+        with (
+            patch.object(cover, "async_schedule_update_ha_state"),
+            patch.object(
+                cover, "auto_stop_if_necessary", new_callable=AsyncMock
+            ) as stop,
+        ):
+            cover.auto_updater_hook(None)
+            for task in cover.hass._test_tasks:
+                await task
+        stop.assert_awaited_once()
+
+        cover.hass._test_tasks.clear()
+        cover.tilt_calc.start_travel(100)  # tilt now mid-travel
+        with patch.object(cover, "async_schedule_update_ha_state"):
+            cover.auto_updater_hook(None)
+        assert cover.hass._test_tasks == []
+
 
 # ===================================================================
 # auto_stop_if_necessary with tilt
@@ -1428,6 +1463,8 @@ class TestResyncAllModes:
 
 
 class TestLogGuard:
+    """_log reaches the logger only when DEBUG is enabled."""
+
     def test_log_skips_logger_when_debug_off(self, make_cover):
         cover = make_cover()
         with (

--- a/tests/test_cover_base_extra.py
+++ b/tests/test_cover_base_extra.py
@@ -1424,3 +1424,38 @@ class TestResyncAllModes:
             await cover.async_resync("closed")
 
         assert not hasattr(cover, "_phase")
+
+
+# ===================================================================
+# _log guard
+# ===================================================================
+
+
+class TestLogGuard:
+    def test_log_skips_logger_when_debug_off(self, make_cover, caplog):
+        cover = make_cover()
+        with (
+            patch(
+                "custom_components.cover_time_based.cover_base._LOGGER.isEnabledFor",
+                return_value=False,
+            ),
+            patch(
+                "custom_components.cover_time_based.cover_base._LOGGER.debug"
+            ) as debug,
+        ):
+            cover._log("hello %s", "world")
+        debug.assert_not_called()
+
+    def test_log_logs_when_debug_on(self, make_cover):
+        cover = make_cover()
+        with (
+            patch(
+                "custom_components.cover_time_based.cover_base._LOGGER.isEnabledFor",
+                return_value=True,
+            ),
+            patch(
+                "custom_components.cover_time_based.cover_base._LOGGER.debug"
+            ) as debug,
+        ):
+            cover._log("hello %s", "world")
+        debug.assert_called_once()

--- a/tests/test_cover_base_extra.py
+++ b/tests/test_cover_base_extra.py
@@ -345,15 +345,22 @@ class TestRemoveFromHass:
 # ===================================================================
 
 
+@pytest.fixture
+def traveling_cover(make_cover):
+    """A cover part-way through a 0 → 100 travel, with the updater torn down."""
+    cover = make_cover()
+    cover.travel_calc.set_position(0)
+    cover.travel_calc.start_travel(100)
+    yield cover
+    cover.stop_auto_updater()
+
+
 class TestAutoUpdaterHook:
     """Test the periodic auto-updater callback."""
 
     @pytest.mark.asyncio
-    async def test_auto_updater_hook_calls_update(self, make_cover):
-        cover = make_cover()
-        cover.travel_calc.set_position(0)
-        cover.travel_calc.start_travel(100)
-
+    async def test_auto_updater_hook_calls_update(self, traveling_cover):
+        cover = traveling_cover
         mock_update = MagicMock()
         with (
             patch.object(cover, "async_schedule_update_ha_state", mock_update),
@@ -388,23 +395,18 @@ class TestAutoUpdaterTickCost:
     spawns the auto-stop task only when the position is reached."""
 
     @pytest.mark.asyncio
-    async def test_unchanged_position_writes_once(self, make_cover):
-        cover = make_cover()
-        cover.travel_calc.set_position(0)
-        cover.travel_calc.start_travel(100)
+    async def test_unchanged_position_writes_once(self, traveling_cover):
+        cover = traveling_cover
         cover.start_auto_updater()
         mock_update = MagicMock()
         with patch.object(cover, "async_schedule_update_ha_state", mock_update):
             for _ in range(5):  # microseconds apart: the integer position is the same
                 cover.auto_updater_hook(None)
         assert mock_update.call_count == 1
-        cover.stop_auto_updater()
 
     @pytest.mark.asyncio
-    async def test_changed_position_writes_again(self, make_cover):
-        cover = make_cover()
-        cover.travel_calc.set_position(0)
-        cover.travel_calc.start_travel(100)
+    async def test_changed_position_writes_again(self, traveling_cover):
+        cover = traveling_cover
         cover.start_auto_updater()
         mock_update = MagicMock()
         with patch.object(cover, "async_schedule_update_ha_state", mock_update):
@@ -413,13 +415,10 @@ class TestAutoUpdaterTickCost:
             cover.travel_calc.start_travel(100)
             cover.auto_updater_hook(None)
         assert mock_update.call_count == 2
-        cover.stop_auto_updater()
 
     @pytest.mark.asyncio
-    async def test_restart_writes_on_first_tick(self, make_cover):
-        cover = make_cover()
-        cover.travel_calc.set_position(0)
-        cover.travel_calc.start_travel(100)
+    async def test_restart_writes_on_first_tick(self, traveling_cover):
+        cover = traveling_cover
         mock_update = MagicMock()
         with patch.object(cover, "async_schedule_update_ha_state", mock_update):
             cover.start_auto_updater()
@@ -428,13 +427,10 @@ class TestAutoUpdaterTickCost:
             cover.start_auto_updater()
             cover.auto_updater_hook(None)
         assert mock_update.call_count == 2
-        cover.stop_auto_updater()
 
     @pytest.mark.asyncio
-    async def test_no_stop_task_before_arrival(self, make_cover):
-        cover = make_cover()
-        cover.travel_calc.set_position(0)
-        cover.travel_calc.start_travel(100)
+    async def test_no_stop_task_before_arrival(self, traveling_cover):
+        cover = traveling_cover
         with patch.object(cover, "async_schedule_update_ha_state"):
             cover.auto_updater_hook(None)
         assert cover.hass._test_tasks == []
@@ -1432,7 +1428,7 @@ class TestResyncAllModes:
 
 
 class TestLogGuard:
-    def test_log_skips_logger_when_debug_off(self, make_cover, caplog):
+    def test_log_skips_logger_when_debug_off(self, make_cover):
         cover = make_cover()
         with (
             patch(

--- a/tests/test_cover_services.py
+++ b/tests/test_cover_services.py
@@ -8,6 +8,7 @@ import pytest
 import voluptuous as vol
 import yaml
 from homeassistant.exceptions import HomeAssistantError, Unauthorized
+from homeassistant.helpers.entity_component import DATA_INSTANCES
 
 from custom_components.cover_time_based.cover import (
     CONF_CLOSE_SWITCH_ENTITY_ID,
@@ -47,7 +48,7 @@ class TestResolveEntity:
 
     def test_raises_when_entity_components_has_no_cover(self):
         hass = MagicMock()
-        hass.data = {"entity_components": {}}
+        hass.data = {DATA_INSTANCES: {}}
 
         with pytest.raises(HomeAssistantError, match="Cover platform not loaded"):
             resolve_entity(hass, "cover.test")
@@ -57,7 +58,7 @@ class TestResolveEntity:
         component.get_entity.return_value = None
 
         hass = MagicMock()
-        hass.data = {"entity_components": {"cover": component}}
+        hass.data = {DATA_INSTANCES: {"cover": component}}
 
         with pytest.raises(HomeAssistantError, match=r"cover.test"):
             resolve_entity(hass, "cover.test")
@@ -68,7 +69,7 @@ class TestResolveEntity:
         component.get_entity.return_value = MagicMock()  # not CoverTimeBased
 
         hass = MagicMock()
-        hass.data = {"entity_components": {"cover": component}}
+        hass.data = {DATA_INSTANCES: {"cover": component}}
 
         with pytest.raises(HomeAssistantError, match="not a cover_time_based"):
             resolve_entity(hass, "cover.test")
@@ -91,7 +92,7 @@ class TestResolveEntity:
         component.get_entity.return_value = entity
 
         hass = MagicMock()
-        hass.data = {"entity_components": {"cover": component}}
+        hass.data = {DATA_INSTANCES: {"cover": component}}
 
         result = resolve_entity(hass, "cover.test")
         assert result is entity

--- a/tests/test_cover_wrapped.py
+++ b/tests/test_cover_wrapped.py
@@ -1926,3 +1926,72 @@ class TestWrappedSyncsToLivePositionAtStartup:
 
         assert cover.travel_calc.current_position() == 30
         _mock_position_store.async_save.assert_not_awaited()
+
+
+class TestWrappedDecisionCost:
+    """The wrapped decision helpers read the underlying's state once, and an
+    attribute report that changes nothing does no work.
+    """
+
+    _F_SET_TILT = 128  # CoverEntityFeature.SET_TILT_POSITION
+
+    def test_position_driver_reads_state_once(self):
+        # Native-both inline cover: the longest decision chain
+        # (_position_driver -> _use_native_set_position -> _use_native_tilt
+        # -> _wrapped_supports_set_tilt_position, then
+        # _wrapped_supports_set_position).
+        cover = _make_wrapped_cover(
+            tilt_time_close=5, tilt_time_open=5, tilt_mode="inline"
+        )
+        st = _set_wrapped_features(
+            cover, _F_OPEN | _F_CLOSE | _F_SET_POSITION | self._F_SET_TILT
+        )
+        cover.hass.states.get = MagicMock(return_value=st)
+        assert cover._position_driver() is cover._native_position_driver
+        assert cover.hass.states.get.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_attribute_event_with_same_position_and_no_updater_does_not_snap(
+        self,
+    ):
+        cover = _make_wrapped_cover()
+        cover.travel_calc.set_position(40)
+        st = _set_wrapped_features(cover, 0, state="open", current_position=40)
+        event = MagicMock()
+        event.data = {"entity_id": "cover.inner", "new_state": st}
+        with patch.object(cover, "set_known_position", new=AsyncMock()) as snap:
+            await cover._handle_external_attribute_change(event)
+        snap.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_attribute_event_with_same_position_but_running_updater_still_snaps(
+        self,
+    ):
+        cover = _make_wrapped_cover()
+        cover.travel_calc.set_position(40)
+        cover._unsubscribe_auto_updater = MagicMock()
+        st = _set_wrapped_features(cover, 0, state="open", current_position=40)
+        event = MagicMock()
+        event.data = {"entity_id": "cover.inner", "new_state": st}
+        with patch.object(cover, "set_known_position", new=AsyncMock()) as snap:
+            await cover._handle_external_attribute_change(event)
+        snap.assert_awaited_once()
+        cover._unsubscribe_auto_updater = None
+
+    @pytest.mark.asyncio
+    async def test_attribute_event_reads_position_from_the_event(self):
+        cover = _make_wrapped_cover()
+        cover.travel_calc.set_position(40)
+        event_state = MagicMock()
+        event_state.state = "open"
+        event_state.attributes = {ATTR_CURRENT_POSITION: 55}
+        event = MagicMock()
+        event.data = {"entity_id": "cover.inner", "new_state": event_state}
+        # A different value in the state machine: reading it would give 99.
+        stale = MagicMock()
+        stale.state = "open"
+        stale.attributes = {ATTR_CURRENT_POSITION: 99}
+        cover.hass.states.get = MagicMock(return_value=stale)
+        with patch.object(cover, "set_known_position", new=AsyncMock()) as snap:
+            await cover._handle_external_attribute_change(event)
+        snap.assert_awaited_once_with(position=55, supersede=False)

--- a/tests/test_cover_wrapped.py
+++ b/tests/test_cover_wrapped.py
@@ -1808,6 +1808,52 @@ class TestStartupDelayEchoDoesNotHijackTimedMove:
         assert cover._startup_delay_task is None or cover._startup_delay_task.done()
 
 
+class TestRedundantReportDuringStartupDelay:
+    """A redundant position report inside the travel_startup_delay window must
+    not clear the pending move's bookkeeping.
+
+    Snapping runs set_known_position -> _handle_stop and drops _last_command,
+    which is the only record of the pending move's direction while the tracker
+    is still parked. Without it a reversal issued in the window no longer
+    reads as a direction change: async_close_cover sees the tracker settled at
+    0 with nothing to cancel, skips the re-drive, and the delay fires on the
+    original target — the cover runs on instead of stopping.
+    """
+
+    def _prep(self, cover):
+        cover.start_auto_updater = MagicMock()
+        cover.async_write_ha_state = MagicMock()
+        cover.async_schedule_update_ha_state = MagicMock()
+
+    @pytest.mark.asyncio
+    async def test_reversal_survives_redundant_report_in_startup_window(self):
+        # features = 15 == OPEN|CLOSE|SET_POSITION|STOP; force_time_based keeps
+        # the timed path so the move waits out travel_startup_delay.
+        cover = _make_wrapped_cover(
+            force_time_based_position=True, travel_startup_delay=1.5
+        )
+        st = _set_wrapped_features(cover, 15, state="closed", current_position=0)
+        self._prep(cover)
+        cover.travel_calc.set_position(0)
+
+        await cover.async_set_cover_position(position=40)
+        assert cover._startup_delay_task is not None
+        assert not cover._startup_delay_task.done()
+        assert not cover.travel_calc.is_traveling()  # parked in the window
+
+        # The underlying re-reports the position it already had, past the
+        # bounce grace window and while the delay is still pending.
+        cover._last_self_command_time = None
+        await cover._handle_external_attribute_change(_attr_event("cover.inner", st))
+
+        cover.hass.services.async_call.reset_mock()
+        await cover.async_close_cover()
+
+        services = [c.args[1] for c in _calls(cover.hass.services.async_call)]
+        assert "stop_cover" in services
+        assert cover._startup_delay_task is None or cover._startup_delay_task.done()
+
+
 class TestWrappedSyncsToLivePositionAtStartup:
     """B12: on restart the tracker restores from the PositionStore, but the
     underlying may have been moved (app/remote) while HA was down. Trust a

--- a/tests/test_cover_wrapped.py
+++ b/tests/test_cover_wrapped.py
@@ -12,11 +12,13 @@ from homeassistant.const import STATE_CLOSED, STATE_UNAVAILABLE
 
 from custom_components.cover_time_based.cover_wrapped import WrappedCoverTimeBased
 
-# CoverEntityFeature bit values (OPEN=1, CLOSE=2, SET_POSITION=4, STOP=8).
+# CoverEntityFeature bit values (OPEN=1, CLOSE=2, SET_POSITION=4, STOP=8,
+# SET_TILT_POSITION=128).
 _F_OPEN = 1
 _F_CLOSE = 2
 _F_SET_POSITION = 4
 _F_STOP = 8
+_F_SET_TILT = 128
 
 
 # ---------------------------------------------------------------------------
@@ -96,6 +98,13 @@ def _set_wrapped_features(cover, features, *, state="open", current_position=Non
 def _calls(mock: AsyncMock):
     """Return the list of calls made on hass.services.async_call."""
     return mock.call_args_list
+
+
+def _attr_event(entity_id, state):
+    """An attribute-change event carrying `state` as the entity's new state."""
+    event = MagicMock()
+    event.data = {"entity_id": entity_id, "new_state": state}
+    return event
 
 
 def _cover_svc(service, entity_id):
@@ -1204,13 +1213,11 @@ class TestUseNativeTilt:
     """_use_native_tilt() requires InlineTilt + wrapped SET_TILT_POSITION,
     and is off for command-echo covers and non-inline strategies."""
 
-    _F_SET_TILT = 128  # CoverEntityFeature.SET_TILT_POSITION
-
     def test_native_tilt_when_inline_and_set_tilt_supported(self):
         cover = _make_wrapped_cover(
             tilt_time_close=5, tilt_time_open=5, tilt_mode="inline"
         )
-        _set_wrapped_features(cover, _F_OPEN | _F_CLOSE | self._F_SET_TILT)
+        _set_wrapped_features(cover, _F_OPEN | _F_CLOSE | _F_SET_TILT)
         assert cover._use_native_tilt() is True
 
     def test_not_native_without_set_tilt_position(self):
@@ -1224,7 +1231,7 @@ class TestUseNativeTilt:
         cover = _make_wrapped_cover(
             tilt_time_close=5, tilt_time_open=5, tilt_mode="sequential_close"
         )
-        _set_wrapped_features(cover, _F_OPEN | _F_CLOSE | self._F_SET_TILT)
+        _set_wrapped_features(cover, _F_OPEN | _F_CLOSE | _F_SET_TILT)
         assert cover._use_native_tilt() is False
 
     def test_not_native_for_command_echo(self):
@@ -1234,20 +1241,18 @@ class TestUseNativeTilt:
             tilt_mode="inline",
             reports_command_not_endpoint=True,
         )
-        _set_wrapped_features(cover, _F_OPEN | _F_CLOSE | self._F_SET_TILT)
+        _set_wrapped_features(cover, _F_OPEN | _F_CLOSE | _F_SET_TILT)
         assert cover._use_native_tilt() is False
 
     def test_not_native_without_tilt_configured(self):
         cover = _make_wrapped_cover()  # no tilt times → no tilt strategy
-        _set_wrapped_features(cover, _F_OPEN | _F_CLOSE | self._F_SET_TILT)
+        _set_wrapped_features(cover, _F_OPEN | _F_CLOSE | _F_SET_TILT)
         assert cover._use_native_tilt() is False
 
 
 class TestNativeTiltForwarding:
     """Native tilt covers forward set_cover_tilt_position and animate tilt_calc,
     and the auto-updater issues no relay stop when the tilt move completes."""
-
-    _F_SET_TILT = 128
 
     def _prep(self, cover):
         cover.start_auto_updater = MagicMock()
@@ -1258,7 +1263,7 @@ class TestNativeTiltForwarding:
         cover = _make_wrapped_cover(
             tilt_time_close=5, tilt_time_open=5, tilt_mode="inline"
         )
-        _set_wrapped_features(cover, _F_OPEN | _F_CLOSE | self._F_SET_TILT)
+        _set_wrapped_features(cover, _F_OPEN | _F_CLOSE | _F_SET_TILT)
         self._prep(cover)
         return cover
 
@@ -1328,8 +1333,6 @@ class TestTiltSettleSnap:
     """On settle, a native-tilt cover snaps tilt_calc to the device's reported
     current_tilt_position; non-native strategies do not."""
 
-    _F_SET_TILT = 128
-
     def _prep(self, cover):
         cover.start_auto_updater = MagicMock()
         cover.async_write_ha_state = MagicMock()
@@ -1341,7 +1344,7 @@ class TestTiltSettleSnap:
             tilt_time_close=5, tilt_time_open=5, tilt_mode="inline"
         )
         st = _set_wrapped_features(
-            cover, _F_OPEN | _F_CLOSE | self._F_SET_TILT, state="open"
+            cover, _F_OPEN | _F_CLOSE | _F_SET_TILT, state="open"
         )
         st.attributes["current_position"] = 100
         st.attributes["current_tilt_position"] = 45
@@ -1359,7 +1362,7 @@ class TestTiltSettleSnap:
             tilt_time_close=5, tilt_time_open=5, tilt_mode="sequential_close"
         )
         st = _set_wrapped_features(
-            cover, _F_OPEN | _F_CLOSE | self._F_SET_TILT, state="open"
+            cover, _F_OPEN | _F_CLOSE | _F_SET_TILT, state="open"
         )
         st.attributes["current_position"] = 100
         st.attributes["current_tilt_position"] = 45
@@ -1382,7 +1385,7 @@ class TestTiltSettleSnap:
             tilt_time_close=5, tilt_time_open=5, tilt_mode="inline"
         )
         st = _set_wrapped_features(
-            cover, _F_OPEN | _F_CLOSE | self._F_SET_TILT, state="open"
+            cover, _F_OPEN | _F_CLOSE | _F_SET_TILT, state="open"
         )
         st.attributes["current_position"] = 100
         st.attributes["current_tilt_position"] = 0
@@ -1399,14 +1402,12 @@ class TestNativeCouplingNeutralized:
     """A position move on a native-tilt cover schedules no main-motor tilt
     restore — the device manages its own slats."""
 
-    _F_SET_TILT = 128
-
     @pytest.mark.asyncio
     async def test_no_tilt_restore_scheduled_for_native(self):
         cover = _make_wrapped_cover(
             tilt_time_close=5, tilt_time_open=5, tilt_mode="inline"
         )
-        _set_wrapped_features(cover, _F_OPEN | _F_CLOSE | self._F_SET_TILT)
+        _set_wrapped_features(cover, _F_OPEN | _F_CLOSE | _F_SET_TILT)
         cover._tilt_restore_target = 77  # pretend something set it
 
         tilt_target, pre_step_delay, started = await cover._plan_tilt_for_travel(
@@ -1443,7 +1444,7 @@ class TestNativeCouplingNeutralized:
             tilt_time_close=5, tilt_time_open=5, tilt_mode="inline"
         )
         _set_wrapped_features(
-            cover, _F_OPEN | _F_CLOSE | self._F_SET_TILT, state="unavailable"
+            cover, _F_OPEN | _F_CLOSE | _F_SET_TILT, state="unavailable"
         )
         cover.tilt_calc.set_position(80)
         cover._triggered_externally = False
@@ -1456,8 +1457,6 @@ class TestNativePositionWithNativeTilt:
     """A native-both-inline cover drives position natively too (symmetry);
     timed-tilt strategies keep the timed position path."""
 
-    _F_SET_TILT = 128
-
     def _prep(self, cover):
         cover.start_auto_updater = MagicMock()
         cover.async_write_ha_state = MagicMock()
@@ -1467,18 +1466,14 @@ class TestNativePositionWithNativeTilt:
         cover = _make_wrapped_cover(
             tilt_time_close=5, tilt_time_open=5, tilt_mode="inline"
         )
-        _set_wrapped_features(
-            cover, _F_OPEN | _F_CLOSE | _F_SET_POSITION | self._F_SET_TILT
-        )
+        _set_wrapped_features(cover, _F_OPEN | _F_CLOSE | _F_SET_POSITION | _F_SET_TILT)
         assert cover._use_native_set_position() is True
 
     def test_timed_position_kept_for_sequential_even_with_set_position(self):
         cover = _make_wrapped_cover(
             tilt_time_close=5, tilt_time_open=5, tilt_mode="sequential_close"
         )
-        _set_wrapped_features(
-            cover, _F_OPEN | _F_CLOSE | _F_SET_POSITION | self._F_SET_TILT
-        )
+        _set_wrapped_features(cover, _F_OPEN | _F_CLOSE | _F_SET_POSITION | _F_SET_TILT)
         assert cover._use_native_set_position() is False
 
     def test_timed_position_kept_for_inline_without_set_tilt(self):
@@ -1495,9 +1490,7 @@ class TestNativePositionWithNativeTilt:
         cover = _make_wrapped_cover(
             tilt_time_close=5, tilt_time_open=5, tilt_mode="inline"
         )
-        _set_wrapped_features(
-            cover, _F_OPEN | _F_CLOSE | _F_SET_POSITION | self._F_SET_TILT
-        )
+        _set_wrapped_features(cover, _F_OPEN | _F_CLOSE | _F_SET_POSITION | _F_SET_TILT)
         self._prep(cover)
         cover.travel_calc.set_position(100)
         cover.tilt_calc.set_position(50)
@@ -1513,8 +1506,6 @@ class TestNativeTiltSweep:
     """During a position travel, a native cover's tilt display sweeps to the
     direction endpoint (0 closing, 100 opening); no physical tilt command."""
 
-    _F_SET_TILT = 128
-
     def _prep(self, cover):
         cover.start_auto_updater = MagicMock()
         cover.async_write_ha_state = MagicMock()
@@ -1524,9 +1515,7 @@ class TestNativeTiltSweep:
         cover = _make_wrapped_cover(
             tilt_time_close=5, tilt_time_open=5, tilt_mode="inline"
         )
-        _set_wrapped_features(
-            cover, _F_OPEN | _F_CLOSE | _F_SET_POSITION | self._F_SET_TILT
-        )
+        _set_wrapped_features(cover, _F_OPEN | _F_CLOSE | _F_SET_POSITION | _F_SET_TILT)
         self._prep(cover)
         return cover
 
@@ -1579,7 +1568,7 @@ class TestNativeTiltSweep:
             tilt_time_close=5, tilt_time_open=5, tilt_mode="inline"
         )
         st = _set_wrapped_features(
-            cover, _F_OPEN | _F_CLOSE | _F_SET_POSITION | self._F_SET_TILT
+            cover, _F_OPEN | _F_CLOSE | _F_SET_POSITION | _F_SET_TILT
         )
         self._prep(cover)
         cover.travel_calc.set_position(100)
@@ -1933,8 +1922,6 @@ class TestWrappedDecisionCost:
     attribute report that changes nothing does no work.
     """
 
-    _F_SET_TILT = 128  # CoverEntityFeature.SET_TILT_POSITION
-
     def test_position_driver_reads_state_once(self):
         # Native-both inline cover: the longest decision chain
         # (_position_driver -> _use_native_set_position -> _use_native_tilt
@@ -1944,7 +1931,7 @@ class TestWrappedDecisionCost:
             tilt_time_close=5, tilt_time_open=5, tilt_mode="inline"
         )
         st = _set_wrapped_features(
-            cover, _F_OPEN | _F_CLOSE | _F_SET_POSITION | self._F_SET_TILT
+            cover, _F_OPEN | _F_CLOSE | _F_SET_POSITION | _F_SET_TILT
         )
         cover.hass.states.get = MagicMock(return_value=st)
         assert cover._position_driver() is cover._native_position_driver
@@ -1957,10 +1944,10 @@ class TestWrappedDecisionCost:
         cover = _make_wrapped_cover()
         cover.travel_calc.set_position(40)
         st = _set_wrapped_features(cover, 0, state="open", current_position=40)
-        event = MagicMock()
-        event.data = {"entity_id": "cover.inner", "new_state": st}
         with patch.object(cover, "set_known_position", new=AsyncMock()) as snap:
-            await cover._handle_external_attribute_change(event)
+            await cover._handle_external_attribute_change(
+                _attr_event("cover.inner", st)
+            )
         snap.assert_not_awaited()
 
     @pytest.mark.asyncio
@@ -1971,10 +1958,10 @@ class TestWrappedDecisionCost:
         cover.travel_calc.set_position(40)
         cover._unsubscribe_auto_updater = MagicMock()
         st = _set_wrapped_features(cover, 0, state="open", current_position=40)
-        event = MagicMock()
-        event.data = {"entity_id": "cover.inner", "new_state": st}
         with patch.object(cover, "set_known_position", new=AsyncMock()) as snap:
-            await cover._handle_external_attribute_change(event)
+            await cover._handle_external_attribute_change(
+                _attr_event("cover.inner", st)
+            )
         snap.assert_awaited_once()
         cover._unsubscribe_auto_updater = None
 
@@ -1982,16 +1969,11 @@ class TestWrappedDecisionCost:
     async def test_attribute_event_reads_position_from_the_event(self):
         cover = _make_wrapped_cover()
         cover.travel_calc.set_position(40)
-        event_state = MagicMock()
-        event_state.state = "open"
-        event_state.attributes = {ATTR_CURRENT_POSITION: 55}
-        event = MagicMock()
-        event.data = {"entity_id": "cover.inner", "new_state": event_state}
+        event_state = _set_wrapped_features(cover, 0, state="open", current_position=55)
         # A different value in the state machine: reading it would give 99.
-        stale = MagicMock()
-        stale.state = "open"
-        stale.attributes = {ATTR_CURRENT_POSITION: 99}
-        cover.hass.states.get = MagicMock(return_value=stale)
+        _set_wrapped_features(cover, 0, state="open", current_position=99)
         with patch.object(cover, "set_known_position", new=AsyncMock()) as snap:
-            await cover._handle_external_attribute_change(event)
+            await cover._handle_external_attribute_change(
+                _attr_event("cover.inner", event_state)
+            )
         snap.assert_awaited_once_with(position=55, supersede=False)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -20,6 +20,7 @@ from custom_components.cover_time_based import (
 from custom_components.cover_time_based.card_resources import (
     _CARD_INSTALLED_ISSUE,
     _RESOURCE_ID_KEY,
+    async_register_card_resource,
 )
 from custom_components.cover_time_based.const import DOMAIN
 
@@ -581,7 +582,7 @@ class TestCardResourceUnregistration:
     @pytest.mark.asyncio
     async def test_failed_delete_still_clears_recorded_id(self):
         """A hand-deleted resource makes async_delete_item raise. The recorded
-        id must still be dropped, or the setup-entry guard would skip
+        id must still be dropped, or the registrar's guard would skip
         re-registration for the rest of the session."""
         resources = FakeResources(
             items=[{"id": "new-id", "url": _CARD_JS_URL}], loaded=True
@@ -599,14 +600,12 @@ class TestCardResourceUnregistration:
 
         assert _RESOURCE_ID_KEY not in hass.data[DOMAIN]
 
-        # ...so re-adding a cover in the same session registers the card again.
+        # ...so re-adding a cover in the same session registers the card again:
+        # the real registrar rescans, finds the still-present resource by URL
+        # and re-records its id.
         hass.config_entries.async_forward_entry_setups = AsyncMock()
-        with patch(
-            "custom_components.cover_time_based.async_register_card_resource",
-            AsyncMock(),
-        ) as reg:
-            await async_setup_entry(hass, entry)
-        reg.assert_awaited_once()
+        await async_setup_entry(hass, entry)
+        assert hass.data[DOMAIN][_RESOURCE_ID_KEY] == "new-id"
 
     @pytest.mark.asyncio
     async def test_remove_last_entry_falls_back_to_remove_extra_js_url(self):
@@ -632,31 +631,30 @@ class TestCardResourceUnregistration:
 
 
 class TestCardResourceRegisteredOnce:
-    """Each config entry's setup must not rescan every Lovelace resource once
-    the card's resource id is already recorded for this session."""
+    """Registering the card must not rescan every Lovelace resource once the
+    resource id is already recorded for this session — every config entry's
+    setup calls the registrar."""
 
     @pytest.mark.asyncio
-    async def test_setup_entry_skips_registration_when_recorded(self):
-        hass = MagicMock()
-        hass.data = {DOMAIN: {_RESOURCE_ID_KEY: "abc"}}
-        hass.config_entries.async_forward_entry_setups = AsyncMock()
-        entry = MagicMock()
-        with patch(
-            "custom_components.cover_time_based.async_register_card_resource",
-            AsyncMock(),
-        ) as reg:
-            await async_setup_entry(hass, entry)
-        reg.assert_not_awaited()
+    async def test_register_returns_early_when_id_recorded(self):
+        resources = FakeResources()
+        resources.async_items = MagicMock(wraps=resources.async_items)
+        resources.async_create_item = AsyncMock(wraps=resources.async_create_item)
+        hass = _make_setup_hass(resources)
+        hass.data[DOMAIN] = {_RESOURCE_ID_KEY: "abc"}
+
+        await async_register_card_resource(hass, _CARD_BASE_URL, _CARD_JS_URL)
+
+        resources.async_items.assert_not_called()
+        resources.async_create_item.assert_not_awaited()
+        assert hass.data[DOMAIN][_RESOURCE_ID_KEY] == "abc"
 
     @pytest.mark.asyncio
-    async def test_setup_entry_registers_when_not_recorded(self):
-        hass = MagicMock()
-        hass.data = {}
-        hass.config_entries.async_forward_entry_setups = AsyncMock()
-        entry = MagicMock()
-        with patch(
-            "custom_components.cover_time_based.async_register_card_resource",
-            AsyncMock(),
-        ) as reg:
-            await async_setup_entry(hass, entry)
-        reg.assert_awaited_once()
+    async def test_register_creates_resource_when_id_not_recorded(self):
+        resources = FakeResources()
+        hass = _make_setup_hass(resources)
+
+        await async_register_card_resource(hass, _CARD_BASE_URL, _CARD_JS_URL)
+
+        assert resources.created == [{"res_type": "module", "url": _CARD_JS_URL}]
+        assert hass.data[DOMAIN][_RESOURCE_ID_KEY] == "new-id"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -579,6 +579,36 @@ class TestCardResourceUnregistration:
         assert resources.deleted == ["new-id"]
 
     @pytest.mark.asyncio
+    async def test_failed_delete_still_clears_recorded_id(self):
+        """A hand-deleted resource makes async_delete_item raise. The recorded
+        id must still be dropped, or the setup-entry guard would skip
+        re-registration for the rest of the session."""
+        resources = FakeResources(
+            items=[{"id": "new-id", "url": _CARD_JS_URL}], loaded=True
+        )
+        resources.async_delete_item = AsyncMock(side_effect=Exception("gone"))
+        entry = MagicMock()
+        entry.entry_id = "e1"
+        hass = self._make_remove_hass(resources, remaining=[])
+
+        with patch(
+            "custom_components.cover_time_based.async_get_position_store"
+        ) as mock_store:
+            mock_store.return_value.async_remove = AsyncMock()
+            await async_remove_entry(hass, entry)
+
+        assert _RESOURCE_ID_KEY not in hass.data[DOMAIN]
+
+        # ...so re-adding a cover in the same session registers the card again.
+        hass.config_entries.async_forward_entry_setups = AsyncMock()
+        with patch(
+            "custom_components.cover_time_based.async_register_card_resource",
+            AsyncMock(),
+        ) as reg:
+            await async_setup_entry(hass, entry)
+        reg.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_remove_last_entry_falls_back_to_remove_extra_js_url(self):
         # Registered via the add_extra_js_url fallback → no stored resource id.
         entry = MagicMock()
@@ -599,3 +629,34 @@ class TestCardResourceUnregistration:
         mock_remove_js.assert_called_once()
         _, js_url = mock_remove_js.call_args.args
         assert js_url == _CARD_JS_URL
+
+
+class TestCardResourceRegisteredOnce:
+    """Each config entry's setup must not rescan every Lovelace resource once
+    the card's resource id is already recorded for this session."""
+
+    @pytest.mark.asyncio
+    async def test_setup_entry_skips_registration_when_recorded(self):
+        hass = MagicMock()
+        hass.data = {DOMAIN: {_RESOURCE_ID_KEY: "abc"}}
+        hass.config_entries.async_forward_entry_setups = AsyncMock()
+        entry = MagicMock()
+        with patch(
+            "custom_components.cover_time_based.async_register_card_resource",
+            AsyncMock(),
+        ) as reg:
+            await async_setup_entry(hass, entry)
+        reg.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_setup_entry_registers_when_not_recorded(self):
+        hass = MagicMock()
+        hass.data = {}
+        hass.config_entries.async_forward_entry_setups = AsyncMock()
+        entry = MagicMock()
+        with patch(
+            "custom_components.cover_time_based.async_register_card_resource",
+            AsyncMock(),
+        ) as reg:
+            await async_setup_entry(hass, entry)
+        reg.assert_awaited_once()

--- a/tests/test_websocket_api.py
+++ b/tests/test_websocket_api.py
@@ -3,6 +3,7 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from homeassistant.helpers.entity_component import DATA_INSTANCES
 
 from custom_components.cover_time_based.cover import (
     CONF_CLOSE_SWITCH_ENTITY_ID,
@@ -2208,7 +2209,7 @@ class TestWsResolveEntity:
         component = MagicMock()
         component.get_entity.return_value = None
         hass = MagicMock()
-        hass.data = {"entity_components": {"cover": component}}
+        hass.data = {DATA_INSTANCES: {"cover": component}}
         assert resolve_entity_or_none(hass, "cover.test") is None
 
     def test_returns_none_wrong_type(self):
@@ -2217,7 +2218,7 @@ class TestWsResolveEntity:
         component = MagicMock()
         component.get_entity.return_value = MagicMock()  # not CoverTimeBased
         hass = MagicMock()
-        hass.data = {"entity_components": {"cover": component}}
+        hass.data = {DATA_INSTANCES: {"cover": component}}
         assert resolve_entity_or_none(hass, "cover.test") is None
 
     def test_returns_entity_when_valid(self):
@@ -2238,7 +2239,7 @@ class TestWsResolveEntity:
         component = MagicMock()
         component.get_entity.return_value = entity
         hass = MagicMock()
-        hass.data = {"entity_components": {"cover": component}}
+        hass.data = {DATA_INSTANCES: {"cover": component}}
 
         result = resolve_entity_or_none(hass, "cover.test")
         assert result is entity


### PR DESCRIPTION
## Summary

Efficiency items from a whole-integration review, all verified behaviour-preserving with a base-vs-head side-by-side on a real Home Assistant instance (per-tick published states identical), plus one latent bug the change exposed and fixes.

- **Auto-updater tick**: while a cover moves, the 100 ms tick wrote HA state every time and spawned a no-op `auto_stop_if_necessary` task each tick (a 30 s travel: ~300 writes for ~100 real changes, ~300 discarded tasks). It now writes only when the reported position or tilt changed and spawns the auto-stop only on arrival; the tick computes its position snapshot once and passes it into `position_reached`. Measured: 1002 writes → 103 over a 100 s travel, identical published states; a relay going unavailable mid-travel still publishes immediately (that path never depended on the tick).
- **`_log`** returns before formatting when DEBUG is off (100+ call sites, many per tick). DEBUG output is byte-identical.
- **Wrapped cover**: `_position_driver` reads the underlying's `supported_features` once per decision instead of two or three times; the attribute-change handler uses the event's own state instead of re-reading the state machine, and skips the snap when the reported position equals the tracker and no auto-updater is running.
  - That skip removed a latent bug: with a startup delay, a redundant position report inside the delay window cleared the pending move's bookkeeping, so a user reversal issued in that window was silently dropped and the cover ran on to the endpoint. Now honoured; regression test and CHANGELOG line added.
- **Card resource registration**: `async_register_card_resource` returns immediately once the resource id is recorded for the session, instead of rescanning every Lovelace resource on every config-entry setup (and every card save, which reloads the entry). The unregister forgets the id before attempting the delete, so a failed delete cannot block re-registration.
- `helpers.resolve_entity` uses `DATA_INSTANCES`; two history-narrating comments trimmed.

## Tests

Unit tests per change (tick write/spawn behaviour including a dual-motor tilt arrival, `_log` guard, wrapped feature reads and event-state use, card registrar idempotence and failed-delete recovery) plus the wrapped startup-delay regression. Review mutations (always-write, spawn-every-tick, no memory reset, swapped tilt tuple, revert the snap skip) each fail exactly the test that pins them.
