### PR TITLE
test: lock the relay-feedback per-send arm clears as load-bearing

### DIFF
--- a/custom_components/cover_time_based/cover_base.py
+++ b/custom_components/cover_time_based/cover_base.py
@@ -114,6 +114,13 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
     # poll would only rewrite unchanged state.
     _attr_should_poll = False
 
+    # Direction relay entity ids, set by the relay-driven mode mixins
+    # (CoverSwitch and its subclasses). Declared here because base methods such
+    # as _movement_target reference them; a wrapped cover sets neither and never
+    # reaches those methods.
+    _open_switch_entity_id: str | None
+    _close_switch_entity_id: str | None
+
     # Whether this control mode can drive tilt at all. A single-button cover
     # cannot choose a direction, so it sets this False (see the design spec).
     supports_tilt = True
@@ -2316,6 +2323,9 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
             current = self.travel_calc.current_position()
             if target == current:
                 return
+            # Travel was live when we entered this branch, so the tracker holds
+            # a known position after the settle.
+            assert current is not None
 
         relay_was_on = self._cancel_delay_task()
         if relay_was_on:
@@ -3262,6 +3272,9 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
             else:
                 await self._async_handle_command(SERVICE_STOP_COVER)
             if endpoint_applies and not self._moving_tilt_motor:
+                # endpoint_applies implies _at_endpoint(current_travel), which is
+                # False for None, so the position is known here.
+                assert current_travel is not None
                 self._on_endpoint_reached(int(current_travel))
             self._last_command = None
             self._moving_tilt_motor = False

--- a/custom_components/cover_time_based/cover_base.py
+++ b/custom_components/cover_time_based/cover_base.py
@@ -249,6 +249,13 @@ class CoverTimeBased(CalibrationMixin, CoverEntity, RestoreEntity):
         #   _feedback_armed_entity — set by the _send_* that just energized a
         #     relay OFF->ON; read and cleared by _begin_movement to decide
         #     whether to defer tracking. Never outlives the send->begin hop.
+        #     Each _send_* clears this first, and that eager per-send clear is
+        #     load-bearing, not redundant: _movement_epoch is too coarse to
+        #     reject a stale arm centrally (a tilt-to-safe pre-step and its
+        #     deferred travel leg share one epoch yet drive different relays,
+        #     and the command dispatchers do not bump it), so an arm stranded by
+        #     one phase would otherwise be consumed by the next on the wrong
+        #     relay — see test_travel_leg_after_tilt_pre_step_does_not_inherit_tilt_arm.
         #   _feedback_wait_entity / _feedback_wait_future — the relay whose ON
         #     echo the deferred move (or a feedback-timed calibration drive) is
         #     waiting on, and the future its confirming echo resolves. Live only

--- a/tests/test_relay_feedback.py
+++ b/tests/test_relay_feedback.py
@@ -1262,7 +1262,8 @@ class TestRelayFeedbackPulseMode:
 
         open_calls = [c for c in spy.call_args_list if c.args[0] == "switch.open"]
         assert open_calls, "open relay should have been marked pending"
