### PR TITLE
chore: Codex's one seat, the run-it reviewer, runs on Sol

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,12 +1,13 @@
 # Project-scoped Codex config. Codex reads AGENTS.md, a git symlink to CLAUDE.md, so
-# the seats follow the same repo rules as Claude. Codex only loads this file when the
+# its one seat — /finish-branch's run-it reviewer, dispatched from a Claude session —
+# follows the same repo rules as Claude. Codex only loads this file when the
 # checkout path has a trust_level = "trusted" entry in ~/.codex/config.toml.
-model = "gpt-6-astra"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 
 [sandbox_workspace_write]
-# Codex closes sandbox network access by default. The seats need it open: the test
-# install pip-fetches Home Assistant and the run-it seat talks to the Docker HA
+# Codex closes sandbox network access by default. The run-it seat needs it open: the test
+# install pip-fetches Home Assistant and its experiments talk to the Docker HA
 # instance. Codex has no allowlist, so this is all-or-nothing; the sandbox still
 # confines writes to the worktree.
 network_access = true


### PR DESCRIPTION
Owner decision 2026-09-06: Claude and Codex are separated. Codex holds exactly one seat in the workflow, /finish-branch's run-it reviewer, dispatched from a Claude session through codex-seat.sh review-run, and that seat runs on gpt-5.6-sol rather than gpt-6-astra (the run-it seat did not need the top tier on the Claude side either — the planted-defect probe found no Fable-only catch; the yardstick is the tripwire). Copilot's automatic review is switched off in this repo's ruleset where the owner controls one.

Signed-off-by: Clinton Gormley <clintongormley@gmail.com>
