### PR TITLE
chore: project-scoped Codex config, CLAUDE.md and AGENTS.md

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,7 @@
+# Project-scoped Codex config. Codex reads AGENTS.md (a symlink to CLAUDE.md here).
+model = "gpt-6-astra"
+model_reasoning_effort = "high"
+
+[sandbox_workspace_write]
+# Closed by default; pip and the Docker HA instance need it.
+network_access = true

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,7 +1,12 @@
-# Project-scoped Codex config. Codex reads AGENTS.md (a symlink to CLAUDE.md here).
+# Project-scoped Codex config. Codex reads AGENTS.md, a git symlink to CLAUDE.md, so
+# the seats follow the same repo rules as Claude. Codex only loads this file when the
+# checkout path has a trust_level = "trusted" entry in ~/.codex/config.toml.
 model = "gpt-6-astra"
 model_reasoning_effort = "high"
 
 [sandbox_workspace_write]
-# Closed by default; pip and the Docker HA instance need it.
+# Codex closes sandbox network access by default. The seats need it open: the test
+# install pip-fetches Home Assistant and the run-it seat talks to the Docker HA
+# instance. Codex has no allowlist, so this is all-or-nothing; the sandbox still
+# confines writes to the worktree.
 network_access = true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,8 +3,8 @@
 ## Git Workflow
 
 - **NEVER commit directly to main** — always create a feature branch first.
-- This checkout is a fork. Push branches to `origin` (clintongormley); PRs go to
-    `upstream` (Sese-Schneider/ha-cover-time-based), which is `gh`'s default.
+- Work from a fork: push branches to your fork and open the PR against
+    `Sese-Schneider/ha-cover-time-based` `main` (`gh repo set-default` there).
 - **Branch naming**: descriptive (e.g. `fix/relay-feedback`). Never include
     version numbers in branch names — HACS scans all branches and complains
     about non-compliant ones, even after deletion.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,47 @@
+# Claude Code Instructions
+
+## Git Workflow
+
+- **NEVER commit directly to main** — always create a feature branch first.
+- This checkout is a fork. Push branches to `origin` (clintongormley); PRs go to
+    `upstream` (Sese-Schneider/ha-cover-time-based), which is `gh`'s default.
+- **Branch naming**: descriptive (e.g. `fix/relay-feedback`). Never include
+    version numbers in branch names — HACS scans all branches and complains
+    about non-compliant ones, even after deletion.
+- Do NOT merge PRs automatically — wait for user approval.
+- When merging a PR (after approval), delete the feature branch.
+
+## Changelog
+
+- Record all user-facing changes in `CHANGELOG.md` under the top
+    `## <version> (unreleased)` section (`### Features`, `### Fixes`). Link the
+    issue or PR. `bin/release.sh` turns that section into the release notes.
+
+## Code Quality
+
+- Run `bash bin/install-hooks.sh` once per clone/worktree. The committed
+    `.githooks/pre-push` mirrors CI: ruff format + lint, translation drift
+    (`scripts/check_translations.py` — a missing key in any language is an
+    error), docs drift (`scripts/check_docs.py` — adding, removing or renaming a
+    module or service without touching README/docs blocks the push), then
+    `pytest tests/` and, when the card changed, `npm run test:fe:cov`. Bypass in
+    an emergency with `git push --no-verify`.
+- Before creating a PR run `ruff check .`, `ruff format .`, `npx pyright`, and
+    for the card `npm run lint` and `npm run format:check`.
+- CI runs the tests against stable, dev and minimum (HA 2025.2.0) channels;
+    the hook only runs against the locally installed HA.
+- New user-facing strings must be translated into every language: backend in
+    `strings.json` + `translations/<lang>.json`, card in
+    `frontend/translations.js`. See `TRANSLATING.md`.
+- The `manifest.json` keys must be sorted: `domain`, `name` first, then all
+    remaining keys in alphabetical order.
+- `docs/superpowers/`, `docs/plans/` and `docs/handoffs/` are gitignored —
+    specs, plans and handoffs are local working files; never commit them.
+
+## Integration Layout
+
+- Component lives in `custom_components/cover_time_based/`; the configuration
+    card is static ESM under `frontend/` (no build step).
+- Domain: `cover_time_based`. Alias in `~/workspace/tools/worktree.py`: `cover`.
+- Main HA dev container: `ha-cover-main` (start with `ha-wt cover-main`).
+- Feature worktrees: `/new-worktree cover <branch>`.


### PR DESCRIPTION
Adds a short `CLAUDE.md` capturing the repo's git workflow, changelog convention, pre-push gate and layout; `.codex/config.toml` (pins `gpt-6-astra` at high reasoning effort, opens sandbox network access for pip and the Docker HA instance); and `AGENTS.md` as a symlink to `CLAUDE.md` so Codex seats read the same repo rules Claude does.