-        assert open_calls[0].kwargs.get("timeout") >= 8, (
+        timeout = open_calls[0].kwargs.get("timeout")
+        assert timeout is not None and timeout >= 8, (
             "pending window must cover the 8s pulse so the completion OFF echo "
             "is still filtered as our own"
         )
@@ -1433,6 +1434,7 @@ class TestRelayFeedbackWaitSlot:
                 await asyncio.sleep(0)
             assert first.cancelled()
             second = cover._calibration.feedback_task
+            assert second is not None
             assert second is not first and not second.done()
             assert cover._feedback_wait_entity == "switch.open"
             second.cancel()

--- a/tests/test_relay_feedback.py
+++ b/tests/test_relay_feedback.py
@@ -588,6 +588,40 @@ class TestRelayFeedbackGuards:
         assert cover._feedback_wait_entity is None
 
     @pytest.mark.asyncio
+    async def test_travel_leg_after_tilt_pre_step_does_not_inherit_tilt_arm(
+        self, make_cover
+    ):
+        """A dual-motor tilt-to-safe pre-step arms the tilt relay's feedback wait
+        then starts tilt_calc directly, never reaching _begin_movement, so the
+        arm is stranded on the tilt relay. When the deferred travel leg begins
+        with its own relay already energised — so its _send_* re-arms nothing —
+        the travel move must start inline, not inherit the stranded tilt arm and
+        park on the tilt relay's ON echo (a wait its already-latched travel relay
+        would never satisfy). Same movement epoch as the pre-step throughout."""
+        cover = _make_dual_motor(make_cover, safe_tilt_position=0)
+        stub_switches(cover)
+        cover.travel_calc.set_position(50)
+        cover.tilt_calc.set_position(50)
+
+        with patch.object(cover, "async_write_ha_state"):
+            await cover.set_position(80)  # open; tilt-to-safe (→0) pre-step first
+            await _turns()
+            # The pre-step armed the tilt-close relay and stranded it.
+            assert cover._pending_travel_target == 80
+            assert cover._feedback_armed_entity == "switch.tilt_close"
+
+            # The travel (open) relay is already energised when the pre-step
+            # completes, so the travel _send_open flips nothing and re-arms nothing.
+            stub_switches(cover, on=("switch.open",))
+            await cover._start_pending_travel()
+            await _turns()
+
+        # Travel already running: no ON echo is coming, so it starts inline. The
+        # move must NOT be parked on the stranded tilt relay's echo.
+        assert cover._feedback_wait_entity != "switch.tilt_close"
+        assert cover.travel_calc.is_traveling() is True
+
+    @pytest.mark.asyncio
     async def test_direction_relay_already_on_starts_inline(self, make_cover):
         cover = make_cover(wait_for_relay_feedback=True)
         stub_switches(cover, on=("switch.open",))


### PR DESCRIPTION
## What

A review-backlog refactor proposed collapsing the ~11 per-`_send_*`
`self._feedback_armed_entity = None` clears into a single mechanism — either an
epoch-stamped arm rejected at consume, or a clear in the two command
dispatchers. This PR **does not** make that change: it proves, with a
regression test, that the scattered clears are **load-bearing**, and locks that
in so it isn't re-attempted blind.

## Why the centralisation is unsafe

- **Epoch-stamping the arm**: a dual-motor *tilt-to-safe pre-step* arms the tilt
  relay and strands it — it starts `tilt_calc` directly and never reaches
  `_begin_movement`. The deferred travel leg's `_begin_movement` runs at the
  **same** `_movement_epoch` (neither `_async_handle_command` nor
  `_raw_direction_command` bumps it), so the stranded tilt arm is consumed for
  the *travel* move and it parks on the tilt relay's ON echo — a wait its
  already-latched travel relay never satisfies (a full feedback-timeout stall).
  A per-movement epoch is too coarse: one epoch spans multiple phases/relays.
  The whole suite stayed green under that change, so the leak was invisible to
  it — the new test is what surfaces it.
- **Clearing in the two dispatchers**: the tilt sends (`_send_tilt_open/close`)
  are invoked directly from several orchestration sites, bypassing both
  dispatchers, so a dispatcher-level clear would miss them.

## Changes

- `test_travel_leg_after_tilt_pre_step_does_not_inherit_tilt_arm` — drives the
  real dual-motor pre-step then completes the travel leg with the travel relay
  already energised; passes today, fails under the epoch-stamp approach.
- A comment on the `_feedback_armed_entity` field doc recording why the eager
  per-send clear can't be centralised.
- A small, behaviour-neutral cleanup of nine pre-existing `pyright` errors in
  the two touched files (mixin-attribute annotations on the base class, two
  `current_position()` None-narrowing asserts that state the invariant, and two
  test-side None checks).

Full suite: 1957 passing. `ruff` + `pyright` clean on the touched files.