### PR TITLE
refactor: derive the websocket config wiring from one field table (backlog 5.2)

### DIFF
--- a/custom_components/cover_time_based/websocket_api.py
+++ b/custom_components/cover_time_based/websocket_api.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from collections.abc import Callable
+from typing import Any, NamedTuple
 
 import voluptuous as vol
 from homeassistant.components import websocket_api
@@ -75,41 +76,187 @@ from .helpers import resolve_entity_or_none
 
 _LOGGER = logging.getLogger(__name__)
 
-# Map from WS field names to config entry option keys
-_FIELD_MAP = {
-    "control_mode": CONF_CONTROL_MODE,
-    "pulse_time": CONF_PULSE_TIME,
-    "relay_reports_off": CONF_RELAY_REPORTS_OFF,
-    "send_endpoint_stop": CONF_SEND_ENDPOINT_STOP,
-    "force_endpoint_redrive": CONF_FORCE_ENDPOINT_REDRIVE,
-    "wait_for_relay_feedback": CONF_WAIT_FOR_RELAY_FEEDBACK,
-    "recalibrate_before_position": CONF_RECALIBRATE_BEFORE_POSITION,
-    "open_switch_entity_id": CONF_OPEN_SWITCH_ENTITY_ID,
-    "close_switch_entity_id": CONF_CLOSE_SWITCH_ENTITY_ID,
-    "stop_switch_entity_id": CONF_STOP_SWITCH_ENTITY_ID,
-    "cover_entity_id": CONF_COVER_ENTITY_ID,
-    "ignore_reported_position": CONF_IGNORE_REPORTED_POSITION,
-    "force_time_based_position": CONF_FORCE_TIME_BASED_POSITION,
-    "reports_command_not_endpoint": CONF_REPORTS_COMMAND_NOT_ENDPOINT,
-    "ignore_endpoint_states": CONF_IGNORE_ENDPOINT_STATES,
-    "ignore_all_reports": CONF_IGNORE_ALL_REPORTS,
-    "invert": CONF_INVERT,
-    "tilt_mode": CONF_TILT_MODE,
-    "travel_time_close": CONF_TRAVEL_TIME_CLOSE,
-    "travel_time_open": CONF_TRAVEL_TIME_OPEN,
-    "tilt_time_close": CONF_TILT_TIME_CLOSE,
-    "tilt_time_open": CONF_TILT_TIME_OPEN,
-    "travel_startup_delay": CONF_TRAVEL_STARTUP_DELAY,
-    "tilt_startup_delay": CONF_TILT_STARTUP_DELAY,
-    "endpoint_runon_time": CONF_ENDPOINT_RUNON_TIME,
-    "min_movement_time": CONF_MIN_MOVEMENT_TIME,
-    "safe_tilt_position": CONF_SAFE_TILT_POSITION,
-    "max_tilt_allowed_position": CONF_MAX_TILT_ALLOWED_POSITION,
-    "tilt_open_switch": CONF_TILT_OPEN_SWITCH,
-    "tilt_close_switch": CONF_TILT_CLOSE_SWITCH,
-    "tilt_stop_switch": CONF_TILT_STOP_SWITCH,
-    "close_includes_tilt": CONF_CLOSE_INCLUDES_TILT,
-    "assumed_state": CONF_ASSUMED_STATE,
+
+# Single source of truth for every configurable field the card exchanges over
+# the websocket. Each descriptor drives all three derived structures below —
+# the ws-key→conf-key map (`_FIELD_MAP`), the `get_config` response defaults,
+# and the `update_config` voluptuous schema — so a new option is added in one
+# place, not four. Adding a row here is the whole wiring change.
+class _ConfigField(NamedTuple):
+    ws_key: str  # the key the card sends and receives
+    conf_key: str | None  # config-entry option key; None = validated but never
+    # persisted or returned (a legacy knob a cached card still sends)
+    validator: Any  # voluptuous validator for the update_config schema
+    default: Any = None  # get_config fallback when the option is absent
+    normalize: Callable[[Any], Any] | None = None  # applied on read and write
+
+
+def _normalize_tilt_mode(value: Any) -> Any:
+    """Map the legacy "sequential" tilt mode to its canonical name.
+
+    The frontend no longer has dropdown/hint keys for the bare "sequential"
+    string; the migration and resolver alias handle behaviour, and this keeps
+    the read and write paths consistent for any entry that escapes migration.
+    """
+    return "sequential_close" if value == "sequential" else value
+
+
+# Validators shared across fields of the same shape. `None` is always accepted
+# (a cleared field), matching HA's own optional-value convention.
+_BOOL = vol.Any(None, bool)
+_ENTITY = vol.Any(str, None)
+_PERCENT_OR_NONE = vol.Any(None, PERCENT)
+_PULSE_TIME = vol.Any(
+    None, vol.All(vol.Coerce(float), vol.Range(min=MIN_DURATION, max=10))
+)
+_TRAVEL_TIME = vol.Any(
+    None, vol.All(vol.Coerce(float), vol.Range(min=MIN_DURATION, max=600))
+)
+_DELAY = vol.Any(None, vol.All(vol.Coerce(float), vol.Range(min=0, max=600)))
+
+_CONFIG_FIELDS: tuple[_ConfigField, ...] = (
+    _ConfigField(
+        "control_mode",
+        CONF_CONTROL_MODE,
+        vol.In(
+            [
+                CONTROL_MODE_WRAPPED,
+                CONTROL_MODE_SWITCH,
+                CONTROL_MODE_PULSE,
+                CONTROL_MODE_TOGGLE,
+                CONTROL_MODE_TOGGLE_OPPOSITE,
+                CONTROL_MODE_SINGLE_BUTTON,
+            ]
+        ),
+        default=CONTROL_MODE_SWITCH,
+    ),
+    _ConfigField(
+        "pulse_time", CONF_PULSE_TIME, _PULSE_TIME, default=DEFAULT_PULSE_TIME
+    ),
+    _ConfigField(
+        "relay_reports_off",
+        CONF_RELAY_REPORTS_OFF,
+        _BOOL,
+        default=DEFAULT_RELAY_REPORTS_OFF,
+    ),
+    _ConfigField(
+        "send_endpoint_stop",
+        CONF_SEND_ENDPOINT_STOP,
+        _BOOL,
+        default=DEFAULT_SEND_ENDPOINT_STOP,
+    ),
+    _ConfigField(
+        "force_endpoint_redrive",
+        CONF_FORCE_ENDPOINT_REDRIVE,
+        _BOOL,
+        default=DEFAULT_FORCE_ENDPOINT_REDRIVE,
+    ),
+    _ConfigField(
+        "wait_for_relay_feedback",
+        CONF_WAIT_FOR_RELAY_FEEDBACK,
+        _BOOL,
+        default=DEFAULT_WAIT_FOR_RELAY_FEEDBACK,
+    ),
+    _ConfigField(
+        "recalibrate_before_position",
+        CONF_RECALIBRATE_BEFORE_POSITION,
+        _BOOL,
+        default=DEFAULT_RECALIBRATE_BEFORE_POSITION,
+    ),
+    _ConfigField("open_switch_entity_id", CONF_OPEN_SWITCH_ENTITY_ID, _ENTITY),
+    _ConfigField("close_switch_entity_id", CONF_CLOSE_SWITCH_ENTITY_ID, _ENTITY),
+    _ConfigField("stop_switch_entity_id", CONF_STOP_SWITCH_ENTITY_ID, _ENTITY),
+    _ConfigField("cover_entity_id", CONF_COVER_ENTITY_ID, _ENTITY),
+    _ConfigField(
+        "ignore_reported_position",
+        CONF_IGNORE_REPORTED_POSITION,
+        _BOOL,
+        default=DEFAULT_IGNORE_REPORTED_POSITION,
+    ),
+    _ConfigField(
+        "force_time_based_position",
+        CONF_FORCE_TIME_BASED_POSITION,
+        _BOOL,
+        default=DEFAULT_FORCE_TIME_BASED_POSITION,
+    ),
+    _ConfigField(
+        "reports_command_not_endpoint",
+        CONF_REPORTS_COMMAND_NOT_ENDPOINT,
+        _BOOL,
+        default=DEFAULT_REPORTS_COMMAND_NOT_ENDPOINT,
+    ),
+    _ConfigField(
+        "ignore_endpoint_states",
+        CONF_IGNORE_ENDPOINT_STATES,
+        _BOOL,
+        default=DEFAULT_IGNORE_ENDPOINT_STATES,
+    ),
+    _ConfigField(
+        "ignore_all_reports",
+        CONF_IGNORE_ALL_REPORTS,
+        _BOOL,
+        default=DEFAULT_IGNORE_ALL_REPORTS,
+    ),
+    _ConfigField("invert", CONF_INVERT, _BOOL, default=DEFAULT_INVERT),
+    _ConfigField(
+        "tilt_mode",
+        CONF_TILT_MODE,
+        vol.In(
+            [
+                "none",
+                "sequential_close",
+                "sequential_open",
+                "sequential",
+                "dual_motor",
+                "inline",
+            ]
+        ),
+        default="none",
+        normalize=_normalize_tilt_mode,
+    ),
+    _ConfigField("travel_time_close", CONF_TRAVEL_TIME_CLOSE, _TRAVEL_TIME),
+    _ConfigField("travel_time_open", CONF_TRAVEL_TIME_OPEN, _TRAVEL_TIME),
+    _ConfigField("tilt_time_close", CONF_TILT_TIME_CLOSE, _TRAVEL_TIME),
+    _ConfigField("tilt_time_open", CONF_TILT_TIME_OPEN, _TRAVEL_TIME),
+    _ConfigField("travel_startup_delay", CONF_TRAVEL_STARTUP_DELAY, _DELAY),
+    _ConfigField("tilt_startup_delay", CONF_TILT_STARTUP_DELAY, _DELAY),
+    _ConfigField(
+        "endpoint_runon_time",
+        CONF_ENDPOINT_RUNON_TIME,
+        _DELAY,
+        default=DEFAULT_ENDPOINT_RUNON_TIME,
+    ),
+    _ConfigField("min_movement_time", CONF_MIN_MOVEMENT_TIME, _DELAY),
+    # Accepted and ignored (conf_key None, so never persisted or returned): a
+    # browser holding a cached copy of the old card still sends it.
+    _ConfigField("direction_change_delay", None, _DELAY),
+    _ConfigField(
+        "safe_tilt_position", CONF_SAFE_TILT_POSITION, _PERCENT_OR_NONE, default=100
+    ),
+    _ConfigField(
+        "max_tilt_allowed_position", CONF_MAX_TILT_ALLOWED_POSITION, _PERCENT_OR_NONE
+    ),
+    _ConfigField("tilt_open_switch", CONF_TILT_OPEN_SWITCH, _ENTITY),
+    _ConfigField("tilt_close_switch", CONF_TILT_CLOSE_SWITCH, _ENTITY),
+    _ConfigField("tilt_stop_switch", CONF_TILT_STOP_SWITCH, _ENTITY),
+    _ConfigField(
+        "close_includes_tilt",
+        CONF_CLOSE_INCLUDES_TILT,
+        _BOOL,
+        default=DEFAULT_CLOSE_INCLUDES_TILT,
+    ),
+    _ConfigField(
+        "assumed_state", CONF_ASSUMED_STATE, _BOOL, default=DEFAULT_ASSUMED_STATE
+    ),
+)
+
+# Map from WS field names to config entry option keys, for the fields that
+# persist. Derived so it can never drift from the table above.
+_FIELD_MAP = {f.ws_key: f.conf_key for f in _CONFIG_FIELDS if f.conf_key is not None}
+
+# The update_config field validators, keyed by the WS key that carries them.
+_UPDATE_CONFIG_FIELD_SCHEMA = {
+    vol.Optional(f.ws_key): f.validator for f in _CONFIG_FIELDS
 }
 
 
@@ -204,77 +351,19 @@ async def ws_get_config(
         return
 
     options = config_entry.options
-    # Normalize the legacy "sequential" string in the GET response so the
-    # frontend always sees the current canonical name. The migration and
-    # resolver alias handle behavior; this guard keeps the UI consistent
-    # for any entry that somehow escapes migration.
-    tilt_mode = options.get(CONF_TILT_MODE, "none")
-    if tilt_mode == "sequential":
-        tilt_mode = "sequential_close"
-    connection.send_result(
-        msg["id"],
-        {
-            "entry_id": config_entry.entry_id,
-            "control_mode": options.get(CONF_CONTROL_MODE, CONTROL_MODE_SWITCH),
-            "pulse_time": options.get(CONF_PULSE_TIME, DEFAULT_PULSE_TIME),
-            "relay_reports_off": options.get(
-                CONF_RELAY_REPORTS_OFF, DEFAULT_RELAY_REPORTS_OFF
-            ),
-            "send_endpoint_stop": options.get(
-                CONF_SEND_ENDPOINT_STOP, DEFAULT_SEND_ENDPOINT_STOP
-            ),
-            "open_switch_entity_id": options.get(CONF_OPEN_SWITCH_ENTITY_ID),
-            "close_switch_entity_id": options.get(CONF_CLOSE_SWITCH_ENTITY_ID),
-            "stop_switch_entity_id": options.get(CONF_STOP_SWITCH_ENTITY_ID),
-            "cover_entity_id": options.get(CONF_COVER_ENTITY_ID),
-            "ignore_reported_position": options.get(
-                CONF_IGNORE_REPORTED_POSITION, DEFAULT_IGNORE_REPORTED_POSITION
-            ),
-            "force_time_based_position": options.get(
-                CONF_FORCE_TIME_BASED_POSITION, DEFAULT_FORCE_TIME_BASED_POSITION
-            ),
-            "reports_command_not_endpoint": options.get(
-                CONF_REPORTS_COMMAND_NOT_ENDPOINT,
-                DEFAULT_REPORTS_COMMAND_NOT_ENDPOINT,
-            ),
-            "ignore_endpoint_states": options.get(
-                CONF_IGNORE_ENDPOINT_STATES, DEFAULT_IGNORE_ENDPOINT_STATES
-            ),
-            "ignore_all_reports": options.get(
-                CONF_IGNORE_ALL_REPORTS, DEFAULT_IGNORE_ALL_REPORTS
-            ),
-            "invert": options.get(CONF_INVERT, DEFAULT_INVERT),
-            "tilt_mode": tilt_mode,
-            "travel_time_close": options.get(CONF_TRAVEL_TIME_CLOSE),
-            "travel_time_open": options.get(CONF_TRAVEL_TIME_OPEN),
-            "tilt_time_close": options.get(CONF_TILT_TIME_CLOSE),
-            "tilt_time_open": options.get(CONF_TILT_TIME_OPEN),
-            "travel_startup_delay": options.get(CONF_TRAVEL_STARTUP_DELAY),
-            "tilt_startup_delay": options.get(CONF_TILT_STARTUP_DELAY),
-            "endpoint_runon_time": options.get(
-                CONF_ENDPOINT_RUNON_TIME, DEFAULT_ENDPOINT_RUNON_TIME
-            ),
-            "min_movement_time": options.get(CONF_MIN_MOVEMENT_TIME),
-            "safe_tilt_position": options.get(CONF_SAFE_TILT_POSITION, 100),
-            "max_tilt_allowed_position": options.get(CONF_MAX_TILT_ALLOWED_POSITION),
-            "tilt_open_switch": options.get(CONF_TILT_OPEN_SWITCH),
-            "tilt_close_switch": options.get(CONF_TILT_CLOSE_SWITCH),
-            "tilt_stop_switch": options.get(CONF_TILT_STOP_SWITCH),
-            "close_includes_tilt": options.get(
-                CONF_CLOSE_INCLUDES_TILT, DEFAULT_CLOSE_INCLUDES_TILT
-            ),
-            "assumed_state": options.get(CONF_ASSUMED_STATE, DEFAULT_ASSUMED_STATE),
-            "force_endpoint_redrive": options.get(
-                CONF_FORCE_ENDPOINT_REDRIVE, DEFAULT_FORCE_ENDPOINT_REDRIVE
-            ),
-            "wait_for_relay_feedback": options.get(
-                CONF_WAIT_FOR_RELAY_FEEDBACK, DEFAULT_WAIT_FOR_RELAY_FEEDBACK
-            ),
-            "recalibrate_before_position": options.get(
-                CONF_RECALIBRATE_BEFORE_POSITION, DEFAULT_RECALIBRATE_BEFORE_POSITION
-            ),
-        },
-    )
+    # Every persisted field, read through the shared table so the response can
+    # never drift from what update_config accepts. Fields carrying a normalize
+    # hook (e.g. the legacy "sequential" tilt mode) are canonicalised here so
+    # the card always sees the current name, whatever escaped migration.
+    result: dict[str, Any] = {"entry_id": config_entry.entry_id}
+    for field in _CONFIG_FIELDS:
+        if field.conf_key is None:
+            continue
+        value = options.get(field.conf_key, field.default)
+        if field.normalize is not None:
+            value = field.normalize(value)
+        result[field.ws_key] = value
+    connection.send_result(msg["id"], result)
 
 
 @websocket_api.require_admin
@@ -282,80 +371,7 @@ async def ws_get_config(
     {
         "type": "cover_time_based/update_config",
         vol.Required("entity_id"): str,
-        vol.Optional("control_mode"): vol.In(
-            [
-                CONTROL_MODE_WRAPPED,
-                CONTROL_MODE_SWITCH,
-                CONTROL_MODE_PULSE,
-                CONTROL_MODE_TOGGLE,
-                CONTROL_MODE_TOGGLE_OPPOSITE,
-                CONTROL_MODE_SINGLE_BUTTON,
-            ]
-        ),
-        vol.Optional("pulse_time"): vol.Any(
-            None, vol.All(vol.Coerce(float), vol.Range(min=MIN_DURATION, max=10))
-        ),
-        vol.Optional("relay_reports_off"): vol.Any(None, bool),
-        vol.Optional("send_endpoint_stop"): vol.Any(None, bool),
-        vol.Optional("force_endpoint_redrive"): vol.Any(None, bool),
-        vol.Optional("wait_for_relay_feedback"): vol.Any(None, bool),
-        vol.Optional("recalibrate_before_position"): vol.Any(None, bool),
-        vol.Optional("open_switch_entity_id"): vol.Any(str, None),
-        vol.Optional("close_switch_entity_id"): vol.Any(str, None),
-        vol.Optional("stop_switch_entity_id"): vol.Any(str, None),
-        vol.Optional("cover_entity_id"): vol.Any(str, None),
-        vol.Optional("ignore_reported_position"): vol.Any(None, bool),
-        vol.Optional("force_time_based_position"): vol.Any(None, bool),
-        vol.Optional("reports_command_not_endpoint"): vol.Any(None, bool),
-        vol.Optional("ignore_endpoint_states"): vol.Any(None, bool),
-        vol.Optional("ignore_all_reports"): vol.Any(None, bool),
-        vol.Optional("invert"): vol.Any(None, bool),
-        vol.Optional("assumed_state"): vol.Any(None, bool),
-        vol.Optional("tilt_mode"): vol.In(
-            [
-                "none",
-                "sequential_close",
-                "sequential_open",
-                "sequential",
-                "dual_motor",
-                "inline",
-            ]
-        ),
-        vol.Optional("travel_time_close"): vol.Any(
-            None, vol.All(vol.Coerce(float), vol.Range(min=MIN_DURATION, max=600))
-        ),
-        vol.Optional("travel_time_open"): vol.Any(
-            None, vol.All(vol.Coerce(float), vol.Range(min=MIN_DURATION, max=600))
-        ),
-        vol.Optional("tilt_time_close"): vol.Any(
-            None, vol.All(vol.Coerce(float), vol.Range(min=MIN_DURATION, max=600))
-        ),
-        vol.Optional("tilt_time_open"): vol.Any(
-            None, vol.All(vol.Coerce(float), vol.Range(min=MIN_DURATION, max=600))
-        ),
-        vol.Optional("travel_startup_delay"): vol.Any(
-            None, vol.All(vol.Coerce(float), vol.Range(min=0, max=600))
-        ),
-        vol.Optional("tilt_startup_delay"): vol.Any(
-            None, vol.All(vol.Coerce(float), vol.Range(min=0, max=600))
-        ),
-        vol.Optional("endpoint_runon_time"): vol.Any(
-            None, vol.All(vol.Coerce(float), vol.Range(min=0, max=600))
-        ),
-        vol.Optional("min_movement_time"): vol.Any(
-            None, vol.All(vol.Coerce(float), vol.Range(min=0, max=600))
-        ),
-        # Accepted and ignored (absent from _FIELD_MAP, so never persisted):
-        # a browser holding a cached copy of the old card still sends it.
-        vol.Optional("direction_change_delay"): vol.Any(
-            None, vol.All(vol.Coerce(float), vol.Range(min=0, max=600))
-        ),
-        vol.Optional("safe_tilt_position"): vol.Any(None, PERCENT),
-        vol.Optional("max_tilt_allowed_position"): vol.Any(None, PERCENT),
-        vol.Optional("tilt_open_switch"): vol.Any(str, None),
-        vol.Optional("tilt_close_switch"): vol.Any(str, None),
-        vol.Optional("tilt_stop_switch"): vol.Any(str, None),
-        vol.Optional("close_includes_tilt"): vol.Any(None, bool),
+        **_UPDATE_CONFIG_FIELD_SCHEMA,
     }
 )
 @websocket_api.async_response
@@ -397,18 +413,19 @@ async def ws_update_config(
 
     new_options = dict(config_entry.options)
 
-    for ws_key, conf_key in _FIELD_MAP.items():
-        if ws_key in msg:
-            value = msg[ws_key]
-            if value is None:
-                new_options.pop(conf_key, None)
-            else:
-                # Normalize the legacy "sequential" string on write so
-                # persisted options never carry it — the frontend no longer
-                # has dropdown/hint keys for it.
-                if conf_key == CONF_TILT_MODE and value == "sequential":
-                    value = "sequential_close"
-                new_options[conf_key] = value
+    for field in _CONFIG_FIELDS:
+        if field.conf_key is None or field.ws_key not in msg:
+            continue
+        value = msg[field.ws_key]
+        if value is None:
+            new_options.pop(field.conf_key, None)
+        else:
+            # A field's normalize hook (e.g. the legacy "sequential" tilt mode)
+            # canonicalises the value so persisted options never carry a name
+            # the frontend can no longer render.
+            if field.normalize is not None:
+                value = field.normalize(value)
+            new_options[field.conf_key] = value
 
     # Reject script entities in a mode that cannot drive one (they auto-return
     # to 'off', which switch/toggle modes misread as a stop). Validate the

--- a/custom_components/cover_time_based/websocket_api.py
+++ b/custom_components/cover_time_based/websocket_api.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
-from typing import Any, NamedTuple
+from dataclasses import dataclass
+from typing import Any
 
 import voluptuous as vol
 from homeassistant.components import websocket_api
@@ -68,8 +69,10 @@ from .cover import (
     DEFAULT_REPORTS_COMMAND_NOT_ENDPOINT,
     DEFAULT_SEND_ENDPOINT_STOP,
     DEFAULT_WAIT_FOR_RELAY_FEEDBACK,
-    MIN_DURATION,
     PERCENT,
+    POSITIVE_DURATION,
+    PULSE_DURATION,
+    TRAVEL_DURATION,
 )
 from .cover_base import RawCommandNotSupported
 from .helpers import resolve_entity_or_none
@@ -78,11 +81,15 @@ _LOGGER = logging.getLogger(__name__)
 
 
 # Single source of truth for every configurable field the card exchanges over
-# the websocket. Each descriptor drives all three derived structures below —
+# the websocket. Each descriptor drives all three websocket structures below —
 # the ws-key→conf-key map (`_FIELD_MAP`), the `get_config` response defaults,
-# and the `update_config` voluptuous schema — so a new option is added in one
-# place, not four. Adding a row here is the whole wiring change.
-class _ConfigField(NamedTuple):
+# and the `update_config` voluptuous schema — which previously drifted apart
+# field by field because they were maintained separately. A new field is one
+# row here. (A genuinely new *option* still also needs its `CONF_`/`DEFAULT_`
+# constants in const.py, the card, and translations — this table covers only
+# the websocket layer, not the factory in cover.py.)
+@dataclass(frozen=True)
+class _ConfigField:
     ws_key: str  # the key the card sends and receives
     conf_key: str | None  # config-entry option key; None = validated but never
     # persisted or returned (a legacy knob a cached card still sends)
@@ -102,17 +109,14 @@ def _normalize_tilt_mode(value: Any) -> Any:
 
 
 # Validators shared across fields of the same shape. `None` is always accepted
-# (a cleared field), matching HA's own optional-value convention.
+# (a cleared field), matching HA's own optional-value convention. The duration
+# bounds live once in cover.py; reuse them rather than restating the limits.
 _BOOL = vol.Any(None, bool)
 _ENTITY = vol.Any(str, None)
 _PERCENT_OR_NONE = vol.Any(None, PERCENT)
-_PULSE_TIME = vol.Any(
-    None, vol.All(vol.Coerce(float), vol.Range(min=MIN_DURATION, max=10))
-)
-_TRAVEL_TIME = vol.Any(
-    None, vol.All(vol.Coerce(float), vol.Range(min=MIN_DURATION, max=600))
-)
-_DELAY = vol.Any(None, vol.All(vol.Coerce(float), vol.Range(min=0, max=600)))
+_PULSE_TIME = vol.Any(None, PULSE_DURATION)
+_TRAVEL_TIME = vol.Any(None, TRAVEL_DURATION)
+_DELAY = vol.Any(None, POSITIVE_DURATION)
 
 _CONFIG_FIELDS: tuple[_ConfigField, ...] = (
     _ConfigField(
@@ -352,9 +356,8 @@ async def ws_get_config(
 
     options = config_entry.options
     # Every persisted field, read through the shared table so the response can
-    # never drift from what update_config accepts. Fields carrying a normalize
-    # hook (e.g. the legacy "sequential" tilt mode) are canonicalised here so
-    # the card always sees the current name, whatever escaped migration.
+    # never drift from what update_config accepts; normalize hooks canonicalise
+    # the value (see _normalize_tilt_mode) on the way out.
     result: dict[str, Any] = {"entry_id": config_entry.entry_id}
     for field in _CONFIG_FIELDS:
         if field.conf_key is None:
@@ -420,9 +423,8 @@ async def ws_update_config(
         if value is None:
             new_options.pop(field.conf_key, None)
         else:
-            # A field's normalize hook (e.g. the legacy "sequential" tilt mode)
-            # canonicalises the value so persisted options never carry a name
-            # the frontend can no longer render.
+            # normalize hooks canonicalise on the way in too (see
+            # _normalize_tilt_mode), so a save never persists a legacy name.
             if field.normalize is not None:
                 value = field.normalize(value)
             new_options[field.conf_key] = value

--- a/tests/test_websocket_config_fields.py
+++ b/tests/test_websocket_config_fields.py
@@ -49,8 +49,7 @@ from custom_components.cover_time_based.cover import (
     CONF_TRAVEL_TIME_OPEN,
     CONF_WAIT_FOR_RELAY_FEEDBACK,
 )
-
-from .test_websocket_api import (
+from tests.test_websocket_api import (
     ENTITY_ID,
     ENTRY_ID,
     _make_connection,
@@ -134,17 +133,11 @@ EXPECTED_FIELD_MAP = {
     "assumed_state": CONF_ASSUMED_STATE,
 }
 
-# The complete set of keys the update_config schema declares (the fixed frame
-# plus every optional field, including the accepted-and-ignored legacy knob).
-# ``id`` is injected by @websocket_command for every WS message.
+# The complete set of keys the update_config schema declares: the fixed frame
+# (``id`` is injected by @websocket_command), every persisted field, and the
+# one accepted-but-ignored legacy knob a cached card may still send.
 EXPECTED_SCHEMA_KEYS = (
-    {"id", "type", "entity_id"}
-    | set(EXPECTED_FIELD_MAP)
-    | {
-        "safe_tilt_position",
-        "max_tilt_allowed_position",
-        "direction_change_delay",
-    }
+    {"id", "type", "entity_id"} | set(EXPECTED_FIELD_MAP) | {"direction_change_delay"}
 )
 
 
@@ -168,59 +161,6 @@ async def _get_config(options):
     return conn.send_result.call_args[0][1]
 
 
-# ---------------------------------------------------------------------------
-# _FIELD_MAP
-# ---------------------------------------------------------------------------
-
-
-def test_field_map_is_exact():
-    assert websocket_api._FIELD_MAP == EXPECTED_FIELD_MAP
-
-
-# ---------------------------------------------------------------------------
-# get_config response
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_get_config_default_output_is_exact():
-    result = await _get_config({})
-    assert result.pop("entry_id") == ENTRY_ID
-    assert result == EXPECTED_DEFAULT_CONFIG
-
-
-@pytest.mark.asyncio
-async def test_get_config_echoes_every_stored_value():
-    # A non-default value for every persisted field, so a dropped or
-    # mis-keyed field in the derived response shows up here.
-    stored = {
-        conf_key: f"stored::{ws_key}" for ws_key, conf_key in EXPECTED_FIELD_MAP.items()
-    }
-    result = await _get_config(stored)
-    result.pop("entry_id")
-    for ws_key, conf_key in EXPECTED_FIELD_MAP.items():
-        assert result[ws_key] == stored[conf_key], ws_key
-
-
-@pytest.mark.asyncio
-async def test_get_config_normalizes_legacy_sequential_tilt_mode_on_read():
-    result = await _get_config({CONF_TILT_MODE: "sequential"})
-    assert result["tilt_mode"] == "sequential_close"
-
-
-# ---------------------------------------------------------------------------
-# update_config schema
-# ---------------------------------------------------------------------------
-
-
-def test_update_schema_declares_exactly_the_expected_keys():
-    assert _schema_keys() == EXPECTED_SCHEMA_KEYS
-
-
-def test_every_field_map_key_is_in_the_update_schema():
-    assert set(EXPECTED_FIELD_MAP) - _schema_keys() == set()
-
-
 def _frame(**fields):
     return {
         "id": 1,
@@ -230,35 +170,8 @@ def _frame(**fields):
     }
 
 
-def test_update_schema_rejects_pulse_time_above_ten():
-    schema = websocket_api.ws_update_config._ws_schema
-    schema(_frame(pulse_time=5))
-    with pytest.raises(vol.Invalid):
-        schema(_frame(pulse_time=11))
-
-
-def test_update_schema_rejects_travel_time_above_six_hundred():
-    schema = websocket_api.ws_update_config._ws_schema
-    schema(_frame(travel_time_open=600))
-    with pytest.raises(vol.Invalid):
-        schema(_frame(travel_time_open=601))
-
-
-def test_update_schema_accepts_but_never_persists_direction_change_delay():
-    # In the schema (a cached old card still sends it) but absent from
-    # _FIELD_MAP, so it is validated and dropped, never written.
-    assert "direction_change_delay" in _schema_keys()
-    assert CONF_DIRECTION_CHANGE_DELAY not in websocket_api._FIELD_MAP.values()
-
-
-# ---------------------------------------------------------------------------
-# update_config persistence
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_update_persists_mapped_fields_and_drops_direction_change_delay():
-    hass, _config_entry, entity_reg = _make_hass(options={})
+async def _update(msg_fields):
+    hass, _, entity_reg = _make_hass(options=msg_fields.pop("_options", {}))
     conn = _make_connection()
     with (
         patch(
@@ -270,75 +183,88 @@ async def test_update_persists_mapped_fields_and_drops_direction_change_delay():
             return_value=None,
         ),
     ):
-        await _ws_update_config(
-            hass,
-            conn,
-            {
-                "id": 1,
-                "type": "cover_time_based/update_config",
-                "entity_id": ENTITY_ID,
-                "travel_time_open": 12.5,
-                "invert": True,
-                "direction_change_delay": 3.0,
-            },
+        await _ws_update_config(hass, conn, _frame(**msg_fields))
+    return hass.config_entries.async_update_entry.call_args.kwargs["options"]
+
+
+class TestFieldMap:
+    """_FIELD_MAP is derived from the table but must stay ws_key -> conf_key."""
+
+    def test_field_map_is_exact(self):
+        assert websocket_api._FIELD_MAP == EXPECTED_FIELD_MAP
+
+
+class TestGetConfigResponse:
+    """get_config returns every field's stored value or its default."""
+
+    @pytest.mark.asyncio
+    async def test_default_output_is_exact(self):
+        result = await _get_config({})
+        assert result.pop("entry_id") == ENTRY_ID
+        assert result == EXPECTED_DEFAULT_CONFIG
+
+    @pytest.mark.asyncio
+    async def test_echoes_every_stored_value(self):
+        # A non-default value for every persisted field, so a dropped or
+        # mis-keyed field in the derived response shows up here.
+        stored = {
+            conf_key: f"stored::{ws_key}"
+            for ws_key, conf_key in EXPECTED_FIELD_MAP.items()
+        }
+        result = await _get_config(stored)
+        result.pop("entry_id")
+        for ws_key, conf_key in EXPECTED_FIELD_MAP.items():
+            assert result[ws_key] == stored[conf_key], ws_key
+
+    @pytest.mark.asyncio
+    async def test_normalizes_legacy_sequential_tilt_mode_on_read(self):
+        result = await _get_config({CONF_TILT_MODE: "sequential"})
+        assert result["tilt_mode"] == "sequential_close"
+
+
+class TestUpdateSchema:
+    """The update_config voluptuous schema accepts exactly the wired fields."""
+
+    def test_declares_exactly_the_expected_keys(self):
+        assert _schema_keys() == EXPECTED_SCHEMA_KEYS
+
+    def test_rejects_pulse_time_above_ten(self):
+        schema = websocket_api.ws_update_config._ws_schema
+        schema(_frame(pulse_time=5))
+        with pytest.raises(vol.Invalid):
+            schema(_frame(pulse_time=11))
+
+    def test_rejects_travel_time_above_six_hundred(self):
+        schema = websocket_api.ws_update_config._ws_schema
+        schema(_frame(travel_time_open=600))
+        with pytest.raises(vol.Invalid):
+            schema(_frame(travel_time_open=601))
+
+    def test_accepts_but_never_persists_direction_change_delay(self):
+        # In the schema (a cached old card still sends it) but absent from
+        # _FIELD_MAP, so it is validated and dropped, never written.
+        assert "direction_change_delay" in _schema_keys()
+        assert CONF_DIRECTION_CHANGE_DELAY not in websocket_api._FIELD_MAP.values()
+
+
+class TestUpdatePersistence:
+    """update_config writes mapped fields and honours the None/legacy rules."""
+
+    @pytest.mark.asyncio
+    async def test_persists_mapped_fields_and_drops_direction_change_delay(self):
+        saved = await _update(
+            {"travel_time_open": 12.5, "invert": True, "direction_change_delay": 3.0}
         )
-    saved = hass.config_entries.async_update_entry.call_args.kwargs["options"]
-    assert saved[CONF_TRAVEL_TIME_OPEN] == 12.5
-    assert saved[CONF_INVERT] is True
-    assert CONF_DIRECTION_CHANGE_DELAY not in saved
+        assert saved[CONF_TRAVEL_TIME_OPEN] == 12.5
+        assert saved[CONF_INVERT] is True
+        assert CONF_DIRECTION_CHANGE_DELAY not in saved
 
+    @pytest.mark.asyncio
+    async def test_normalizes_legacy_sequential_tilt_mode_on_write(self):
+        saved = await _update({"tilt_mode": "sequential"})
+        assert saved[CONF_TILT_MODE] == "sequential_close"
 
-@pytest.mark.asyncio
-async def test_update_normalizes_legacy_sequential_tilt_mode_on_write():
-    hass, _config_entry, entity_reg = _make_hass(options={})
-    conn = _make_connection()
-    with (
-        patch(
-            "custom_components.cover_time_based.websocket_api.er.async_get",
-            return_value=entity_reg,
-        ),
-        patch(
-            "custom_components.cover_time_based.websocket_api.resolve_entity_or_none",
-            return_value=None,
-        ),
-    ):
-        await _ws_update_config(
-            hass,
-            conn,
-            {
-                "id": 1,
-                "type": "cover_time_based/update_config",
-                "entity_id": ENTITY_ID,
-                "tilt_mode": "sequential",
-            },
-        )
-    saved = hass.config_entries.async_update_entry.call_args.kwargs["options"]
-    assert saved[CONF_TILT_MODE] == "sequential_close"
-
-
-@pytest.mark.asyncio
-async def test_update_removes_a_field_set_to_none():
-    hass, _config_entry, entity_reg = _make_hass(options={CONF_INVERT: True})
-    conn = _make_connection()
-    with (
-        patch(
-            "custom_components.cover_time_based.websocket_api.er.async_get",
-            return_value=entity_reg,
-        ),
-        patch(
-            "custom_components.cover_time_based.websocket_api.resolve_entity_or_none",
-            return_value=None,
-        ),
-    ):
-        await _ws_update_config(
-            hass,
-            conn,
-            {
-                "id": 1,
-                "type": "cover_time_based/update_config",
-                "entity_id": ENTITY_ID,
-                "invert": None,
-            },
-        )
-    saved = hass.config_entries.async_update_entry.call_args.kwargs["options"]
-    assert CONF_INVERT not in saved
+    @pytest.mark.asyncio
+    async def test_removes_a_field_set_to_none(self):
+        saved = await _update({"_options": {CONF_INVERT: True}, "invert": None})
+        assert CONF_INVERT not in saved

--- a/tests/test_websocket_config_fields.py
+++ b/tests/test_websocket_config_fields.py
@@ -1,0 +1,344 @@
+"""Golden characterization tests for the websocket config-field wiring.
+
+5.2 collapses three hand-maintained parallel structures in ``websocket_api``
+(``_FIELD_MAP``, the ``get_config`` response, the ``update_config`` schema)
+into one derived table. These tests pin the *exact* observable behaviour of
+all three so the derivation cannot silently change what a card sees or what a
+save persists. They must stay green across the refactor.
+"""
+
+from unittest.mock import patch
+
+import pytest
+import voluptuous as vol
+
+from custom_components.cover_time_based import websocket_api
+from custom_components.cover_time_based.cover import (
+    CONF_ASSUMED_STATE,
+    CONF_CLOSE_INCLUDES_TILT,
+    CONF_CLOSE_SWITCH_ENTITY_ID,
+    CONF_CONTROL_MODE,
+    CONF_COVER_ENTITY_ID,
+    CONF_DIRECTION_CHANGE_DELAY,
+    CONF_ENDPOINT_RUNON_TIME,
+    CONF_FORCE_ENDPOINT_REDRIVE,
+    CONF_FORCE_TIME_BASED_POSITION,
+    CONF_IGNORE_ALL_REPORTS,
+    CONF_IGNORE_ENDPOINT_STATES,
+    CONF_IGNORE_REPORTED_POSITION,
+    CONF_INVERT,
+    CONF_MAX_TILT_ALLOWED_POSITION,
+    CONF_MIN_MOVEMENT_TIME,
+    CONF_OPEN_SWITCH_ENTITY_ID,
+    CONF_PULSE_TIME,
+    CONF_RECALIBRATE_BEFORE_POSITION,
+    CONF_RELAY_REPORTS_OFF,
+    CONF_REPORTS_COMMAND_NOT_ENDPOINT,
+    CONF_SAFE_TILT_POSITION,
+    CONF_SEND_ENDPOINT_STOP,
+    CONF_STOP_SWITCH_ENTITY_ID,
+    CONF_TILT_CLOSE_SWITCH,
+    CONF_TILT_MODE,
+    CONF_TILT_OPEN_SWITCH,
+    CONF_TILT_STARTUP_DELAY,
+    CONF_TILT_STOP_SWITCH,
+    CONF_TILT_TIME_CLOSE,
+    CONF_TILT_TIME_OPEN,
+    CONF_TRAVEL_STARTUP_DELAY,
+    CONF_TRAVEL_TIME_CLOSE,
+    CONF_TRAVEL_TIME_OPEN,
+    CONF_WAIT_FOR_RELAY_FEEDBACK,
+)
+
+from .test_websocket_api import (
+    ENTITY_ID,
+    ENTRY_ID,
+    _make_connection,
+    _make_hass,
+    _ws_get_config,
+    _ws_update_config,
+)
+
+# The complete get_config response for a config entry with empty options —
+# every default, spelled out. entry_id is dynamic and checked separately.
+EXPECTED_DEFAULT_CONFIG = {
+    "control_mode": "switch",
+    "pulse_time": 1.0,
+    "relay_reports_off": True,
+    "send_endpoint_stop": True,
+    "open_switch_entity_id": None,
+    "close_switch_entity_id": None,
+    "stop_switch_entity_id": None,
+    "cover_entity_id": None,
+    "ignore_reported_position": False,
+    "force_time_based_position": False,
+    "reports_command_not_endpoint": False,
+    "ignore_endpoint_states": False,
+    "ignore_all_reports": False,
+    "invert": False,
+    "tilt_mode": "none",
+    "travel_time_close": None,
+    "travel_time_open": None,
+    "tilt_time_close": None,
+    "tilt_time_open": None,
+    "travel_startup_delay": None,
+    "tilt_startup_delay": None,
+    "endpoint_runon_time": 2.0,
+    "min_movement_time": None,
+    "safe_tilt_position": 100,
+    "max_tilt_allowed_position": None,
+    "tilt_open_switch": None,
+    "tilt_close_switch": None,
+    "tilt_stop_switch": None,
+    "close_includes_tilt": True,
+    "assumed_state": True,
+    "force_endpoint_redrive": False,
+    "wait_for_relay_feedback": False,
+    "recalibrate_before_position": False,
+}
+
+# The exact ws_key -> conf_key mapping every persisted field goes through.
+EXPECTED_FIELD_MAP = {
+    "control_mode": CONF_CONTROL_MODE,
+    "pulse_time": CONF_PULSE_TIME,
+    "relay_reports_off": CONF_RELAY_REPORTS_OFF,
+    "send_endpoint_stop": CONF_SEND_ENDPOINT_STOP,
+    "force_endpoint_redrive": CONF_FORCE_ENDPOINT_REDRIVE,
+    "wait_for_relay_feedback": CONF_WAIT_FOR_RELAY_FEEDBACK,
+    "recalibrate_before_position": CONF_RECALIBRATE_BEFORE_POSITION,
+    "open_switch_entity_id": CONF_OPEN_SWITCH_ENTITY_ID,
+    "close_switch_entity_id": CONF_CLOSE_SWITCH_ENTITY_ID,
+    "stop_switch_entity_id": CONF_STOP_SWITCH_ENTITY_ID,
+    "cover_entity_id": CONF_COVER_ENTITY_ID,
+    "ignore_reported_position": CONF_IGNORE_REPORTED_POSITION,
+    "force_time_based_position": CONF_FORCE_TIME_BASED_POSITION,
+    "reports_command_not_endpoint": CONF_REPORTS_COMMAND_NOT_ENDPOINT,
+    "ignore_endpoint_states": CONF_IGNORE_ENDPOINT_STATES,
+    "ignore_all_reports": CONF_IGNORE_ALL_REPORTS,
+    "invert": CONF_INVERT,
+    "tilt_mode": CONF_TILT_MODE,
+    "travel_time_close": CONF_TRAVEL_TIME_CLOSE,
+    "travel_time_open": CONF_TRAVEL_TIME_OPEN,
+    "tilt_time_close": CONF_TILT_TIME_CLOSE,
+    "tilt_time_open": CONF_TILT_TIME_OPEN,
+    "travel_startup_delay": CONF_TRAVEL_STARTUP_DELAY,
+    "tilt_startup_delay": CONF_TILT_STARTUP_DELAY,
+    "endpoint_runon_time": CONF_ENDPOINT_RUNON_TIME,
+    "min_movement_time": CONF_MIN_MOVEMENT_TIME,
+    "safe_tilt_position": CONF_SAFE_TILT_POSITION,
+    "max_tilt_allowed_position": CONF_MAX_TILT_ALLOWED_POSITION,
+    "tilt_open_switch": CONF_TILT_OPEN_SWITCH,
+    "tilt_close_switch": CONF_TILT_CLOSE_SWITCH,
+    "tilt_stop_switch": CONF_TILT_STOP_SWITCH,
+    "close_includes_tilt": CONF_CLOSE_INCLUDES_TILT,
+    "assumed_state": CONF_ASSUMED_STATE,
+}
+
+# The complete set of keys the update_config schema declares (the fixed frame
+# plus every optional field, including the accepted-and-ignored legacy knob).
+# ``id`` is injected by @websocket_command for every WS message.
+EXPECTED_SCHEMA_KEYS = (
+    {"id", "type", "entity_id"}
+    | set(EXPECTED_FIELD_MAP)
+    | {
+        "safe_tilt_position",
+        "max_tilt_allowed_position",
+        "direction_change_delay",
+    }
+)
+
+
+def _schema_keys():
+    schema = websocket_api.ws_update_config._ws_schema
+    return {getattr(marker, "schema", marker) for marker in schema.schema}
+
+
+async def _get_config(options):
+    hass, _, entity_reg = _make_hass(options=options)
+    conn = _make_connection()
+    with patch(
+        "custom_components.cover_time_based.websocket_api.er.async_get",
+        return_value=entity_reg,
+    ):
+        await _ws_get_config(
+            hass,
+            conn,
+            {"id": 1, "type": "cover_time_based/get_config", "entity_id": ENTITY_ID},
+        )
+    return conn.send_result.call_args[0][1]
+
+
+# ---------------------------------------------------------------------------
+# _FIELD_MAP
+# ---------------------------------------------------------------------------
+
+
+def test_field_map_is_exact():
+    assert websocket_api._FIELD_MAP == EXPECTED_FIELD_MAP
+
+
+# ---------------------------------------------------------------------------
+# get_config response
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_config_default_output_is_exact():
+    result = await _get_config({})
+    assert result.pop("entry_id") == ENTRY_ID
+    assert result == EXPECTED_DEFAULT_CONFIG
+
+
+@pytest.mark.asyncio
+async def test_get_config_echoes_every_stored_value():
+    # A non-default value for every persisted field, so a dropped or
+    # mis-keyed field in the derived response shows up here.
+    stored = {
+        conf_key: f"stored::{ws_key}" for ws_key, conf_key in EXPECTED_FIELD_MAP.items()
+    }
+    result = await _get_config(stored)
+    result.pop("entry_id")
+    for ws_key, conf_key in EXPECTED_FIELD_MAP.items():
+        assert result[ws_key] == stored[conf_key], ws_key
+
+
+@pytest.mark.asyncio
+async def test_get_config_normalizes_legacy_sequential_tilt_mode_on_read():
+    result = await _get_config({CONF_TILT_MODE: "sequential"})
+    assert result["tilt_mode"] == "sequential_close"
+
+
+# ---------------------------------------------------------------------------
+# update_config schema
+# ---------------------------------------------------------------------------
+
+
+def test_update_schema_declares_exactly_the_expected_keys():
+    assert _schema_keys() == EXPECTED_SCHEMA_KEYS
+
+
+def test_every_field_map_key_is_in_the_update_schema():
+    assert set(EXPECTED_FIELD_MAP) - _schema_keys() == set()
+
+
+def _frame(**fields):
+    return {
+        "id": 1,
+        "type": "cover_time_based/update_config",
+        "entity_id": ENTITY_ID,
+        **fields,
+    }
+
+
+def test_update_schema_rejects_pulse_time_above_ten():
+    schema = websocket_api.ws_update_config._ws_schema
+    schema(_frame(pulse_time=5))
+    with pytest.raises(vol.Invalid):
+        schema(_frame(pulse_time=11))
+
+
+def test_update_schema_rejects_travel_time_above_six_hundred():
+    schema = websocket_api.ws_update_config._ws_schema
+    schema(_frame(travel_time_open=600))
+    with pytest.raises(vol.Invalid):
+        schema(_frame(travel_time_open=601))
+
+
+def test_update_schema_accepts_but_never_persists_direction_change_delay():
+    # In the schema (a cached old card still sends it) but absent from
+    # _FIELD_MAP, so it is validated and dropped, never written.
+    assert "direction_change_delay" in _schema_keys()
+    assert CONF_DIRECTION_CHANGE_DELAY not in websocket_api._FIELD_MAP.values()
+
+
+# ---------------------------------------------------------------------------
+# update_config persistence
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_persists_mapped_fields_and_drops_direction_change_delay():
+    hass, _config_entry, entity_reg = _make_hass(options={})
+    conn = _make_connection()
+    with (
+        patch(
+            "custom_components.cover_time_based.websocket_api.er.async_get",
+            return_value=entity_reg,
+        ),
+        patch(
+            "custom_components.cover_time_based.websocket_api.resolve_entity_or_none",
+            return_value=None,
+        ),
+    ):
+        await _ws_update_config(
+            hass,
+            conn,
+            {
+                "id": 1,
+                "type": "cover_time_based/update_config",
+                "entity_id": ENTITY_ID,
+                "travel_time_open": 12.5,
+                "invert": True,
+                "direction_change_delay": 3.0,
+            },
+        )
+    saved = hass.config_entries.async_update_entry.call_args.kwargs["options"]
+    assert saved[CONF_TRAVEL_TIME_OPEN] == 12.5
+    assert saved[CONF_INVERT] is True
+    assert CONF_DIRECTION_CHANGE_DELAY not in saved
+
+
+@pytest.mark.asyncio
+async def test_update_normalizes_legacy_sequential_tilt_mode_on_write():
+    hass, _config_entry, entity_reg = _make_hass(options={})
+    conn = _make_connection()
+    with (
+        patch(
+            "custom_components.cover_time_based.websocket_api.er.async_get",
+            return_value=entity_reg,
+        ),
+        patch(
+            "custom_components.cover_time_based.websocket_api.resolve_entity_or_none",
+            return_value=None,
+        ),
+    ):
+        await _ws_update_config(
+            hass,
+            conn,
+            {
+                "id": 1,
+                "type": "cover_time_based/update_config",
+                "entity_id": ENTITY_ID,
+                "tilt_mode": "sequential",
+            },
+        )
+    saved = hass.config_entries.async_update_entry.call_args.kwargs["options"]
+    assert saved[CONF_TILT_MODE] == "sequential_close"
+
+
+@pytest.mark.asyncio
+async def test_update_removes_a_field_set_to_none():
+    hass, _config_entry, entity_reg = _make_hass(options={CONF_INVERT: True})
+    conn = _make_connection()
+    with (
+        patch(
+            "custom_components.cover_time_based.websocket_api.er.async_get",
+            return_value=entity_reg,
+        ),
+        patch(
+            "custom_components.cover_time_based.websocket_api.resolve_entity_or_none",
+            return_value=None,
+        ),
+    ):
+        await _ws_update_config(
+            hass,
+            conn,
+            {
+                "id": 1,
+                "type": "cover_time_based/update_config",
+                "entity_id": ENTITY_ID,
+                "invert": None,
+            },
+        )
+    saved = hass.config_entries.async_update_entry.call_args.kwargs["options"]
+    assert CONF_INVERT not in saved


### PR DESCRIPTION
## What

The config-card websocket layer maintained **three** hand-kept parallel structures in `websocket_api.py` — `_FIELD_MAP` (ws-key → conf-key), the `get_config` response defaults, and the `update_config` voluptuous schema — each ~33 entries that had to stay in lockstep. Missing one gave a silent bug: a field wired into `_FIELD_MAP` but absent from the schema was accepted by unit tests yet rejected by real HA; a field absent from `_FIELD_MAP` was validated but never persisted.

This collapses all three onto **one** ordered table of `_ConfigField` descriptors (`ws_key`, `conf_key`, `validator`, `default`, `normalize`). The three structures are now derived from it, so a new field is a single row instead of three parallel edits.

Addresses backlog item 5.2.

## Behaviour is unchanged

Pure refactor. The legacy `sequential` tilt-mode normalization moves onto the descriptor (applied on both read and write, exactly as before), and `direction_change_delay` stays schema-only (`conf_key=None`: validated, never persisted or returned).

Verified with a second model family (Codex) running old-vs-new differentially: identical `get_config` values (104 cases), identical schema keys + validation boundaries (1632 probes), identical `_FIELD_MAP` (incl. order), identical persistence, guards/auth intact, and the card renders + autosaves identically across 60 mode combinations. The one delta is `get_config` JSON **key order** for three flags — the parent's `_FIELD_MAP` order and `get_config` order differed, so a single ordered table can't reproduce both; persistence and `_FIELD_MAP` order are preserved and the card is order-insensitive.

## Scope

Deliberately the websocket layer only. The factory `_create_cover_from_options` in `cover.py` is a structurally different transform (conf-key → constructor kwarg, per-mode grouping) and is left as-is.

## Tests

New golden characterization tests (`tests/test_websocket_config_fields.py`) pin the full `get_config` default output, the exact `_FIELD_MAP`, the complete schema key set, and the validation boundaries — green on the pre-refactor code first, then kept green. Full suite: 1956 passing.